### PR TITLE
fix: move build-tool deps out of [project.dependencies]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Topic :: Communications :: Email",
   "Topic :: Software Development :: Libraries",
 ]
-dependencies = ["toml==0.10.2", "wheel", "maturin>=1.0,<2.0"]
+dependencies = []
 
 [project.optional-dependencies]
 test = ["pytest~=7.4.4", "pytest-benchmark==4.0.0", "mail-parser==3.15.0"]


### PR DESCRIPTION
Closes #45

`toml`, `wheel`, and `maturin` are build-time tools, not runtime requirements of the installed package (a compiled PyO3 extension plus a thin `__init__.py`). Listing them in `[project.dependencies]` forced every consumer to install them; `maturin` is already correctly declared in `[build-system].requires`. This sets `dependencies = []` since the package has no runtime Python dependencies.