### PR TITLE
ci(publish): drop the unschedulable macos-13 (x86_64) wheel job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -114,8 +114,9 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runner: macos-13 # macos-12 is being removed from GitHub-hosted runners
-            target: x86_64
+          # Only arm64 macOS wheels. The macos-13 (x86_64) runner is being
+          # retired and became unschedulable (its job sat queued until GitHub
+          # cancelled the release). x86_64 macOS installs fall back to the sdist.
           - runner: macos-14
             target: aarch64
     steps:


### PR DESCRIPTION
The macos-13 (x86_64) runner is being retired and became **unschedulable** — its job sat queued in the v0.4.0 release run until GitHub cancelled it, which cancelled the `Release` (PyPI upload) job too. So v0.4.0 never published.

Drop the macos-13 entry; build only the **arm64 (macos-14)** macOS wheel. x86_64 macOS installs fall back to the sdist (build-from-source). All other platforms (Linux x86_64/x86/aarch64/armv7/ppc64le/s390x, musllinux, Windows x64/x86) are unchanged and were succeeding.

Follow-up to publish v0.4.0: re-create the v0.4.0 release on the updated master so `publish.yml` runs without the macos-13 dependency.