### PR TITLE
feat: expose content_id and disposition on attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `mail.headers["From"][0]`, or `mail.headers.get("From", [""])[0]` to keep a
   missing-header fallback.
 
+### Added
+
+- `PyAttachment.content_id` — the part's `Content-ID` with angle brackets
+  stripped, or `None`. RFC 2392 `cid:` URLs reference that bracket-less form, so
+  resolving the inline images an HTML body points at is now a dictionary lookup.
+  It was previously impossible: the value was parsed and discarded at the FFI
+  boundary (#98).
+- `PyAttachment.disposition` — the raw `Content-Disposition` token, typically
+  `"inline"` or `"attachment"`, or `None` when the part declares no such header.
+  An absent header is reported distinctly from an explicit `inline`, which
+  mailparse's parsed value alone cannot express since it defaults to `Inline`
+  (#98).
+
 ### Fixed
 
 - `subject` and `date` are read from the parsed headers directly instead of back

--- a/Readme.md
+++ b/Readme.md
@@ -123,7 +123,15 @@ Legend:
 | `headers` | `dict[str, list[str]]` | All values of every header, in order. |
 | `attachments` | `list[PyAttachment]` | Non-body parts (see below). |
 
-Each `PyAttachment` has `mimetype: str`, `filename: str`, and `content: bytes`.
+Each `PyAttachment` has:
+
+| Attribute | Type | Description |
+| --- | --- | --- |
+| `mimetype` | `str` | The part's media type. |
+| `filename` | `str` | See below; `""` when the part declares none. |
+| `content` | `bytes` | Decoded bytes, transfer-encoding undone. |
+| `content_id` | `str \| None` | `Content-ID` with angle brackets stripped. |
+| `disposition` | `str \| None` | Raw `Content-Disposition` token, or `None` if absent. |
 
 ### Headers
 
@@ -137,6 +145,27 @@ mail.headers["From"]       # ['sender@example.com'] -- always a list
 
 `subject` and `date` are read from the parsed headers directly rather than out
 of this map, so they always reflect the first occurrence of their field.
+
+### Resolving inline images (`cid:`)
+
+`content_id` is exposed without angle brackets, which is the form RFC 2392
+`cid:` URLs use — so resolving the images an HTML body references is a lookup:
+
+```python
+import re
+
+mail = parse_email(raw)
+by_cid = {a.content_id: a for a in mail.attachments if a.content_id}
+
+for cid in re.findall(r'cid:([^"\'>\s]+)', mail.text_html[0]):
+    attachment = by_cid.get(cid)
+    if attachment:
+        print(cid, attachment.mimetype, len(attachment.content), "bytes")
+```
+
+`disposition` reports the part's raw `Content-Disposition` token, and
+distinguishes an absent header (`None`) from an explicit `inline` — the two are
+different statements about intent.
 
 ### Bodies vs. attachments
 

--- a/fast_mail_parser/__init__.pyi
+++ b/fast_mail_parser/__init__.pyi
@@ -12,12 +12,30 @@ class PyAttachment:
     parameter (RFC 2183, including RFC 2231 extended values), falling back to
     the ``Content-Type`` ``name`` parameter. It is ``""`` when the part declares
     neither -- common for inline images referenced only by ``Content-ID``.
+
+    ``content_id`` is the part's ``Content-ID`` with angle brackets stripped, or
+    ``None``. RFC 2392 ``cid:`` URLs in an HTML body reference this bracket-less
+    form, so resolving inline images is a lookup keyed on this value.
+
+    ``disposition`` is the raw ``Content-Disposition`` token (typically
+    ``"inline"`` or ``"attachment"``), or ``None`` when the part declares no such
+    header -- an absent header is reported distinctly from an explicit
+    ``inline``.
     """
 
-    def __init__(self, mimetype: str, content: bytes, filename: str) -> None:
+    def __init__(
+        self,
+        mimetype: str,
+        content: bytes,
+        filename: str,
+        content_id: str | None,
+        disposition: str | None,
+    ) -> None:
         self.mimetype = mimetype
         self.content = content
         self.filename = filename
+        self.content_id = content_id
+        self.disposition = disposition
 
 
 class PyMail:

--- a/src/fast_mail_parser.rs
+++ b/src/fast_mail_parser.rs
@@ -31,6 +31,19 @@ pub struct PyAttachment {
     pub content: Vec<u8>,
     #[pyo3(get)]
     pub filename: String,
+    /// The part's `Content-ID` with angle brackets stripped, or `None`.
+    ///
+    /// RFC 2392 `cid:` URLs in an HTML body reference this bracket-less form, so
+    /// resolving inline images is a lookup keyed on this value.
+    #[pyo3(get)]
+    pub content_id: Option<String>,
+    /// The part's raw `Content-Disposition` token -- typically `"inline"` or
+    /// `"attachment"` -- or `None` when the part declares no such header.
+    ///
+    /// `None` and `"inline"` are reported distinctly: an absent header is not
+    /// the same statement as an explicit `inline`.
+    #[pyo3(get)]
+    pub disposition: Option<String>,
 }
 
 #[pymethods]
@@ -47,6 +60,8 @@ impl PyAttachment {
             mimetype: attachment.mimetype,
             content: attachment.content,
             filename: attachment.filename,
+            content_id: attachment.content_id,
+            disposition: attachment.disposition,
         }
     }
 }

--- a/src/mail_parser.rs
+++ b/src/mail_parser.rs
@@ -60,6 +60,33 @@ fn part_filename(disposition: &ParsedContentDisposition, ctype: &ParsedContentTy
         .unwrap_or_default()
 }
 
+/// Strip the angle brackets from a `Content-ID` value, preserving case.
+///
+/// RFC 2392 `cid:` URLs reference the bracket-less form, so normalizing here is
+/// what turns `cid:` resolution into a plain lookup for callers.
+fn normalize_content_id(raw: &str) -> String {
+    raw.trim()
+        .trim_start_matches('<')
+        .trim_end_matches('>')
+        .to_string()
+}
+
+/// The part's raw `Content-Disposition` token, or `None` when it declares none.
+///
+/// mailparse defaults the parsed disposition to `Inline` when the header is
+/// absent, which is indistinguishable from an explicit
+/// `Content-Disposition: inline`, so presence is confirmed against the raw
+/// headers before reporting a token.
+fn disposition_token(part: &ParsedMail<'_>, kind: &DispositionType) -> Option<String> {
+    part.get_headers().get_first_value("Content-Disposition")?;
+    Some(match kind {
+        DispositionType::Inline => "inline".to_owned(),
+        DispositionType::Attachment => "attachment".to_owned(),
+        DispositionType::FormData => "form-data".to_owned(),
+        DispositionType::Extension(other) => other.clone(),
+    })
+}
+
 #[derive(Debug)]
 pub(crate) struct Mail {
     pub(crate) subject: String,
@@ -75,6 +102,8 @@ pub(crate) struct Attachment {
     pub(crate) mimetype: String,
     pub(crate) content: Vec<u8>,
     pub(crate) filename: String,
+    pub(crate) content_id: Option<String>,
+    pub(crate) disposition: Option<String>,
 }
 
 impl<'a> Mail {
@@ -150,10 +179,17 @@ impl<'a> Mail {
             let content = part.get_body_raw()?;
 
             if !is_body {
+                let content_id = part
+                    .get_headers()
+                    .get_first_value("Content-ID")
+                    .map(|raw| normalize_content_id(&raw));
+
                 attachments.push(Attachment {
                     mimetype: mime.to_string(),
                     content,
                     filename,
+                    content_id,
+                    disposition: disposition_token(&part, &disposition.disposition),
                 });
             } else if mime == "text/html" {
                 // For text parts, build the Python-facing string from the bytes

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -1,4 +1,4 @@
-from fast_mail_parser import PyMail
+from fast_mail_parser import PyMail, parse_email
 
 
 def test__attachments_are_available(attachment_mail: PyMail):
@@ -34,3 +34,39 @@ def test__expected_attachments_are_present(large_mail: PyMail):
     attachments = [a for a in large_mail.attachments if a.filename in expected_attachment_names]
 
     assert len(attachments) == 2
+
+
+def test__content_id_is_none_when_absent(attachment_mail: PyMail):
+    # The fixture's PNG declares a disposition but no Content-ID.
+    attachment = attachment_mail.attachments[0]
+
+    assert attachment.content_id is None
+    assert attachment.disposition == "inline"
+
+
+def test__disposition_is_none_when_the_header_is_absent():
+    # An absent Content-Disposition is reported distinctly from an explicit
+    # `inline` -- mailparse defaults its parsed disposition to Inline, so the two
+    # would otherwise be indistinguishable.
+    raw = (
+        b"Subject: no disposition\r\n"
+        b"MIME-Version: 1.0\r\n"
+        b'Content-Type: multipart/mixed; boundary="b1"\r\n'
+        b"\r\n"
+        b"--b1\r\n"
+        b"Content-Type: text/plain\r\n"
+        b"\r\n"
+        b"body\r\n"
+        b"--b1\r\n"
+        b"Content-Type: image/png\r\n"
+        b"Content-Transfer-Encoding: base64\r\n"
+        b"\r\n"
+        b"UE5HIGhlcmU=\r\n"
+        b"--b1--\r\n"
+    )
+    mail = parse_email(raw)
+
+    png = next(a for a in mail.attachments if a.mimetype == "image/png")
+    assert png.disposition is None
+    assert png.content_id is None
+    assert png.content == b"PNG here"

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -26,7 +26,13 @@ EXPECTED_MAIL_ATTRS = {
     "attachments",
     "headers",
 }
-EXPECTED_ATTACHMENT_ATTRS = {"mimetype", "content", "filename"}
+EXPECTED_ATTACHMENT_ATTRS = {
+    "mimetype",
+    "content",
+    "filename",
+    "content_id",
+    "disposition",
+}
 
 # First line starts with whitespace, so it is an overhanging continuation with
 # no preceding header key — mailparse rejects this, surfacing as ParseError.

--- a/tests/test_rfc_corpus.py
+++ b/tests/test_rfc_corpus.py
@@ -21,6 +21,7 @@ Behaviors intentionally locked here (current contract):
 
 import glob
 import os
+import re
 
 import pytest
 
@@ -217,3 +218,43 @@ def test__text_attachment_by_disposition_is_not_body():
     attachment = next(a for a in mail.attachments if a.filename == "log.txt")
     assert attachment.mimetype == "text/plain"
     assert b"log line one" in attachment.content
+
+
+# --- Content-ID / inline resolution ----------------------------------------
+
+
+def test__content_id_is_normalized_without_angle_brackets():
+    # The fixture declares `Content-ID: <img1>`; RFC 2392 cid: URLs reference the
+    # bracket-less form, so that is what is exposed.
+    mail = _load("multipart_related")
+    png = next(a for a in mail.attachments if a.mimetype == "image/png")
+
+    assert png.content_id == "img1"
+
+
+def test__disposition_reports_the_raw_token():
+    mail = _load("multipart_related")
+    png = next(a for a in mail.attachments if a.mimetype == "image/png")
+    assert png.disposition == "inline"
+
+    # add_attachment marks parts `attachment`.
+    mail = _load("multipart_mixed_attachment")
+    png = next(a for a in mail.attachments if a.mimetype == "image/png")
+    assert png.disposition == "attachment"
+
+
+def test__cid_references_in_html_resolve_to_attachments():
+    # The canonical HTML-mail task, end to end: map every cid: URL in the body
+    # to the attachment that carries it.
+    mail = _load("multipart_related")
+
+    by_cid = {a.content_id: a for a in mail.attachments if a.content_id}
+    referenced = re.findall(r'cid:([^"\'>\s]+)', mail.text_html[0])
+
+    assert referenced, "fixture must reference at least one cid:"
+    for cid in referenced:
+        assert cid in by_cid, f"unresolved cid reference: {cid}"
+        assert by_cid[cid].content, f"cid {cid} resolved to an empty part"
+
+    assert referenced == ["img1"]
+    assert by_cid["img1"].content[:8] == b"\x89PNG\r\n\x1a\n"


### PR DESCRIPTION
Part **3 of #98** (typed API additions). Purely additive — no existing attribute changes. #98 stays open for parts 1 and 2.

## Why

`mailparse` parses both values and the binding layer discarded them, which made the canonical HTML-mail task impossible: an inline image referenced as `cid:img1` could not be matched to the part carrying it.

## What

| Attribute | Type | Behavior |
| --- | --- | --- |
| `content_id` | `str \| None` | `Content-ID` with angle brackets stripped (`<img1>` → `img1`) |
| `disposition` | `str \| None` | Raw `Content-Disposition` token, `None` when the header is absent |

```python
by_cid = {a.content_id: a for a in mail.attachments if a.content_id}
for cid in re.findall(r'cid:([^"\'>\s]+)', mail.text_html[0]):
    attachment = by_cid.get(cid)
```

Two details worth calling out:

- **`content_id` is normalized deliberately.** RFC 2392 `cid:` URLs reference the bracket-less form, so stripping here is what turns resolution into a lookup instead of string surgery in every consumer.
- **`disposition` distinguishes absent from `inline`.** mailparse defaults its parsed disposition to `Inline`, so an absent header is otherwise indistinguishable from an explicit `Content-Disposition: inline` — different statements about intent. Presence is confirmed against the raw headers before reporting a token.

Only attachments carry these, matching the API sketched in #98.

## Sequencing

#98 noted it was "sequenced with #22/#23/#25/#28" and builds on whatever those land. All four closed earlier today, so this rebases onto the corrected disposition semantics from #122 — `disposition` reuses the value that classifier already parses, rather than re-reading the header.

## Tests

- Normalization on `multipart_related` (`Content-ID: <img1>` → `"img1"`).
- Both `None` cases: no `Content-ID`, and no `Content-Disposition` header at all.
- Both raw tokens: `inline` (from `add_related`) and `attachment` (from `add_attachment`).
- **End-to-end**: every `cid:` reference in the fixture's HTML body resolves to an attachment with real bytes, PNG magic intact. I verified the extraction regex against the actual fixture rather than assuming it matched.

`EXPECTED_ATTACHMENT_ATTRS` in the contract suite deliberately freezes the attribute set, so it moves for any addition — updated.

## Acceptance (#98, part 3 only)

- [x] `content_id` normalized (brackets stripped, case preserved) and `None` when absent
- [x] A fixture HTML mail's `cid:` references resolve to the right attachments end-to-end
- [x] `disposition` reflects the part's Content-Disposition token, coordinated with #25's landed semantics
- [x] All existing attributes unchanged (pure addition; full corpus still green)
- [x] Stubs updated; README table + `cid:` usage example; CHANGELOG entry

Not this PR: `PyAddress` (part 1) and `date_parsed` (part 2). The latter needs a new pyo3 feature/dependency for datetime conversion, so it belongs in its own change.