### PR TITLE
perf: decode text-part transfer encoding only once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,7 @@ dependencies = [
 name = "fast_mail_parser"
 version = "0.4.0"
 dependencies = [
+ "charset",
  "mailparse",
  "pyo3",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,10 @@ path = "src/fast_mail_parser.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
+# `charset` is also a transitive dependency of `mailparse`; we depend on it
+# directly to reuse the exact charset-decoding step mailparse applies in
+# `get_body`, so text parts are decoded only once (see `decode_charset`).
+charset = "0.1.3"
 mailparse = "0.16.1"
 pyo3 = "0.29"
 

--- a/src/mail_parser.rs
+++ b/src/mail_parser.rs
@@ -10,6 +10,7 @@
 //! objects. Keeping the two models separate decouples the parsing logic from the
 //! Python bindings.
 
+use charset::{decode_ascii, Charset};
 use mailparse::*;
 use std::collections::HashMap;
 
@@ -28,6 +29,20 @@ const MAX_MIME_DEPTH: usize = 256;
 
 pub(crate) fn parse_email(payload: &[u8]) -> Result<Mail, MailParseError> {
     Mail::new(payload)
+}
+
+/// Decode already-transfer-decoded `body` bytes into a `String` using the part's
+/// charset (defaulting to us-ascii when the label is missing or unrecognized).
+///
+/// This mirrors mailparse's internal `get_body_as_string` exactly -- same crate,
+/// same logic -- so it can be fed the bytes from `get_body_raw` to produce the
+/// same result as `get_body` without decoding the transfer encoding twice.
+fn decode_charset(body: &[u8], ctype: &ParsedContentType) -> String {
+    if let Some(charset) = Charset::for_label(ctype.charset.as_bytes()) {
+        charset.decode(body).0.into_owned()
+    } else {
+        decode_ascii(body).into_owned()
+    }
 }
 
 #[derive(Debug)]
@@ -75,25 +90,31 @@ impl<'a> Mail {
             let attachment_name = mail.ctype.params.get("name");
             let mime = mail.ctype.mimetype.as_str();
 
-            // Propagate body decode failures instead of swallowing them with
-            // `unwrap_or_default()`. A broken transfer encoding (e.g. invalid
-            // base64/quoted-printable) or an undecodable charset would otherwise
-            // be silently turned into an empty body, hiding corruption from the
-            // caller. `get_body_raw`/`get_body` return `MailParseError`, which the
-            // PyO3 layer surfaces to Python as `ParseError`.
-            attachments.push(Attachment {
-                mimetype: mime.to_string(),
-                content: mail.get_body_raw()?,
-                filename: attachment_name.cloned().unwrap_or_default(),
-            });
+            // Undo the Content-Transfer-Encoding (e.g. base64/quoted-printable)
+            // exactly once. `?` propagates a broken transfer encoding instead of
+            // swallowing it with `unwrap_or_default()`, which would silently turn
+            // corruption into an empty body; the PyO3 layer surfaces the error to
+            // Python as `ParseError`.
+            let content = mail.get_body_raw()?;
 
+            // For text parts, build the Python-facing string from the bytes we
+            // just decoded instead of calling `get_body()`, which would re-run the
+            // identical transfer decode a second time. `decode_charset` performs
+            // only the charset step, so the result matches mailparse's `get_body`
+            // output byte-for-byte (see `decode_charset`).
             if attachment_name.is_none() {
                 if mime == "text/plain" {
-                    text_plain.push(mail.get_body()?)
+                    text_plain.push(decode_charset(&content, &mail.ctype));
                 } else if mime == "text/html" {
-                    text_html.push(mail.get_body()?)
+                    text_html.push(decode_charset(&content, &mail.ctype));
                 }
             }
+
+            attachments.push(Attachment {
+                mimetype: mime.to_string(),
+                content,
+                filename: attachment_name.cloned().unwrap_or_default(),
+            });
         }
 
         Ok(Self {


### PR DESCRIPTION
## What

`text/plain` and `text/html` parts were transfer-decoded **twice**:

1. `get_body_raw()` → bytes for `attachments[].content`
2. `get_body()` → string for `text_plain`/`text_html`, which **re-runs the same** base64/quoted-printable decode before applying the charset.

This decodes the transfer encoding **once** (`get_body_raw()`), reuses those bytes for both the attachment content and the text bodies, and applies only the charset step via a new `decode_charset()` helper — a faithful copy of mailparse's own internal `get_body_as_string` using the same `charset` crate (already a transitive dep). Output is **byte-identical**.

## Benchmark

Targeted input — a ~2 MB base64-encoded `text/html` body (the path this change touches), 200 iterations, same input both builds:

| build | min | median | mean |
|---|---|---|---|
| master | 8.308 ms | 8.841 ms | 8.965 ms |
| this PR | 4.390 ms | 4.706 ms | **4.706 ms** |

**~1.9× faster** on base64/quoted-printable-encoded text bodies. The existing `tests/benchmark` (`large_message.eml`) is unchanged within noise — that corpus is dominated by base64 *attachments*, which carry a `name` param and were only ever decoded once.

## Risk

- Behavior-preserving: `decode_charset` replicates mailparse's charset logic exactly (same crate, same code path). For 7bit/8bit text it reduces to the prior `get_as_string(raw)`; for base64/QP it reduces to `get_decoded_as_string()` minus the redundant transfer decode.
- Transfer-decode errors still surface (now from the single `get_body_raw()?`), preserving the existing `ParseError` contract.
- All 91 correctness tests + RFC corpus pass. `cargo clippy --release` clean.