### PR TITLE
ci: enforce cargo audit, add Dependabot and cargo-deny config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # Rust crate dependencies (Cargo.toml / Cargo.lock at the repo root).
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # GitHub Actions used by the workflows in .github/workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,11 +55,13 @@ jobs:
         continue-on-error: true
 
   # ---------------------------------------------------------------------------
-  # Supply-chain audit. Advisory (continue-on-error) so a fresh advisory against
-  # a pinned dependency surfaces without blocking unrelated PRs — flip to
-  # blocking once the dependency stack is current. cargo-audit needs a newer
-  # rustc than the repo's pinned 1.83, so the job runs on stable via
-  # RUSTUP_TOOLCHAIN (overrides the rust-toolchain file).
+  # Supply-chain audit. Blocking (no continue-on-error): the dependency stack is
+  # current (PyO3 0.29) and the Cargo.lock audits clean, so a new advisory
+  # against any dependency should fail the build and gate the PR rather than pass
+  # silently. (It was previously advisory only because the stack was stale and a
+  # fresh advisory against a pinned dep would have blocked unrelated PRs.)
+  # cargo-audit needs a newer rustc than the repo's pinned 1.83, so the job runs
+  # on stable via RUSTUP_TOOLCHAIN (overrides the rust-toolchain file).
   #
   # cargo-audit is `cargo install`ed from source (~3 min — previously the
   # slowest job by far). The compiled binary is cached and keyed on the pinned
@@ -76,7 +78,7 @@ jobs:
   # binary version.
   # ---------------------------------------------------------------------------
   security-audit:
-    name: cargo audit (advisory)
+    name: cargo audit
     runs-on: ubuntu-latest
     env:
       RUSTUP_TOOLCHAIN: stable
@@ -97,7 +99,6 @@ jobs:
         if: steps.cache-cargo-audit.outputs.cache-hit != 'true'
         run: cargo install cargo-audit --version ${{ env.CARGO_AUDIT_VERSION }} --locked
       - name: cargo audit
-        continue-on-error: true
         run: cargo audit
 
   # ---------------------------------------------------------------------------

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,48 @@
+# cargo-deny configuration.
+#
+# Starter config for local and future-CI supply-chain checks. There is no
+# cargo-deny CI job wired up yet (out of scope); run it locally with:
+#   cargo install cargo-deny --locked
+#   cargo deny check
+#
+# Docs: https://embarkstudios.github.io/cargo-deny/
+
+# --- Advisories --------------------------------------------------------------
+# Pulled from the RustSec advisory DB. Security vulnerabilities and unmaintained
+# crates are hard errors; yanked crates warn so they surface without blocking.
+[advisories]
+version = 2
+yanked = "warn"
+
+# --- Licenses ----------------------------------------------------------------
+# Allow only well-known permissive licenses. SPDX identifiers; see
+# https://spdx.org/licenses/. Add to this list as new (vetted) deps appear.
+[licenses]
+version = 2
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+]
+confidence-threshold = 0.8
+
+# --- Bans --------------------------------------------------------------------
+# Catch dependency bloat and accidental duplicates. Multiple versions of the
+# same crate warn (common and not always avoidable) rather than fail.
+[bans]
+multiple-versions = "warn"
+wildcards = "warn"
+
+# --- Sources -----------------------------------------------------------------
+# Only allow dependencies from the canonical crates.io registry. Unknown
+# registries and git sources are rejected.
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
Closes #40

Supply-chain hardening: three items from the issue.

## (a) cargo audit is now blocking
Verified the current `Cargo.lock` audits clean before flipping the gate:

```
$ RUSTUP_TOOLCHAIN=stable cargo +stable audit   # cargo-audit 0.22.2
    Scanning Cargo.lock for vulnerabilities (22 crate dependencies)
    (no advisories) — exit 0
```

Since the dependency stack is current (PyO3 0.29) and the lockfile is clean,
removed `continue-on-error: true` from the `cargo audit` step in the
`security-audit` job so it blocks. Updated the job's leading comment (which
explained why it was advisory) to state it is now enforced, and dropped the
`(advisory)` suffix from the job `name`.

## (b) Dependabot — `.github/dependabot.yml`
Weekly updates for two ecosystems, both rooted at `/`:
- `cargo`
- `github-actions`

## (c) cargo-deny config — `deny.toml`
Starter config with `[advisories]` (deny vulnerabilities/unmaintained, warn on
yanked), `[licenses]` (allow common permissive licenses: MIT, Apache-2.0,
BSD-2/3-Clause, ISC, Unicode-3.0, Zlib, etc.), `[bans]` (warn on
multiple-versions), and `[sources]` (restrict to crates.io).

No cargo-deny CI job was added (out of scope) — the file is for local/future
use; run `cargo deny check` locally.

## Verification
- `test.yml` and `dependabot.yml` parse as valid YAML.
- `deny.toml` parses as valid TOML.
