### PR TITLE
test: round-trip correctness, multi-value header coverage, benchmark assertion

### DIFF
--- a/tests/benchmark/test_read_message.py
+++ b/tests/benchmark/test_read_message.py
@@ -8,6 +8,14 @@ def test__mail_parser___parse_message(large_message: str, benchmark: Callable):
 
 
 def test__fast_mail_parser___parse_message(large_message: str, benchmark: Callable):
-    from fast_mail_parser import parse_email
+    from fast_mail_parser import PyMail, parse_email
+
+    # Assert correctness once, outside the timed loop, so a fast-but-wrong parser
+    # fails this benchmark instead of silently posting a great time. The timing
+    # call below stays the sole thing `benchmark` measures.
+    mail = parse_email(large_message)
+    assert isinstance(mail, PyMail)
+    assert mail.subject, "expected a non-empty subject from the large message"
+    assert mail.headers, "expected the large message to expose headers"
 
     benchmark(parse_email, large_message)

--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -1,0 +1,195 @@
+"""Round-trip / property-style correctness tests.
+
+These build well-formed messages with Python's stdlib ``email`` library
+(``EmailMessage`` + ``BytesGenerator``), serialize them to bytes, parse the
+bytes back with ``fast_mail_parser.parse_email``, and assert the parsed fields
+match what was put in. The stdlib is the trusted producer here, so any
+divergence points at the parser under test.
+
+Scope and rationale:
+- Stdlib only — no ``hypothesis`` (kept out of the dependency set on purpose).
+  We get property/round-trip coverage by enumerating several concrete message
+  *shapes* (plain, multipart/alternative, with attachment) instead.
+- We assert on values we control end-to-end: subject, plain/HTML bodies,
+  attachment count / mimetype / raw content bytes, and ordinary single-valued
+  header values.
+
+Characterized quirks (current parser behavior, intentionally pinned):
+- Every MIME node is reported as an attachment, including the text parts and
+  the multipart *container* nodes (containers carry empty content). So the
+  attachment list length is the number of MIME nodes, not just the "real"
+  file attachments. Tests below filter by mimetype rather than asserting a bare
+  ``len(attachments)`` for multipart messages.
+- ``filename`` is read from the Content-Type ``name`` parameter, not from
+  Content-Disposition ``filename``. ``EmailMessage.add_attachment`` emits the
+  filename ONLY via Content-Disposition (no Content-Type ``name`` param), so for
+  these stdlib-built messages the parser reports ``filename == ""`` even though
+  the attachment content round-trips exactly. Tests assert that observed
+  behavior rather than expecting the disposition filename to surface.
+- Stdlib bodies are emitted with a trailing newline; the parser preserves it,
+  so body comparisons use membership / ``strip`` rather than strict equality.
+"""
+
+from email.generator import BytesGenerator
+from email.message import EmailMessage
+from io import BytesIO
+
+import pytest
+
+from fast_mail_parser import PyAttachment, PyMail, parse_email
+
+
+def _serialize(message: EmailMessage) -> bytes:
+    """Render an EmailMessage to wire-format bytes with CRLF line endings."""
+    buffer = BytesIO()
+    BytesGenerator(buffer, policy=message.policy.clone(linesep="\r\n")).flatten(message)
+    return buffer.getvalue()
+
+
+def _attachment_by_mimetype(mail: PyMail, mimetype: str) -> PyAttachment:
+    for attachment in mail.attachments:
+        if attachment.mimetype == mimetype:
+            return attachment
+    raise AssertionError(f"no attachment with mimetype {mimetype!r}")
+
+
+# --- plain text -------------------------------------------------------------
+
+
+def test__plain_text_round_trip():
+    message = EmailMessage()
+    message["Subject"] = "Plain round trip"
+    message["From"] = "alice@example.com"
+    message["To"] = "bob@example.com"
+    message.set_content("Hello, this is the plain body.\n")
+
+    mail = parse_email(_serialize(message))
+
+    assert mail.subject == "Plain round trip"
+    assert mail.headers["From"] == "alice@example.com"
+    assert mail.headers["To"] == "bob@example.com"
+    assert len(mail.text_plain) == 1
+    assert "Hello, this is the plain body." in mail.text_plain[0]
+    assert mail.text_html == []
+
+
+# --- multipart/alternative --------------------------------------------------
+
+
+def test__multipart_alternative_round_trip():
+    plain = "Plain alternative body."
+    html = "<html><body><p>HTML alternative body.</p></body></html>"
+
+    message = EmailMessage()
+    message["Subject"] = "Alternative round trip"
+    message["From"] = "alice@example.com"
+    message.set_content(plain + "\n")
+    message.add_alternative(html + "\n", subtype="html")
+
+    mail = parse_email(_serialize(message))
+
+    assert mail.subject == "Alternative round trip"
+
+    assert len(mail.text_plain) == 1
+    assert plain in mail.text_plain[0]
+
+    assert len(mail.text_html) == 1
+    assert html in mail.text_html[0]
+
+    # Container node is reported as an attachment alongside the two text nodes.
+    mimetypes = [attachment.mimetype for attachment in mail.attachments]
+    assert "text/plain" in mimetypes
+    assert "text/html" in mimetypes
+    assert "multipart/alternative" in mimetypes
+
+
+# --- multipart/mixed with a binary attachment -------------------------------
+
+
+def test__attachment_round_trip_preserves_content_and_mimetype():
+    payload = bytes(range(256))  # every byte value, to prove binary-safety
+
+    message = EmailMessage()
+    message["Subject"] = "Attachment round trip"
+    message["From"] = "alice@example.com"
+    message.set_content("See attached.\n")
+    message.add_attachment(
+        payload,
+        maintype="application",
+        subtype="octet-stream",
+        filename="payload.bin",
+    )
+
+    mail = parse_email(_serialize(message))
+
+    assert mail.subject == "Attachment round trip"
+    assert "See attached." in mail.text_plain[0]
+
+    attachment = _attachment_by_mimetype(mail, "application/octet-stream")
+    assert attachment.content == payload  # exact bytes survive base64 round trip
+    # add_attachment emits the filename via Content-Disposition only; the parser
+    # reads it from the Content-Type `name` param, so it surfaces as empty here.
+    assert attachment.filename == ""
+
+
+def test__text_attachment_content_round_trips():
+    body = "line one\nline two\n"
+
+    message = EmailMessage()
+    message["Subject"] = "Text attachment"
+    message["From"] = "alice@example.com"
+    message.set_content("Body before attachment.\n")
+    message.add_attachment(
+        body.encode("utf-8"),
+        maintype="text",
+        subtype="plain",
+        filename="notes.txt",
+    )
+
+    mail = parse_email(_serialize(message))
+
+    # The disposition filename is not surfaced (see module docstring), so the
+    # attachment is located by its distinct decoded content, not by filename.
+    text_contents = [
+        a.content.decode("utf-8")
+        for a in mail.attachments
+        if a.mimetype == "text/plain"
+    ]
+    assert body in text_contents
+
+
+# --- header value fidelity --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "key, value",
+    [
+        ("X-Custom-Token", "abc-123-DEF"),
+        ("X-Numeric", "00420"),
+        ("Reply-To", "Support <support@example.com>"),
+    ],
+)
+def test__single_valued_header_round_trips(key: str, value: str):
+    message = EmailMessage()
+    message["Subject"] = "Header fidelity"
+    message["From"] = "alice@example.com"
+    message[key] = value
+    message.set_content("body\n")
+
+    mail = parse_email(_serialize(message))
+
+    assert mail.headers[key] == value
+
+
+def test__returns_pymail_for_every_shape():
+    # A light invariant guard: each builder above produces a parseable PyMail.
+    message = EmailMessage()
+    message["Subject"] = "Invariant"
+    message["From"] = "alice@example.com"
+    message.set_content("body\n")
+
+    mail = parse_email(_serialize(message))
+
+    assert isinstance(mail, PyMail)
+    assert isinstance(mail.subject, str) and mail.subject
+    assert isinstance(mail.headers, dict) and mail.headers

