### PR TITLE
Ship stable-ABI (abi3-py311) wheels — one wheel per platform, every CPython ≥ 3.11

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,11 @@ name: Publish
 # Release builds the multi-platform wheels + sdist and publishes to PyPI.
 # workflow_dispatch builds everything WITHOUT publishing — use it to validate
 # the pipeline (artifacts are uploaded) without cutting a release.
+#
+# Wheels target the CPython stable ABI (cp311-abi3, enabled via the
+# pyo3/abi3-py311 cargo feature): each platform job builds ONE wheel that
+# covers every CPython >= 3.11, including versions released after this build.
+# A new CPython minor requires no changes to this workflow.
 on:
   release:
     types: [created]
@@ -42,7 +47,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist
           sccache: "true"
           manylinux: auto
       - name: Upload wheels
@@ -73,7 +78,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist
           sccache: "true"
           manylinux: musllinux_1_2
       - name: Upload wheels
@@ -101,7 +106,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist
           sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -128,7 +133,7 @@ jobs:
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist --find-interpreter
+          args: --release --out dist
           sccache: "true"
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,13 +112,36 @@ jobs:
         run: cargo audit
 
   # ---------------------------------------------------------------------------
-  # Test matrix — the real merge gate. Runs on CPython 3.11–3.14, built with
-  # PyO3 0.29. (3.9/3.10 dropped and 3.14 added per project policy; 3.7/3.8 are
-  # EOL and unavailable on current ubuntu runners.)
+  # Build once, test everywhere — the real merge gate. A single cp311-abi3
+  # wheel is built (stable ABI, see pyo3/abi3-py311 in Cargo.toml), then that
+  # SAME wheel is installed and tested on every supported CPython (3.11–3.14).
+  # This verifies the abi3 promise instead of assuming it: what ships to PyPI
+  # is one wheel per platform, so CI must not rebuild per Python version.
   # ---------------------------------------------------------------------------
+  build-wheel:
+    name: Build abi3 wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+      - name: Build wheel
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          args: --release --out dist
+          sccache: "true"
+          manylinux: auto
+      - name: Upload wheel
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: test-wheel
+          path: dist
+
   test:
     name: Test (py${{ matrix.python-version }})
     runs-on: ubuntu-latest
+    needs: build-wheel
     strategy:
       fail-fast: false
       matrix:
