### PR TITLE
docs: add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release receives security updates.
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues.
+
+Instead, report them privately via [GitHub private vulnerability reporting](https://github.com/namecheap/fast_mail_parser/security/advisories/new).
+
+Please include as much of the following as you can:
+
+- A description of the issue and its potential impact
+- Steps to reproduce or a proof of concept
+- Affected version(s) or commit(s)
+
+You can expect an initial response within 5 business days.


### PR DESCRIPTION
Adds `SECURITY.md` directing vulnerability reports to [GitHub private vulnerability reporting](https://github.com/namecheap/fast_mail_parser/security/advisories/new), which is now enabled for this repository.

Part of configuring all items on the repository [security overview](https://github.com/namecheap/fast_mail_parser/security): Dependabot security updates, private vulnerability reporting, CodeQL default setup, and secret scanning with push protection are now enabled (Dependabot alerts were already on); this PR completes the security policy item.