### PR TITLE
Fix lossy str->bytes conversion that corrupts non-ASCII input

### DIFF
--- a/src/fast_mail_parser.rs
+++ b/src/fast_mail_parser.rs
@@ -82,15 +82,10 @@ impl PyToBytes for Py<PyAny> {
 
         if let Ok(text) = obj.cast::<PyString>() {
             if let Ok(text) = text.to_str() {
-                // Historical str->bytes mapping: each code point truncated to its
-                // low byte. For ASCII that is exactly the UTF-8 representation, so
-                // copy the bytes directly (a memcpy) instead of walking code
-                // points; only non-ASCII input needs the per-char cast.
-                return Ok(if text.is_ascii() {
-                    text.as_bytes().to_vec()
-                } else {
-                    text.chars().map(|c| c as u8).collect()
-                });
+                // Decode str losslessly as its UTF-8 bytes. ASCII is unchanged
+                // (ASCII == its own UTF-8); non-ASCII code points now round-trip
+                // correctly instead of being truncated to their low byte.
+                return Ok(text.as_bytes().to_vec());
             }
         }
 

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -119,16 +119,14 @@ def test__rejects_non_text_input_with_type_error(bad_input):
         parse_email(bad_input)
 
 
-def test__non_ascii_str_decodes_as_truncated_code_points():
-    # str input is decoded by truncating each code point to its low byte
-    # (historical, lossy behavior). The ASCII fast path must stay byte-identical
-    # to this, so a non-ASCII str must parse exactly like the explicitly
-    # truncated bytes do.
-    raw = "Subject: café über\r\n\r\nbody"  # é, ü -> 0xE9, 0xFC
-    truncated_bytes = bytes((ord(char) & 0xFF) for char in raw)
+def test__non_ascii_str_decodes_as_utf8():
+    # str input is decoded losslessly as its UTF-8 bytes. A non-ASCII str must
+    # therefore parse exactly like its explicit UTF-8 encoding (no truncation of
+    # code points to their low byte).
+    raw = "Subject: café über 日本\r\n\r\nbody"
 
     from_str = parse_email(raw)
-    from_bytes = parse_email(truncated_bytes)
+    from_bytes = parse_email(raw.encode("utf-8"))
 
     assert from_str.subject == from_bytes.subject
     assert from_str.headers == from_bytes.headers


### PR DESCRIPTION
## Summary

`parse_email` accepts `str` or `bytes`. For `str` input, `to_bytes()` in `src/fast_mail_parser.rs` mapped each code point to its low byte (`chars().map(|c| c as u8)`, with an `is_ascii()` fast path). For non-ASCII input this **truncated** code points (e.g. 'é' U+00E9 -> 0xE9, '日' U+65E5 -> 0xE5), silently corrupting the bytes handed to the parser.

This fix decodes `str` losslessly as its UTF-8 bytes via `text.as_bytes().to_vec()` for all strings, dropping both the `is_ascii()` branch and the lossy per-char cast. The `bytes` path and the `TypeError` fallback are unchanged.

## Behavior change

This **changes output for non-ASCII `str` input** (now lossless UTF-8 instead of truncated). It is a correctness fix for a corruption bug; ASCII input and `bytes` input are unchanged. Consumers should be unaffected unless they relied on the (buggy) truncation.

## Tests

Reworked `tests/test_contract.py::test__non_ascii_str_decodes_as_truncated_code_points` -> `test__non_ascii_str_decodes_as_utf8` to assert the new correct behavior: a non-ASCII `str` parses identically to its explicit UTF-8 encoding. `test__accepts_str_and_bytes_equivalently` still passes. Full suite: 70 passed.

Closes #19