### PR TITLE
Remove real PII from test email fixtures

### DIFF
--- a/tests/data/invalid_message.eml
+++ b/tests/data/invalid_message.eml
@@ -1,4 +1,4 @@
-Delivered-To: wartwvister@gmail.com
+Delivered-To: recipient@example.com
 Received: by 2002:ad4:5567:0:0:0:0:0 with SMTP id w7csp199345qvy;
         Tue, 30 Jun 2020 22:39:50 -0700 (PDT)
 X-Google-Smtp-Source: ABdhPJx1ThX8le0touadBy/BdCwGffeaOKkb0vDiV7FnQerlyN7QQIFY9tuNJcqBNN0CUlkxly0G
@@ -30,7 +30,7 @@ ARC-Authentication-Results: i=1; mx.google.com;
 Return-Path: <bounce-mc.us3_24172875.286746-def745e273@mail253.wdc02.mcdlv.net>
 Received: from mail253.wdc02.mcdlv.net (mail253.wdc02.mcdlv.net. [205.201.130.253])
         by mx.google.com with ESMTPS id d93si4829705ybi.258.2020.06.30.22.39.49
-        for <wartwvister@gmail.com>
+        for <recipient@example.com>
         (version=TLS1_2 cipher=ECDHE-ECDSA-AES128-GCM-SHA256 bits=128/128);
         Tue, 30 Jun 2020 22:39:50 -0700 (PDT)
 Received-SPF: pass (google.com: domain of bounce-mc.us3_24172875.286746-def745e273@mail253.wdc02.mcdlv.net designates 205.201.130.253 as permitted sender) client-ip=205.201.130.253;
@@ -46,15 +46,15 @@ DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=openshift.com; s=k1; t=1
 	 Content-Type:MIME-Version; b=Eihu1MP4q/msO3NstvNljEBi/N9O8JCyxXwV3odNXyva2mYQPa+gT8/+Upv0zTkmO
 	 97OF0q68/5iZ094GlBeTZEgVS+v+InDSyuU0t3bhkb5ktRINRr+X4VASXboa4MDSlD
 	 wrCieYRwqqq14FHvHHRxkkZ7HwUaRGHm4v2VvbW4=
-Received: from localhost (localhost [127.0.0.1]) by mail253.wdc02.mcdlv.net (Mailchimp) with ESMTP id 49xVJg029szRDc for <wartwvister@gmail.com>; Wed,
+Received: from localhost (localhost [127.0.0.1]) by mail253.wdc02.mcdlv.net (Mailchimp) with ESMTP id 49xVJg029szRDc for <recipient@example.com>; Wed,
   1 Jul 2020 05:33:55 +0000 (GMT)
 Subject: Your June OpenShift Update
 From: Red Hat OpenShift <noreply@openshift.com>
 Reply-To: Red Hat OpenShift <noreply@openshift.com>
-To: <wartwvister@gmail.com>
+To: <recipient@example.com>
 Date: Wed,
   1 Jul 2020 05:33:42 +0000
-Message-ID: <979c70339150d05eec1531104.def745e273.20200701053326.66f48780af.4a62601a@mail253.wdc02.mcdlv.net>
+Message-ID: <979c70339150d05eec1531104.def745e273.20200701053326.66f48780af.4a62601a@example.com>
 X-Mailer: MailChimp Mailer - **CID66f48780afdef745e273**
 X-Campaign: mailchimp979c70339150d05eec1531104.66f48780af
 X-campaignid: mailchimp979c70339150d05eec1531104.66f48780af

--- a/tests/data/large_message.eml
+++ b/tests/data/large_message.eml
@@ -1,19 +1,19 @@
-Delivered-To: bruce@untroubled.org
+Delivered-To: recipient@example.org
 Received: (qmail 26559 invoked from network); 21 Aug 2016 10:49:40 -0000
 Received: from mx03.futurequest.net (mx03.futurequest.net [69.5.6.174])
   by pt02.futurequest.net ([69.5.6.173])
   with FQDP via TCP; 21 Aug 2016 10:49:40 -0000
 Received: (qmail 19675 invoked from network); 21 Aug 2016 10:49:40 -0000
