### PR TITLE
ci: set Python test matrix to 3.11–3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,10 +102,9 @@ jobs:
         run: cargo audit
 
   # ---------------------------------------------------------------------------
-  # Test matrix — the real merge gate. Builds & passes on CPython 3.9–3.13 with
-  # PyO3 0.29 (3.7/3.8 are EOL and unavailable on current ubuntu runners). 3.13
-  # is a required cell now that PyO3 0.29 supports it (was allowed-failure under
-  # the old 0.16 pin).
+  # Test matrix — the real merge gate. Runs on CPython 3.11–3.14, built with
+  # PyO3 0.29. (3.9/3.10 dropped and 3.14 added per project policy; 3.7/3.8 are
+  # EOL and unavailable on current ubuntu runners.)
   # ---------------------------------------------------------------------------
   test:
     name: Test (py${{ matrix.python-version }})
@@ -113,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5


### PR DESCRIPTION
Sets the CI test matrix to **CPython 3.11, 3.12, 3.13, 3.14** — drops 3.9/3.10, adds 3.14.

## ⚠️ Two things to confirm on the CI result
1. **3.14 + PyO3 0.29:** fast_mail_parser builds a version-specific extension (`pyo3/extension-module`, not abi3). Whether it compiles against CPython 3.14 depends on PyO3 0.29 supporting 3.14 on the runner. **This PR's CI is the source of truth.** If the 3.14 cell fails to build, I'll mark it allowed-failure (experimental) pending a PyO3 bump and report — rather than leave the matrix red.
2. **`requires-python` mismatch:** `pyproject.toml` still declares `requires-python = ">= 3.9"` and lists 3.9/3.10 classifiers. Dropping 3.9/3.10 from CI makes that inconsistent. I did **not** change `pyproject.toml` here (PR #74 is concurrently editing it). If you want to also drop 3.9/3.10 *support* (a breaking change for those users), say so and I'll bump `requires-python` to `>= 3.11` + update classifiers.

Test-only workflow change.