### PR TITLE
ci: add mypy --strict + ruff lint and cache cargo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,11 +18,15 @@ permissions:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Lint. rustfmt is enforced (blocking) now that the source is rustfmt-clean.
-  # clippy and mypy stay advisory (continue-on-error) until their debt clears,
-  # and each runs regardless of the others:
-  #   - clippy -> flip to blocking after the str->bytes fix (#19)
-  #   - mypy   -> flip to blocking after the .pyi stubs type-check clean (#42)
+  # Lint. rustfmt and mypy --strict are enforced (blocking); clippy and ruff
+  # stay advisory (continue-on-error) until their debt clears, and each runs
+  # regardless of the others:
+  #   - rustfmt -> blocking (source is rustfmt-clean).
+  #   - clippy  -> flip to blocking after the str->bytes fix (#19).
+  #   - mypy    -> blocking: `mypy --strict fast_mail_parser/` is clean (#42).
+  #   - ruff    -> advisory: `ruff check .` reports issues in the package
+  #                stubs (UP006/UP007) and in test code (I001/E501/UP*). Fixing
+  #                those is out of scope here; flip to blocking once clean (#44).
   # ---------------------------------------------------------------------------
   lint:
     name: Lint
@@ -47,11 +51,21 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings -W clippy::cast_possible_truncation
         continue-on-error: true
 
-      - name: mypy (type stubs)
+      # Blocking: `mypy --strict fast_mail_parser/` type-checks clean today.
+      - name: mypy --strict
         if: always()
         run: |
           python -m pip install --upgrade pip mypy
-          mypy fast_mail_parser/
+          mypy --strict fast_mail_parser/
+
+      # Advisory: `ruff check .` currently reports issues in the package stubs
+      # (UP006/UP007) and in test code (I001/E501/UP015). Fixing those is out
+      # of scope; drop continue-on-error once they are resolved (#44).
+      - name: ruff check
+        if: always()
+        run: |
+          python -m pip install ruff
+          ruff check .
         continue-on-error: true
 
   # ---------------------------------------------------------------------------
@@ -120,6 +134,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: "1.83"
+      # Cache the cargo registry and build artifacts so `make install` reuses
+      # compiled crates across runs instead of rebuilding from scratch (#47).
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Install the package
         run: make install
       - name: Install test dependencies
@@ -138,12 +158,21 @@ jobs:
   benchmark:
     name: Benchmark quality gate
     runs-on: ubuntu-latest
+    # PR merge gate only: run on pull_request and workflow_dispatch, skip on
+    # push to master — re-running the benchmark post-merge is wasteful (#47).
+    if: github.event_name != 'push'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.10"
           cache: pip
+      - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+        with:
+          toolchain: "1.83"
+      # Cache the cargo registry and build artifacts so `make install` reuses
+      # compiled crates across runs instead of rebuilding from scratch (#47).
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Install the package + test dependencies
         run: |
           make install

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,12 @@
+# Ruff configuration for fast_mail_parser.
+# Sensible, not-overly-strict rule set: pycodestyle errors (E), pyflakes (F),
+# import sorting (I), pyupgrade (UP), and flake8-bugbear (B).
+line-length = 100
+target-version = "py39"
+
+# The Python surface is the thin fast_mail_parser/ wrapper; the Rust extension
+# is built into it. Test data/fixtures are not linted.
+extend-exclude = ["tests/data", "tests/fixtures"]
+
+[lint]
+select = ["E", "F", "I", "UP", "B"]


### PR DESCRIPTION
Closes #44
Closes #47

## Issue #44 — Python type-check/lint in CI
- The lint job's mypy step now runs `mypy --strict fast_mail_parser/`.
- Added a `ruff check .` step (installs ruff via `python -m pip install ruff`) plus a root `ruff.toml` (`select = E,F,I,UP,B`; `line-length = 100`; `target-version = py39`; excludes `tests/data`/`tests/fixtures`).

### Blocking vs advisory (decided empirically — ran both locally against this repo)
- **mypy `--strict` → blocking.** `mypy --strict fast_mail_parser/` reports `Success: no issues found in 1 source file`, so the step has no `continue-on-error`.
- **ruff → advisory (`continue-on-error: true`).** `ruff check .` reports 13 findings: package stub typing (`UP006`/`UP007` in `__init__.pyi`), an import-order nit in `__init__.py` (`I001`), and the rest in test code (`I001`/`E501`/`UP015`). Fixing source/stub/test files is out of scope for this CI-only change and those files are owned by other work, so the step is gated advisory with a comment to flip it to blocking once clean.

## Issue #47 — Cache cargo + move benchmark off every-push
- Added `Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1` (the same pinned SHA the lint job uses) to the `test` matrix job and the `benchmark` job, after checkout and before `make install`. Each is preceded by `dtolnay/rust-toolchain@…# master` with `toolchain: "1.83"` (mirroring the lint job) so rust-cache can locate cargo.
- The `benchmark` job now has `if: github.event_name != 'push'`, so it runs on `pull_request` / `workflow_dispatch` (PR merge gate) and is skipped on push to master.

## Verification
- `python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` → `yaml ok`.
- ruff 0.15.17 and mypy 2.1.0 run locally in a throwaway venv (results above).
- Only `.github/workflows/test.yml` and new `ruff.toml` touched; no source/test/fixture/pyproject changes.