-Received: from localhost.localdomain.com (mail.revesoft.com [208.74.72.248])
+Received: from localhost.localdomain.com (mail.example.com [208.74.72.248])
   by mx03.futurequest.net ([69.5.6.174])
   with ESMTP via TCP; 21 Aug 2016 10:49:39 -0000
 Received: from host86-187-174-57.range86-187.btcentralplus.com ([86.187.174.57]:45321 helo=User)
 	by localhost.localdomain.com with esmtpa (Exim 4.87)
-	(envelope-from <anabelgonzalo@fanox.com>)
+	(envelope-from <sender@example.com>)
 	id 1bakrE-000291-LF; Fri, 19 Aug 2016 20:34:52 +0600
-Reply-To: <anabelgonzalo@fanox.com>
+Reply-To: <sender@example.com>
 Subject: =?utf-8?B?R29vZCBuZXdzOiBMb3JlbSBpcHN1bSBkb2xvciBzaXQgYW1ldCAtIGRldGFpbHMgaW5zaWRl?=
-From: "Anabel Gonzalo"<anabelgonzalo@fanox.com>
+From: "Example Sender"<sender@example.com>
 Date: Wed, 23 Oct 2024 10:34:04 +0300
 MIME-Version: 1.0
 X-Priority: 3
@@ -22,14 +22,14 @@ X-Mailer: Microsoft Outlook Express 6.00.2600.0000
 X-MimeOLE: Produced By Microsoft MimeOLE V6.00.2600.0000
 X-AntiAbuse: This header was added to track abuse, please include it with any abuse report
 X-AntiAbuse: Primary Hostname - localhost.localdomain.com
-X-AntiAbuse: Original Domain - untroubled.org
+X-AntiAbuse: Original Domain - example.org
 X-AntiAbuse: Originator/Caller UID/GID - [47 12] / [47 12]
-X-AntiAbuse: Sender Address Domain - fanox.com
-X-Get-Message-Sender-Via: localhost.localdomain.com: authenticated_id: quazi.limon@revesoft.com
-X-Authenticated-Sender: localhost.localdomain.com: quazi.limon@revesoft.com
+X-AntiAbuse: Sender Address Domain - example.com
+X-Get-Message-Sender-Via: localhost.localdomain.com: authenticated_id: authuser@example.com
+X-Authenticated-Sender: localhost.localdomain.com: authuser@example.com
 Content-Type: multipart/mixed;
 	boundary="mix-4a62f61e:30a2cf33"
-Message-Id: <E1t3Vsa-0004ON-Nu@st10.mi6.kiev.ua>
+Message-Id: <E1t3Vsa-0004ON-Nu@example.com>
 
 --mix-4a62f61e:30a2cf33
 Content-Type: multipart/alternative;

--- a/tests/data/valid_message.eml
+++ b/tests/data/valid_message.eml
@@ -1,4 +1,4 @@
-Delivered-To: wartwvister@gmail.com
+Delivered-To: recipient@example.com
 Received: by 2002:ad4:5567:0:0:0:0:0 with SMTP id w7csp199345qvy;
         Tue, 30 Jun 2020 22:39:50 -0700 (PDT)
 X-Google-Smtp-Source: ABdhPJx1ThX8le0touadBy/BdCwGffeaOKkb0vDiV7FnQerlyN7QQIFY9tuNJcqBNN0CUlkxly0G
@@ -30,7 +30,7 @@ ARC-Authentication-Results: i=1; mx.google.com;
 Return-Path: <bounce-mc.us3_24172875.286746-def745e273@mail253.wdc02.mcdlv.net>
 Received: from mail253.wdc02.mcdlv.net (mail253.wdc02.mcdlv.net. [205.201.130.253])
         by mx.google.com with ESMTPS id d93si4829705ybi.258.2020.06.30.22.39.49
