### PR TITLE
Add Cargo.lock to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include pyproject.toml Cargo.toml
+include pyproject.toml Cargo.toml Cargo.lock
 recursive-include src *


### PR DESCRIPTION
Some build systems expect packages to include a Cargo.lock file, this ensures builds are reproducible.