### PR TITLE
fix(tests): use == for integer equality instead of is

### DIFF
--- a/tests/test_contents.py
+++ b/tests/test_contents.py
@@ -2,7 +2,7 @@ from fast_mail_parser import PyMail
 
 
 def test__plain_text_is_available(valid_mail: PyMail):
-    assert len(valid_mail.text_plain) is 1
+    assert len(valid_mail.text_plain) == 1
 
 
 def test__plain_text_is_correct(valid_mail: PyMail):
@@ -10,7 +10,7 @@ def test__plain_text_is_correct(valid_mail: PyMail):
 
 
 def test__html_is_available(valid_mail: PyMail):
-    assert len(valid_mail.text_html) is 1
+    assert len(valid_mail.text_html) == 1
 
 
 def test__html_is_correct(valid_mail: PyMail):

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -2,7 +2,7 @@ from fast_mail_parser import PyMail
 
 
 def test__total_number_is_valid(valid_mail: PyMail):
-    assert len(valid_mail.headers) is 29
+    assert len(valid_mail.headers) == 29
 
 
 def test__header_is_accessible_by_key(valid_mail: PyMail):


### PR DESCRIPTION
Closes #30

Replace integer-identity comparisons (`is <int>`) with value equality (`== <int>`) in the test suite. The `is` operator on small ints only works via CPython's small-int caching, emits `SyntaxWarning: "is" with a literal` on Python 3.8+, and is incorrect on PyPy.