-        for <wartwvister@gmail.com>
+        for <recipient@example.com>
         (version=TLS1_2 cipher=ECDHE-ECDSA-AES128-GCM-SHA256 bits=128/128);
         Tue, 30 Jun 2020 22:39:50 -0700 (PDT)
 Received-SPF: pass (google.com: domain of bounce-mc.us3_24172875.286746-def745e273@mail253.wdc02.mcdlv.net designates 205.201.130.253 as permitted sender) client-ip=205.201.130.253;
@@ -46,15 +46,15 @@ DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=openshift.com; s=k1; t=1
 	 Content-Type:MIME-Version; b=Eihu1MP4q/msO3NstvNljEBi/N9O8JCyxXwV3odNXyva2mYQPa+gT8/+Upv0zTkmO
 	 97OF0q68/5iZ094GlBeTZEgVS+v+InDSyuU0t3bhkb5ktRINRr+X4VASXboa4MDSlD
 	 wrCieYRwqqq14FHvHHRxkkZ7HwUaRGHm4v2VvbW4=
-Received: from localhost (localhost [127.0.0.1]) by mail253.wdc02.mcdlv.net (Mailchimp) with ESMTP id 49xVJg029szRDc for <wartwvister@gmail.com>; Wed,
+Received: from localhost (localhost [127.0.0.1]) by mail253.wdc02.mcdlv.net (Mailchimp) with ESMTP id 49xVJg029szRDc for <recipient@example.com>; Wed,
   1 Jul 2020 05:33:55 +0000 (GMT)
 Subject: Your June OpenShift Update
 From: Red Hat OpenShift <noreply@openshift.com>
 Reply-To: Red Hat OpenShift <noreply@openshift.com>
-To: <wartwvister@gmail.com>
+To: <recipient@example.com>
 Date: Wed,
   1 Jul 2020 05:33:42 +0000
-Message-ID: <979c70339150d05eec1531104.def745e273.20200701053326.66f48780af.4a62601a@mail253.wdc02.mcdlv.net>
+Message-ID: <979c70339150d05eec1531104.def745e273.20200701053326.66f48780af.4a62601a@example.com>
 X-Mailer: MailChimp Mailer - **CID66f48780afdef745e273**
 X-Campaign: mailchimp979c70339150d05eec1531104.66f48780af
 X-campaignid: mailchimp979c70339150d05eec1531104.66f48780af


### PR DESCRIPTION
## Summary
Scrubs real personal data from the `.eml` test fixtures (public repo). Identifying values are replaced with synthetic `example.com`/`example.org` equivalents while keeping each message valid and structurally identical (same headers, header count, MIME parts, encodings, and non-PII body text), so the parser's behavior is unchanged.

### PII scrubbed
- **`tests/data/valid_message.eml`** and **`tests/data/invalid_message.eml`** (identical headers; the latter is a deliberately malformed variant):
  - Real personal recipient Gmail `wartwvister@gmail.com` -> `recipient@example.com` (Delivered-To, Received `for`, To).
  - `Message-ID` host `@mail253.wdc02.mcdlv.net` -> `@example.com`.
- **`tests/data/large_message.eml`** (CRLF endings preserved):
  - Personal sender name + address `"Anabel Gonzalo" <anabelgonzalo@fanox.com>` -> `"Example Sender" <sender@example.com>` (From, Reply-To, envelope-from).
  - Personal recipient `bruce@untroubled.org` -> `recipient@example.org`.
  - Authenticated-sender `quazi.limon@revesoft.com` -> `authuser@example.com` (X-Get-Message-Sender-Via, X-Authenticated-Sender).
  - Related personal domains in X-AntiAbuse (`untroubled.org`, `fanox.com`) and the `mail.revesoft.com` Received host -> `example.org`/`example.com`.
  - `Message-Id` host `@st10.mi6.kiev.ua` -> `@example.com`.

`tests/data/attachment_message.eml` already used `example.com` addresses — no change needed.

### Assertions
No test assertions required changes. The only header-value assertion (`Reply-To == 'Red Hat OpenShift <noreply@openshift.com>'`) references a non-personal marketing/role address that is intentionally kept, and body-text assertions reference unchanged marketing copy.

### Validation
Built with `maturin develop` and ran the full suite (excluding benchmarks): **63 passed**.

Closes #27