--- a/tests/test_multivalue_headers.py
+++ b/tests/test_multivalue_headers.py
@@ -1,0 +1,95 @@
+"""Characterization tests for duplicate / multi-value headers.
+
+``PyMail.headers`` is a ``dict[str, str]`` (backed by a Rust ``HashMap<String,
+String>``). RFC 5322 allows several header fields to appear more than once
+(``Received``, ``X-*`` trace headers, ``Comments``, etc.), but a ``dict`` cannot
+hold more than one value per key. This file pins the resulting *collapse*
+behavior so consumers know what to expect and so any future change (e.g.
+switching to a multimap) is caught.
+
+What is covered elsewhere (NOT re-tested here):
+- Non-ASCII / RFC 2047 / RFC 6532 header decoding -> ``tests/test_rfc_corpus.py``.
+- Content-Disposition handling and filename sourcing -> ``tests/test_rfc_corpus.py``.
+
+This file focuses solely on the multi-value gap those suites do not cover.
+
+Characterized behavior (current contract):
+- Duplicate headers collapse to a single ``str`` value per key; the values are
+  NOT concatenated, joined, or exposed as a list.
+- Exactly one of the duplicated values is retained. The retained value is one of
+  the originals (we do not over-specify *which*, since it depends on the
+  HashMap collection order in the Rust layer); see the dedicated test for the
+  precise observed selection.
+"""
+
+from fast_mail_parser import parse_email
+
+
+def _build(raw_headers: str) -> bytes:
+    return (raw_headers + "\r\n\r\nbody\r\n").encode("ascii")
+
+
+def test__duplicate_custom_header_collapses_to_single_string():
+    raw = "Subject: dup test\r\nX-Custom: first\r\nX-Custom: second"
+    mail = parse_email(_build(raw))
+
+    value = mail.headers["X-Custom"]
+    assert isinstance(value, str)
+    # Collapsed to one of the original values, never both joined together.
+    assert value in {"first", "second"}
+    assert "first" not in value or "second" not in value
+
+
+def test__duplicate_received_headers_collapse_to_single_value():
+    raw = (
+        "Subject: trace test\r\n"
+        "Received: from a.example.com by mx1.example.com\r\n"
+        "Received: from b.example.com by mx2.example.com"
+    )
+    mail = parse_email(_build(raw))
+
+    received = mail.headers["Received"]
+    assert isinstance(received, str)
+    assert received in {
+        "from a.example.com by mx1.example.com",
+        "from b.example.com by mx2.example.com",
+    }
+
+
+def test__three_duplicates_still_yield_one_value():
+    raw = (
+        "Subject: triple\r\n"
+        "X-Trace: one\r\n"
+        "X-Trace: two\r\n"
+        "X-Trace: three"
+    )
+    mail = parse_email(_build(raw))
+
+    assert mail.headers["X-Trace"] in {"one", "two", "three"}
+
+
+def test__headers_dict_has_one_entry_per_key_despite_duplicates():
+    # The dict cannot represent multiplicity: duplicated keys do not inflate
+    # the entry count. Both X-Dup lines map to a single dict entry.
+    raw = "Subject: count\r\nX-Dup: a\r\nX-Dup: b\r\nX-Unique: u"
+    mail = parse_email(_build(raw))
+
+    assert "X-Dup" in mail.headers
+    assert "X-Unique" in mail.headers
+    # Only the keys we set plus Subject; no per-occurrence duplication.
+    assert mail.headers["X-Unique"] == "u"
+
+
+def test__retained_duplicate_value_is_one_of_the_originals():
+    # Document the observed selection precisely. parse_email feeds headers into a
+    # Rust HashMap via `.collect()`, so the last-inserted value for a key wins;
+    # in practice that surfaces as the LAST occurrence in the message. We assert
+    # the value is one of the originals (the firm guarantee) and additionally
+    # record the observed last-wins behavior so a regression is visible.
+    raw = "Subject: order\r\nX-Order: alpha\r\nX-Order: omega"
+    mail = parse_email(_build(raw))
+
+    value = mail.headers["X-Order"]
+    assert value in {"alpha", "omega"}
+    # Observed behavior: the last occurrence is retained.
+    assert value == "omega"


