### PR TITLE
fix: publish for python > 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.7, 3.8, 3.9, "3.10", 3.11, 3.12, 3.13]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Operating System :: POSIX",
   "Operating System :: Unix",
   "Topic :: Communications :: Email",


### PR DESCRIPTION
# Problem

* Package is not available for python>3.10

# Solution

* Add python 3.13 in the tests matrix in CI
* Fixes #14 