### PR TITLE
fix: keep every value of a repeated header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Both shapes are common in Outlook-generated mail.
 
+- **`headers` is now `dict[str, list[str]]`.** It was `dict[str, str]`, backed by
+  a Rust `HashMap<String, String>`, so a repeated key kept only its **last**
+  value. Every earlier `Received`, `DKIM-Signature`, `Received-SPF` and so on was
+  silently discarded, which made delivery-path tracing and signature
+  verification impossible (#12, #23). Each key now maps to every value it
+  appeared with, in message order. Single-valued headers are one-element lists,
+  so callers never branch on `str`-vs-`list`:
+
+  ```python
+  mail.headers["Received"]   # ['from mx1...', 'from mx2...', 'from mx3...']
+  mail.headers["From"]       # ['sender@example.com']
+  ```
+
+  Migration: index the list — `mail.headers["From"]` becomes
+  `mail.headers["From"][0]`, or `mail.headers.get("From", [""])[0]` to keep a
+  missing-header fallback.
+
 ### Fixed
 
+- `subject` and `date` are read from the parsed headers directly instead of back
+  out of the collected header map, so they no longer inherit that map's
+  representation and always reflect the first occurrence of their field (#28).
 - `PyAttachment.filename` is read from the `Content-Disposition` `filename`
   parameter, including RFC 2231 extended values (`filename*=utf-8''...`),
   falling back to `Content-Type; name` as before. Attachments that declare a

--- a/Readme.md
+++ b/Readme.md
@@ -120,10 +120,23 @@ Legend:
 | `date` | `str` | Date header (empty string if missing). |
 | `text_plain` | `list[str]` | All `text/plain` bodies. |
 | `text_html` | `list[str]` | All `text/html` bodies. |
-| `headers` | `dict[str, str]` | All message headers. |
+| `headers` | `dict[str, list[str]]` | All values of every header, in order. |
 | `attachments` | `list[PyAttachment]` | Non-body parts (see below). |
 
 Each `PyAttachment` has `mimetype: str`, `filename: str`, and `content: bytes`.
+
+### Headers
+
+`headers` maps each header name to a **list** of every value it appeared with,
+in message order, so repeated fields survive:
+
+```python
+mail.headers["Received"]   # ['from mx1...', 'from mx2...', 'from mx3...']
+mail.headers["From"]       # ['sender@example.com'] -- always a list
+```
+
+`subject` and `date` are read from the parsed headers directly rather than out
+of this map, so they always reflect the first occurrence of their field.
 
 ### Bodies vs. attachments
 
@@ -162,9 +175,16 @@ except ParseError as e:
 print("Subject:", email.subject)
 print("Date:", email.date)
 
-# headers is a dict[str, str].
-for name, value in email.headers.items():
-    print(f"{name}: {value}")
+# headers is a dict[str, list[str]]: every occurrence of a repeated header is
+# kept, in the order it appeared. Single-valued headers are one-element lists.
+for name, values in email.headers.items():
+    for value in values:
+        print(f"{name}: {value}")
+
+# So a delivery path stays intact -- for Received, the first entry is the most
+# recent hop.
+for hop in email.headers.get("Received", []):
+    print("Received:", hop)
 
 # text_plain and text_html are lists of strings (one entry per matching part).
 for body in email.text_plain:

--- a/fast_mail_parser/__init__.pyi
+++ b/fast_mail_parser/__init__.pyi
@@ -23,6 +23,11 @@ class PyAttachment:
 class PyMail:
     """A parsed message.
 
+    ``headers`` maps each header name to **every** value it appeared with, in
+    order, so repeated keys such as ``Received`` or ``DKIM-Signature`` are
+    preserved. Single-valued headers are one-element lists:
+    ``headers["From"] == ["a@example.com"]``.
+
     Body parts and attachments are disjoint. A part is body text -- reaching
     ``text_plain`` or ``text_html`` -- when it is ``text/plain`` or ``text/html``
     and is not marked ``Content-Disposition: attachment``; every other part is an
@@ -37,7 +42,7 @@ class PyMail:
         text_html: list[str],
         date: str,
         attachments: list[PyAttachment],
-        headers: dict[str, str],
+        headers: dict[str, list[str]],
     ) -> None:
         self.subject = subject
         self.text_plain = text_plain

--- a/src/fast_mail_parser.rs
+++ b/src/fast_mail_parser.rs
@@ -53,8 +53,8 @@ impl PyAttachment {
 
 /// A parsed email message exposed to Python.
 ///
-/// Note that [`attachments`](Self::attachments) is **not** limited to file
-/// attachments: it contains every node of the message's MIME tree.
+/// Body parts and [`attachments`](Self::attachments) are disjoint; `multipart/*`
+/// container nodes appear in neither.
 #[pyclass]
 pub struct PyMail {
     #[pyo3(get)]
@@ -65,17 +65,17 @@ pub struct PyMail {
     pub text_html: Vec<String>,
     #[pyo3(get)]
     pub date: String,
-    /// Every node of the message's MIME tree, not just file attachments.
+    /// The message's non-body parts: real attachments and inline resources.
     ///
-    /// This includes the text parts (`text/plain`, `text/html`, whose decoded
-    /// bodies also appear in `text_plain`/`text_html`) and the multipart
-    /// container nodes themselves (e.g. `multipart/mixed`, `multipart/alternative`).
-    /// Container nodes carry their MIME type but have empty `content`. A part is
-    /// only a real file attachment when its `filename` is non-empty.
+    /// Per RFC 2183 a part is body text -- and so absent here -- when it is
+    /// `text/plain` or `text/html` and is not marked `Content-Disposition:
+    /// attachment`. `multipart/*` container nodes are MIME structure and are not
+    /// reported. `filename` may still be empty, which is normal for an inline
+    /// image referenced only by `Content-ID`.
     #[pyo3(get)]
     pub attachments: Vec<PyAttachment>,
     #[pyo3(get)]
-    pub headers: HashMap<String, String>,
+    pub headers: HashMap<String, Vec<String>>,
 }
 
 impl PyMail {

--- a/src/mail_parser.rs
+++ b/src/mail_parser.rs
@@ -104,8 +104,14 @@ impl<'a> Mail {
         // map above, so the dedicated fields do not inherit its representation
         // (#28). `get_first_value` is the first occurrence, which is the correct
         // choice for a header that should appear once.
-        let subject = mail.get_headers().get_first_value("Subject").unwrap_or_default();
-        let date = mail.get_headers().get_first_value("Date").unwrap_or_default();
+        let subject = mail
+            .get_headers()
+            .get_first_value("Subject")
+            .unwrap_or_default();
+        let date = mail
+            .get_headers()
+            .get_first_value("Date")
+            .unwrap_or_default();
 
         let mut attachments = vec![];
         let mut text_plain = vec![];

--- a/src/mail_parser.rs
+++ b/src/mail_parser.rs
@@ -67,7 +67,7 @@ pub(crate) struct Mail {
     pub(crate) text_html: Vec<String>,
     pub(crate) date: String,
     pub(crate) attachments: Vec<Attachment>,
-    pub(crate) headers: HashMap<String, String>,
+    pub(crate) headers: HashMap<String, Vec<String>>,
 }
 
 #[derive(Debug)]
@@ -87,15 +87,25 @@ impl<'a> Mail {
 
         let mail = parse_mail(payload)?;
 
-        let headers: HashMap<String, String> = mail
-            .get_headers()
-            .into_iter()
-            .map(|h| (h.get_key(), h.get_value()))
-            .collect();
+        // Keep every value for a repeated key, in the order the keys appear.
+        // Collapsing to one value per key kept only the last, discarding all but
+        // the final `Received`, `DKIM-Signature`, `Received-SPF`, ... -- which
+        // made delivery-path tracing and signature verification impossible
+        // (#12, #23).
+        let mut headers: HashMap<String, Vec<String>> = HashMap::new();
+        for header in mail.get_headers() {
+            headers
+                .entry(header.get_key())
+                .or_default()
+                .push(header.get_value());
+        }
 
-        let subject = headers.get("Subject").map(String::from).unwrap_or_default();
-
-        let date = headers.get("Date").map(String::from).unwrap_or_default();
+        // Read these straight from the parsed headers rather than back out of the
+        // map above, so the dedicated fields do not inherit its representation
+        // (#28). `get_first_value` is the first occurrence, which is the correct
+        // choice for a header that should appear once.
+        let subject = mail.get_headers().get_first_value("Subject").unwrap_or_default();
+        let date = mail.get_headers().get_first_value("Date").unwrap_or_default();
 
         let mut attachments = vec![];
         let mut text_plain = vec![];

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -68,8 +68,10 @@ def test__pymail_attribute_types(valid_mail: PyMail):
 
     assert isinstance(valid_mail.headers, dict)
     assert all(
-        isinstance(key, str) and isinstance(value, str)
-        for key, value in valid_mail.headers.items()
+        isinstance(key, str)
+        and isinstance(values, list)
+        and all(isinstance(value, str) for value in values)
+        for key, values in valid_mail.headers.items()
     )
 
     assert isinstance(valid_mail.attachments, list)

--- a/tests/test_correctness.py
+++ b/tests/test_correctness.py
@@ -66,8 +66,8 @@ def test__plain_text_round_trip():
     mail = parse_email(_serialize(message))
 
     assert mail.subject == "Plain round trip"
-    assert mail.headers["From"] == "alice@example.com"
-    assert mail.headers["To"] == "bob@example.com"
+    assert mail.headers["From"] == ["alice@example.com"]
+    assert mail.headers["To"] == ["bob@example.com"]
     assert len(mail.text_plain) == 1
     assert "Hello, this is the plain body." in mail.text_plain[0]
     assert mail.text_html == []
@@ -177,7 +177,7 @@ def test__single_valued_header_round_trips(key: str, value: str):
 
     mail = parse_email(_serialize(message))
 
-    assert mail.headers[key] == value
+    assert mail.headers[key] == [value]
 
 
 def test__returns_pymail_for_every_shape():

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -6,7 +6,7 @@ def test__total_number_is_valid(valid_mail: PyMail):
 
 
 def test__header_is_accessible_by_key(valid_mail: PyMail):
-    assert valid_mail.headers['Reply-To'] == 'Red Hat OpenShift <noreply@openshift.com>'
+    assert valid_mail.headers['Reply-To'] == ['Red Hat OpenShift <noreply@openshift.com>']
 
 
 def test__subject_is_available_via_property(valid_mail: PyMail):

--- a/tests/test_multivalue_headers.py
+++ b/tests/test_multivalue_headers.py
@@ -1,95 +1,103 @@
-"""Characterization tests for duplicate / multi-value headers.
+"""Tests for duplicate / multi-value headers.
 
-``PyMail.headers`` is a ``dict[str, str]`` (backed by a Rust ``HashMap<String,
-String>``). RFC 5322 allows several header fields to appear more than once
-(``Received``, ``X-*`` trace headers, ``Comments``, etc.), but a ``dict`` cannot
-hold more than one value per key. This file pins the resulting *collapse*
-behavior so consumers know what to expect and so any future change (e.g.
-switching to a multimap) is caught.
+``PyMail.headers`` is a ``dict[str, list[str]]`` (backed by a Rust
+``HashMap<String, Vec<String>>``). RFC 5322 allows several header fields to
+appear more than once (``Received``, ``X-*`` trace headers, ``Comments``, etc.),
+and every occurrence is preserved in the order it appeared in the message.
 
 What is covered elsewhere (NOT re-tested here):
 - Non-ASCII / RFC 2047 / RFC 6532 header decoding -> ``tests/test_rfc_corpus.py``.
 - Content-Disposition handling and filename sourcing -> ``tests/test_rfc_corpus.py``.
 
-This file focuses solely on the multi-value gap those suites do not cover.
-
-Characterized behavior (current contract):
-- Duplicate headers collapse to a single ``str`` value per key; the values are
-  NOT concatenated, joined, or exposed as a list.
-- Exactly one of the duplicated values is retained. The retained value is one of
-  the originals (we do not over-specify *which*, since it depends on the
-  HashMap collection order in the Rust layer); see the dedicated test for the
-  precise observed selection.
+Contract:
+- Every value is a ``list[str]``, including single-valued headers, which are
+  one-element lists.
+- Repeated keys keep every value in message order -- nothing is dropped, joined,
+  or reordered.
+- A repeated key is still a single dict entry; the multiplicity lives in the list.
 """
 
-from fast_mail_parser import parse_email
+from fast_mail_parser import PyMail, parse_email
 
 
 def _build(raw_headers: str) -> bytes:
     return (raw_headers + "\r\n\r\nbody\r\n").encode("ascii")
 
 
-def test__duplicate_custom_header_collapses_to_single_string():
+def test__duplicate_custom_header_keeps_every_value_in_order():
     raw = "Subject: dup test\r\nX-Custom: first\r\nX-Custom: second"
     mail = parse_email(_build(raw))
 
-    value = mail.headers["X-Custom"]
-    assert isinstance(value, str)
-    # Collapsed to one of the original values, never both joined together.
-    assert value in {"first", "second"}
-    assert "first" not in value or "second" not in value
+    assert mail.headers["X-Custom"] == ["first", "second"]
 
 
-def test__duplicate_received_headers_collapse_to_single_value():
+def test__duplicate_received_headers_are_all_returned_in_order():
+    # The delivery path: for Received the FIRST occurrence is the most recent
+    # hop, so order carries meaning and the earlier hops must not be discarded.
     raw = (
         "Subject: trace test\r\n"
         "Received: from a.example.com by mx1.example.com\r\n"
-        "Received: from b.example.com by mx2.example.com"
+        "Received: from b.example.com by mx2.example.com\r\n"
+        "Received: from c.example.com by mx3.example.com"
     )
     mail = parse_email(_build(raw))
 
-    received = mail.headers["Received"]
-    assert isinstance(received, str)
-    assert received in {
+    assert mail.headers["Received"] == [
         "from a.example.com by mx1.example.com",
         "from b.example.com by mx2.example.com",
-    }
+        "from c.example.com by mx3.example.com",
+    ]
 
 
-def test__three_duplicates_still_yield_one_value():
-    raw = (
-        "Subject: triple\r\n"
-        "X-Trace: one\r\n"
-        "X-Trace: two\r\n"
-        "X-Trace: three"
-    )
+def test__three_duplicates_yield_three_values():
+    raw = "Subject: triple\r\nX-Trace: one\r\nX-Trace: two\r\nX-Trace: three"
     mail = parse_email(_build(raw))
 
-    assert mail.headers["X-Trace"] in {"one", "two", "three"}
+    assert mail.headers["X-Trace"] == ["one", "two", "three"]
 
 
-def test__headers_dict_has_one_entry_per_key_despite_duplicates():
-    # The dict cannot represent multiplicity: duplicated keys do not inflate
-    # the entry count. Both X-Dup lines map to a single dict entry.
+def test__single_valued_header_is_a_one_element_list():
+    # Uniform shape: callers never have to branch on str-vs-list.
+    raw = "Subject: single\r\nX-Only: solo"
+    mail = parse_email(_build(raw))
+
+    assert mail.headers["X-Only"] == ["solo"]
+    assert mail.headers["Subject"] == ["single"]
+
+
+def test__duplicate_keys_do_not_inflate_the_entry_count():
+    # Multiplicity lives in the list, not in extra dict entries.
     raw = "Subject: count\r\nX-Dup: a\r\nX-Dup: b\r\nX-Unique: u"
     mail = parse_email(_build(raw))
 
-    assert "X-Dup" in mail.headers
-    assert "X-Unique" in mail.headers
-    # Only the keys we set plus Subject; no per-occurrence duplication.
-    assert mail.headers["X-Unique"] == "u"
+    assert set(mail.headers) == {"Subject", "X-Dup", "X-Unique"}
+    assert mail.headers["X-Dup"] == ["a", "b"]
+    assert mail.headers["X-Unique"] == ["u"]
 
 
-def test__retained_duplicate_value_is_one_of_the_originals():
-    # Document the observed selection precisely. parse_email feeds headers into a
-    # Rust HashMap via `.collect()`, so the last-inserted value for a key wins;
-    # in practice that surfaces as the LAST occurrence in the message. We assert
-    # the value is one of the originals (the firm guarantee) and additionally
-    # record the observed last-wins behavior so a regression is visible.
-    raw = "Subject: order\r\nX-Order: alpha\r\nX-Order: omega"
+def test__every_value_is_a_list_of_str():
+    raw = "Subject: types\r\nX-A: 1\r\nX-A: 2\r\nX-B: 3"
     mail = parse_email(_build(raw))
 
-    value = mail.headers["X-Order"]
-    assert value in {"alpha", "omega"}
-    # Observed behavior: the last occurrence is retained.
-    assert value == "omega"
+    for key, values in mail.headers.items():
+        assert isinstance(key, str)
+        assert isinstance(values, list)
+        assert values, f"{key}: a present header must have at least one value"
+        assert all(isinstance(v, str) for v in values)
+
+
+def test__repeated_header_in_real_fixture_is_preserved(attachment_mail: PyMail):
+    # tests/data/attachment_message.eml carries two Received-SPF lines.
+    assert attachment_mail.headers["Received-SPF"] == ["custom_header1", "custom_header2"]
+
+
+def test__subject_and_date_are_independent_of_the_headers_map():
+    # subject/date are read from the parsed headers directly, so a duplicated
+    # Subject cannot make them disagree with the first occurrence.
+    raw = "Subject: the real one\r\nSubject: a later duplicate\r\nDate: Mon, 01 Jan 2024 12:00:00 +0000"
+    mail = parse_email(_build(raw))
+
+    assert mail.subject == "the real one"
+    assert mail.date == "Mon, 01 Jan 2024 12:00:00 +0000"
+    # The map still reports both occurrences.
+    assert mail.headers["Subject"] == ["the real one", "a later duplicate"]

--- a/tests/test_multivalue_headers.py
+++ b/tests/test_multivalue_headers.py
@@ -94,7 +94,11 @@ def test__repeated_header_in_real_fixture_is_preserved(attachment_mail: PyMail):
 def test__subject_and_date_are_independent_of_the_headers_map():
     # subject/date are read from the parsed headers directly, so a duplicated
     # Subject cannot make them disagree with the first occurrence.
-    raw = "Subject: the real one\r\nSubject: a later duplicate\r\nDate: Mon, 01 Jan 2024 12:00:00 +0000"
+    raw = (
+        "Subject: the real one\r\n"
+        "Subject: a later duplicate\r\n"
+        "Date: Mon, 01 Jan 2024 12:00:00 +0000"
+    )
     mail = parse_email(_build(raw))
 
     assert mail.subject == "the real one"


### PR DESCRIPTION
Closes #12, closes #23, closes #28 (audit refs M2-T2, M3-T2).

## The bug

Headers were collected into `HashMap<String, String>` via `.collect()`, so a repeated key kept only its **last** value. Every earlier `Received`, `DKIM-Signature`, `Received-SPF` was silently discarded — and `Received` is repeated in essentially all real mail, so this hit the common case.

#12 reported it in 2024 with a side-by-side against the stdlib: three `Received` hops in, one out. Delivery-path tracing and DKIM verification were simply not possible.

## The fix

`headers` is now `HashMap<String, Vec<String>>`, surfaced as `dict[str, list[str]]` — every value, in message order:

```python
mail.headers["Received"]   # ['from mx1...', 'from mx2...', 'from mx3...']
mail.headers["From"]       # ['sender@example.com'] -- always a list
```

Single-valued headers are one-element lists, so callers never branch on `str`-vs-`list`.

`subject` and `date` were re-read out of that collapsed map and inherited its collision behavior. They now come from `get_first_value` on the parsed headers directly (#28), so a duplicated `Subject` can't make them disagree with the first occurrence.

## A conflict worth flagging

**#12 and #23 asked for opposite things.** #12 requested an *additive* field explicitly "not to break compatibility"; #23 specifies changing `headers` itself and marks it breaking with a minor bump.

I took **#23**, per the maintainer decision on this: leaving `headers` last-value-wins would keep the reported bug as the **default** path, with correct data available only if you knew to look at a second field. The migration is one index:

```diff
- mail.headers["From"]
+ mail.headers["From"][0]
```

`mail.headers.get("From", [""])[0]` preserves a missing-header fallback. The changelog states this.

Folded into the **unreleased 0.7.0** rather than a second breaking bump, so consumers get one breaking release rather than two in a day.

## About the tests

`test_multivalue_headers.py` was a characterization suite that pinned the collapse as the contract — including `test__retained_duplicate_value_is_one_of_the_originals`, which asserted the *last* occurrence wins. Rewritten to assert values are all present and correctly ordered.

New coverage:
- #23's specified case: the two `Received-SPF` lines in the `attachment_message.eml` fixture.
- Three-hop `Received` ordering, since for `Received` the first entry is the most recent hop and order carries meaning.
- A duplicated `Subject` that must not affect `mail.subject` (#28).
- Uniform shape: every value is a non-empty `list[str]`.

## Acceptance

#23:
- [x] `mail.headers["Received"]` returns all values in order
- [x] `.pyi` declares `headers: dict[str, list[str]]`
- [x] Duplicate-header test using the `attachment_message.eml` fixture's two `Received-SPF`

#28:
- [x] `subject`/`date` independent of the headers-map representation

## Drive-by

Two doc comments in the PyO3 layer still described the pre-#122 attachment semantics ("every node of the message's MIME tree"). I missed them in that PR; corrected here.