### PR DESCRIPTION
Adds test coverage and makes the benchmark assert correctness. New test files only plus an edit to the benchmark; no changes to `src/`, fixtures, `.github/`, `pyproject.toml`, or existing test files. Stdlib only (no new deps, no hypothesis).

## Closes #35 — integration/property tests + benchmark correctness
- **`tests/test_correctness.py`** (new): builds messages with the stdlib `email` library (`EmailMessage` + `BytesGenerator`), serializes to bytes, parses with `fast_mail_parser.parse_email`, and asserts the parsed fields match the inputs. Covers plain text, multipart/alternative, and multipart/mixed with binary + text attachments, plus single-valued header fidelity. Round-trip / property style using the stdlib as the trusted producer.
- **`tests/benchmark/test_read_message.py`** (edited): the fast-parser benchmark now parses the large message once *outside* the timed loop and asserts a valid `PyMail` with a non-empty `subject` and non-empty `headers`, so a fast-but-wrong parser fails. The `benchmark(...)` timing call is unchanged; the two existing benchmark tests still run.

## Closes #33 — multi-value header tests
- **`tests/test_multivalue_headers.py`** (new): parses messages with duplicate headers (`X-Custom`, `Received`, `X-Trace`, `X-Order`) and characterizes the current `dict[str, str]` collapse: one value per key, never concatenated, with the last occurrence retained (HashMap `.collect()` last-wins). The module docstring notes that non-ASCII / RFC 2047 / RFC 6532 header decoding and Content-Disposition handling are already covered by `tests/test_rfc_corpus.py`, so this file focuses solely on the multi-value gap.

## Behavior characterized (not fought)
- `EmailMessage.add_attachment` emits the filename via **Content-Disposition only**; the parser reads it from the Content-Type `name` parameter, so stdlib-built attachments surface `filename == ""` even though their content round-trips byte-exactly. Tests assert that observed behavior (consistent with the existing quirk pinned in `test_rfc_corpus.py`).
- Duplicate headers collapse to the **last** occurrence's value.

## Verification
Built with `maturin develop` (PyO3 0.29) and ran the targeted suite plus the full suite:
- targeted: `pytest tests/test_correctness.py tests/test_multivalue_headers.py tests/benchmark/test_read_message.py` -> **15 passed**
- full suite -> **85 passed**, no regressions