### PR TITLE
fix(tests): share parsed-mail fixtures across module

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,24 +16,24 @@ def read_mail() -> Callable:
     return wrap
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def attachment_mail(read_mail: Callable) -> PyMail:
     message = read_mail('tests/data/attachment_message.eml')
 
     return parse_email(message)
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def valid_mail(valid_message: str, read_mail: Callable) -> PyMail:
     return parse_email(valid_message)
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def large_mail(large_message: str, read_mail: Callable) -> PyMail:
     return parse_email(large_message)
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def valid_message(read_mail: Callable) -> str:
     return read_mail('tests/data/valid_message.eml')
 


### PR DESCRIPTION
Closes #36

The `large_message` fixture was `scope='module'` while `large_mail` (and `valid_mail`, `attachment_mail`) used the default function scope, so the ~785 KB message was re-parsed for every test. This bumps the parsed-mail fixtures and `valid_message` to module scope so each parse is reused across the module; `PyMail` results are read-only and all tests treat them as such, so sharing one parse is safe.