@@ -129,16 +152,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-      - uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          toolchain: stable
-      # Cache the cargo registry and build artifacts so `make install` reuses
-      # compiled crates across runs instead of rebuilding from scratch (#47).
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - name: Install the package
-        run: make install
-      - name: Install test dependencies
-        run: make install-test
+          name: test-wheel
+          path: dist
+          # Same upload@v7/download@v8 pairing as publish.yml: digest checks
+          # can report a spurious mismatch even though the download succeeds.
+          digest-mismatch: warn
+      - name: Install the built wheel + test dependencies
+        run: pip install "$(ls dist/*.whl)[test]"
       - name: Test
         run: make test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Wheels now target the CPython stable ABI (`cp311-abi3`, via the
+  `pyo3/abi3-py311` feature): a single wheel per platform supports every
+  CPython ≥ 3.11, including versions released after the build. New CPython
+  minors no longer require a repo change or a new release for installability
+  (#14, #15, #101). The abi3 build benchmarked ~11% *faster* than the
+  version-specific build (min parse time, CPython 3.12, Apple Silicon), so no
+  hybrid version-specific wheels are shipped.
+- CI now builds one abi3 wheel and runs the full test matrix (CPython
+  3.11–3.14) against that same wheel — the stable-ABI contract is verified,
+  not assumed. The per-version publish matrix collapsed to one wheel per
+  platform.
+
 ## [0.4.0] - 2026-06-12
 
 ### Breaking

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,4 +38,7 @@ mailparse = "0.16.1"
 pyo3 = "0.29"
 
 [features]
-default = ["pyo3/extension-module"]
+# abi3-py311 targets the CPython stable ABI with a 3.11 baseline (matching
+# `requires-python` in pyproject.toml): one wheel per platform covers every
+# CPython >= 3.11, including versions released after this build.
+default = ["pyo3/extension-module", "pyo3/abi3-py311"]

--- a/Readme.md
+++ b/Readme.md
@@ -32,6 +32,17 @@ Use the package manager [pip](https://pypi.org/project/fast_mail_parser/) to ins
 pip install fast-mail-parser
 ```
 
+Wheels target the CPython stable ABI (`cp311-abi3`): one wheel per platform
+covers every supported CPython version, including versions released after the
+package — a new Python no longer has to wait for a new release.
+
+| Python | Support |
+| --- | --- |
+| CPython 3.11+ (including future versions) | Prebuilt wheel |
+| CPython 3.13t/3.14t (free-threaded) | Builds from source; the extension currently re-enables the GIL on import ([#101](https://github.com/namecheap/fast_mail_parser/issues/101)) |
+| CPython ≤ 3.10 | Not supported (last compatible release: 0.2.5) |
+| PyPy | Not supported |
+
 ## Usage
 
 `parse_email` accepts the raw message as `str` or `bytes` and returns a


### PR DESCRIPTION
## Summary

Implements the abi3 half of #101: wheels now target the CPython stable ABI (`cp311-abi3`), so one wheel per platform covers every CPython ≥ 3.11 — including versions that don't exist yet. This permanently ends the "new Python, no wheel" failure mode behind #14 and #15.

## Changes

- **Cargo.toml** — enable `pyo3/abi3-py311` (baseline matches `requires-python >= 3.11`).
- **publish.yml** — drop `--find-interpreter`: each platform job builds a single abi3 wheel instead of one per interpreter. Platform matrix unchanged.
- **test.yml** — build once, test everywhere: a new `build-wheel` job builds one manylinux abi3 wheel; the 3.11–3.14 test matrix installs that *same* wheel and runs the suite against it. The abi3 promise is verified, not assumed. Side effect: the test matrix no longer needs a Rust toolchain — four fewer Rust builds per PR.
- **Readme.md** — supported-versions table + free-threaded note.
- **CHANGELOG.md** — Unreleased entry.

## Benchmark decision (the >5% rule from #101)

Min parse time, CPython 3.12, Apple Silicon (M-series), two runs per configuration, `--benchmark-min-rounds=25`:

| Build | run 1 | run 2 | speedup vs mail-parser |
|---|---|---|---|
| version-specific (master) | 2.0939 ms | 2.1197 ms | 4.36x / 4.32x |
| abi3 (this PR) | 1.8786 ms | 1.8474 ms | 4.92x / 5.01x |

abi3 measured ~11% **faster**, consistently across runs. Decision: full abi3, no hybrid version-specific wheels. The `check_benchmark.py` floor (7.0x) is left unchanged: the CI benchmark job builds from source, which is now abi3 by default, and the measured direction is favorable.

## Free-threaded CPython (deferred, with reasons)

The cp313t/cp314t half of #101 is deferred:

- Free-threaded CPython does not support the stable ABI, so ft wheels are a separate version-specific build axis — orthogonal to this change.
- Running without the GIL needs an explicit PyO3 declaration (`gil_used = false`) plus a shared-state audit. Per #101 that audit must coordinate with the planned lazy-parsing work (#97), which introduces the main shared-state risk — auditing before it lands would have to be redone.
- Current behavior on 3.13t/3.14t (source build, GIL re-enabled on import) is documented in the README.

## Verification

- One locally built `cp311-abi3-macosx_11_0_arm64` wheel installed on CPython 3.11, 3.12, and 3.14: 91/91 tests pass on each (3.13 is covered by the CI matrix).
- `actionlint` and YAML parse clean on both workflows; `cargo fmt --check` clean.

Cross-refs #14 and #15 — those close when the fixed release actually reaches PyPI (blocked on the PEP 541 transfer, pypi/support#11044).