### PR TITLE
Harden parse_email against untrusted-input DoS (cap input size and MIME depth)

### DIFF
--- a/src/mail_parser.rs
+++ b/src/mail_parser.rs
@@ -1,6 +1,19 @@
 use mailparse::*;
 use std::collections::HashMap;
 
+// DoS hardening: `parse_email` runs on untrusted input. The two constants below
+// bound otherwise-unbounded resource use. Both limits sit far above any
+// realistic email, so well-formed messages are never affected.
+
+// Reject payloads larger than 100 MiB. A single email this large is not
+// legitimate; rejecting up front prevents a huge payload from exhausting memory.
+const MAX_INPUT_BYTES: usize = 100 * 1024 * 1024;
+
+// Cap MIME multipart nesting at 256 levels. `extract_mail_parts` recurses over
+// subparts, so a maliciously deep multipart tree could otherwise blow the stack
+// and crash the host process. Real messages nest only a handful of levels deep.
+const MAX_MIME_DEPTH: usize = 256;
+
 pub(crate) fn parse_email(payload: &[u8]) -> Result<Mail, MailParseError> {
     Mail::new(payload)
 }
@@ -24,6 +37,12 @@ pub(crate) struct Attachment {
 
 impl<'a> Mail {
     pub(crate) fn new(payload: &'a [u8]) -> Result<Self, MailParseError> {
+        if payload.len() > MAX_INPUT_BYTES {
+            return Err(MailParseError::Generic(
+                "Input exceeds maximum allowed size",
+            ));
+        }
+
         let mail = parse_mail(payload)?;
 
         let headers: HashMap<String, String> = mail
@@ -40,7 +59,7 @@ impl<'a> Mail {
         let mut text_plain = vec![];
         let mut text_html = vec![];
 
-        for mail in Self::extract_mail_parts(mail) {
+        for mail in Self::extract_mail_parts(mail, 0)? {
             let attachment_name = mail.ctype.params.get("name");
             let mime = mail.ctype.mimetype.as_str();
 
@@ -69,16 +88,25 @@ impl<'a> Mail {
         })
     }
 
-    fn extract_mail_parts(mut mail: ParsedMail<'a>) -> Vec<ParsedMail<'a>> {
+    fn extract_mail_parts(
+        mut mail: ParsedMail<'a>,
+        depth: usize,
+    ) -> Result<Vec<ParsedMail<'a>>, MailParseError> {
+        if depth >= MAX_MIME_DEPTH {
+            return Err(MailParseError::Generic(
+                "MIME nesting exceeds maximum allowed depth",
+            ));
+        }
+
         let mut result = vec![];
         let subparts = std::mem::take(&mut mail.subparts);
 
         for part in subparts {
-            result.extend(Self::extract_mail_parts(part));
+            result.extend(Self::extract_mail_parts(part, depth + 1)?);
         }
 
         result.push(mail);
 
-        result
+        Ok(result)
     }
 }

--- a/tests/test_dos_limits.py
+++ b/tests/test_dos_limits.py
@@ -1,0 +1,82 @@
+"""DoS-hardening tests for parse_email (issue #21).
+
+These exercise the additive guards added in src/mail_parser.rs:
+  - MAX_INPUT_BYTES = 100 MiB  (oversized payload rejection)
+  - MAX_MIME_DEPTH  = 256      (MIME recursion-depth cap)
+
+Both limits sit far above any realistic email, so normal messages parse fine.
+"""
+
+import pytest
+
+from fast_mail_parser import ParseError, parse_email
+
+
+def _build_nested_multipart(levels: int) -> bytes:
+    """Build a raw multipart/mixed message nested `levels` deep.
+
+    Level 0 is the outer/root container. Each level wraps the next inside one
+    `multipart/mixed` part; the innermost level carries a text/plain body. The
+    parser counts the root as depth 0 and each nested subpart as +1, so the
+    deepest text part sits at recursion depth `levels`.
+    """
+    # Innermost leaf: a simple text/plain body.
+    inner = (
+        b"Content-Type: text/plain\r\n\r\n"
+        b"deeply nested body\r\n"
+    )
+
+    body = inner
+    for level in range(levels):
+        boundary = f"b{level}".encode("ascii")
+        body = (
+            b"Content-Type: multipart/mixed; boundary=\"" + boundary + b"\"\r\n\r\n"
+            b"--" + boundary + b"\r\n"
+            + body
+            + b"\r\n--" + boundary + b"--\r\n"
+        )
+
+    # Add a top-level header block so the whole thing looks like an email.
+    return b"Subject: nested\r\n" + body
+
+
+def test_normal_message_parses():
+    """A normal, shallow message parses without error (no regression)."""
+    message = (
+        b"Subject: hello\r\n"
+        b"Content-Type: text/plain\r\n\r\n"
+        b"plain body\r\n"
+    )
+    mail = parse_email(message)
+    assert mail.subject == "hello"
+    assert any("plain body" in part for part in mail.text_plain)
+
+
+def test_normally_nested_multipart_parses():
+    """Multipart nested well within MAX_MIME_DEPTH parses fine."""
+    message = _build_nested_multipart(10)
+    mail = parse_email(message)
+    assert mail.subject == "nested"
+    assert any("deeply nested body" in part for part in mail.text_plain)
+
+
+def test_deeply_nested_multipart_rejected():
+    """Nesting beyond MAX_MIME_DEPTH (256) raises ParseError, not a crash."""
+    # 300 levels is comfortably past the 256-level cap.
+    message = _build_nested_multipart(300)
+    with pytest.raises(ParseError):
+        parse_email(message)
+
+
+def test_oversized_input_rejected():
+    """A payload just over MAX_INPUT_BYTES (100 MiB) raises ParseError.
+
+    Allocating ~100 MiB once in-process is acceptable for a single test run;
+    the cap itself is intentionally kept generous so production emails are
+    never affected. This asserts the guard fires before any parsing work.
+    """
+    max_input_bytes = 100 * 1024 * 1024
+    # A header line plus filler to push total length just past the cap.
+    oversized = b"Subject: big\r\n\r\n" + b"x" * (max_input_bytes + 1)
+    with pytest.raises(ParseError):
+        parse_email(oversized)


### PR DESCRIPTION
## Summary

`parse_email` runs on untrusted input. This adds two additive guards in `src/mail_parser.rs` to close two unbounded resource risks. Both limits sit far above any realistic email, so well-formed messages are unaffected.

### Chosen limits
- **Input size cap — `MAX_INPUT_BYTES = 100 * 1024 * 1024` (100 MiB):** rejected at the start of `Mail::new`, before any parsing, so a huge payload cannot exhaust memory.
- **MIME recursion depth cap — `MAX_MIME_DEPTH = 256`:** `extract_mail_parts` now threads a depth counter and returns an error when exceeded, preventing a deeply-nested multipart message from blowing the stack and crashing the host process. No panic, no silent truncation.

Both errors surface to Python as `ParseError` with a clear message (`Input exceeds maximum allowed size` / `MIME nesting exceeds maximum allowed depth`).

### Tests (`tests/test_dos_limits.py`)
- Oversized input (just over 100 MiB) raises `ParseError`.
- Multipart nested beyond 256 levels raises `ParseError` (not a crash).
- Normally-nested multipart (10 levels) still parses fine.
- A normal message still parses (no regression).

### Verification
- `maturin develop` builds clean; `cargo clippy` reports no warnings.
- `pytest tests/test_dos_limits.py`: 4 passed.
- `pytest --ignore tests/benchmark tests`: 74 passed.

Closes #21