### PR TITLE
feat: typed address fields (from_/to/cc/bcc/reply_to)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Typed address fields on `PyMail`:** `from_` (a `PyAddress` or `None`) plus
+  `to`, `cc`, `bcc` and `reply_to` (lists of `PyAddress`), each with
+  `display_name: str | None` and `address: str`. `mailparse` already parsed these
+  and the binding layer discarded them, leaving every consumer to dig through
+  `headers` and hand-roll RFC 5322 address parsing — display names, quoted
+  strings containing commas, groups, comments — which is the classic thing to get
+  wrong in a one-off regex (#98).
+
+  RFC 5322 groups are flattened to their member mailboxes. An address header that
+  does not parse yields an empty list (or `None`) rather than raising, so a
+  malformed `To:` cannot fail an otherwise good message; the raw value stays in
+  `headers`. Parsing goes through `addrparse_header` rather than the string form,
+  so an RFC 2047 display name that decodes to something containing a comma or
+  angle bracket cannot corrupt the address split.
 - `PyAttachment.content_id` — the part's `Content-ID` with angle brackets
   stripped, or `None`. RFC 2392 `cid:` URLs reference that bracket-less form, so
   resolving the inline images an HTML body points at is now a dictionary lookup.

--- a/Readme.md
+++ b/Readme.md
@@ -118,6 +118,8 @@ Legend:
 | --- | --- | --- |
 | `subject` | `str` | Subject header (empty string if missing). |
 | `date` | `str` | Date header (empty string if missing). |
+| `from_` | `PyAddress \| None` | The `From` mailbox. Named `from_`; `from` is a keyword. |
+| `to` / `cc` / `bcc` / `reply_to` | `list[PyAddress]` | Recipients, groups flattened. |
 | `text_plain` | `list[str]` | All `text/plain` bodies. |
 | `text_html` | `list[str]` | All `text/html` bodies. |
 | `headers` | `dict[str, list[str]]` | All values of every header, in order. |
@@ -132,6 +134,26 @@ Each `PyAttachment` has:
 | `content` | `bytes` | Decoded bytes, transfer-encoding undone. |
 | `content_id` | `str \| None` | `Content-ID` with angle brackets stripped. |
 | `disposition` | `str \| None` | Raw `Content-Disposition` token, or `None` if absent. |
+
+### Addresses
+
+Address headers are parsed rather than handed back as strings — RFC 5322 address
+syntax (display names, quoted strings containing commas, groups, comments) is
+exactly what hand-rolled regexes get wrong:
+
+```python
+mail.from_.display_name   # 'Jane Doe'  (None for a bare address)
+mail.from_.address        # 'jane@example.com'
+
+[a.address for a in mail.to]   # ['a@example.com', 'b@example.com']
+```
+
+- RFC 5322 groups (`To: team: a@x, b@x;`) are **flattened** to their member
+  mailboxes; the group name is structure and is not exposed.
+- RFC 2047 encoded display names are decoded, including inside quoted names.
+- A header that does not parse yields an empty list (or `None` for `from_`)
+  rather than raising — a malformed `To:` never fails an otherwise good message,
+  and the raw value stays in `headers`.
 
 ### Headers
 

--- a/fast_mail_parser/__init__.py
+++ b/fast_mail_parser/__init__.py
@@ -1,8 +1,15 @@
-from .fast_mail_parser import ParseError, PyAttachment, PyMail, parse_email
+from .fast_mail_parser import (
+    ParseError,
+    PyAddress,
+    PyAttachment,
+    PyMail,
+    parse_email,
+)
 
 __all__ = [
     "parse_email",
     "ParseError",
     "PyMail",
     "PyAttachment",
+    "PyAddress",
 ]

--- a/fast_mail_parser/__init__.pyi
+++ b/fast_mail_parser/__init__.pyi
@@ -2,8 +2,22 @@ __all__ = [
     "parse_email",
     "PyMail",
     "PyAttachment",
+    "PyAddress",
     "ParseError",
 ]
+
+
+class PyAddress:
+    """One mailbox from an address header.
+
+    ``display_name`` is ``None`` when the header carries a bare address. RFC 2047
+    encoded-words are decoded, so a non-ASCII name arrives readable.
+    ``address`` is the ``addr-spec`` -- ``local@domain``, without angle brackets.
+    """
+
+    def __init__(self, display_name: str | None, address: str) -> None:
+        self.display_name = display_name
+        self.address = address
 
 class PyAttachment:
     """A non-body MIME part: a real attachment or an inline resource.
@@ -41,6 +55,13 @@ class PyAttachment:
 class PyMail:
     """A parsed message.
 
+    Address headers are parsed into ``PyAddress`` values, taken from the first
+    occurrence of each header. RFC 5322 groups (``To: team: a@x, b@x;``) are
+    flattened to their members. An address header that does not parse yields an
+    empty list (or ``None`` for ``from_``) rather than raising -- a malformed
+    ``To:`` must not fail an otherwise good message, and the raw value stays
+    available through ``headers``.
+
     ``headers`` maps each header name to **every** value it appeared with, in
     order, so repeated keys such as ``Received`` or ``DKIM-Signature`` are
     preserved. Single-valued headers are one-element lists:
@@ -59,6 +80,11 @@ class PyMail:
         text_plain: list[str],
         text_html: list[str],
         date: str,
+        from_: PyAddress | None,
+        to: list[PyAddress],
+        cc: list[PyAddress],
+        bcc: list[PyAddress],
+        reply_to: list[PyAddress],
         attachments: list[PyAttachment],
         headers: dict[str, list[str]],
     ) -> None:
@@ -66,6 +92,11 @@ class PyMail:
         self.text_plain = text_plain
         self.text_html = text_html
         self.date = date
+        self.from_ = from_
+        self.to = to
+        self.cc = cc
+        self.bcc = bcc
+        self.reply_to = reply_to
         self.attachments = attachments
         self.headers = headers
 

--- a/src/fast_mail_parser.rs
+++ b/src/fast_mail_parser.rs
@@ -23,6 +23,29 @@ use std::collections::HashMap;
 
 create_exception!(fast_mail_parser, ParseError, exceptions::PyException);
 
+/// One mailbox from an address header, exposed to Python.
+#[pyclass(skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyAddress {
+    /// The display name, or `None` when the header carries a bare address.
+    ///
+    /// RFC 2047 encoded-words are decoded, so a non-ASCII name arrives readable.
+    #[pyo3(get)]
+    pub display_name: Option<String>,
+    /// The `addr-spec` -- the `local@domain` part, without angle brackets.
+    #[pyo3(get)]
+    pub address: String,
+}
+
+impl PyAddress {
+    pub(crate) fn from_address(address: mail_parser::Address) -> Self {
+        PyAddress {
+            display_name: address.display_name,
+            address: address.address,
+        }
+    }
+}
+
 #[pyclass(skip_from_py_object)]
 #[derive(Clone)]
 pub struct PyAttachment {
@@ -80,6 +103,23 @@ pub struct PyMail {
     pub text_html: Vec<String>,
     #[pyo3(get)]
     pub date: String,
+    /// The `From` mailbox, or `None` when the header is absent or unparseable.
+    ///
+    /// Named `from_` because `from` is a Python keyword.
+    #[pyo3(get)]
+    pub from_: Option<PyAddress>,
+    /// `To` recipients. RFC 5322 groups are flattened to their members.
+    #[pyo3(get)]
+    pub to: Vec<PyAddress>,
+    /// `Cc` recipients, flattened as `to` is.
+    #[pyo3(get)]
+    pub cc: Vec<PyAddress>,
+    /// `Bcc` recipients, flattened as `to` is. Usually empty on received mail.
+    #[pyo3(get)]
+    pub bcc: Vec<PyAddress>,
+    /// `Reply-To` mailboxes, flattened as `to` is.
+    #[pyo3(get)]
+    pub reply_to: Vec<PyAddress>,
     /// The message's non-body parts: real attachments and inline resources.
     ///
     /// Per RFC 2183 a part is body text -- and so absent here -- when it is
@@ -100,6 +140,15 @@ impl PyMail {
             text_plain: mail.text_plain,
             text_html: mail.text_html,
             date: mail.date,
+            from_: mail.from_.map(PyAddress::from_address),
+            to: mail.to.into_iter().map(PyAddress::from_address).collect(),
+            cc: mail.cc.into_iter().map(PyAddress::from_address).collect(),
+            bcc: mail.bcc.into_iter().map(PyAddress::from_address).collect(),
+            reply_to: mail
+                .reply_to
+                .into_iter()
+                .map(PyAddress::from_address)
+                .collect(),
             attachments: mail
                 .attachments
                 .into_iter()
@@ -162,6 +211,7 @@ fn fast_mail_parser(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(parse_email, m)?)?;
     m.add_class::<PyMail>()?;
     m.add_class::<PyAttachment>()?;
+    m.add_class::<PyAddress>()?;
     m.add("ParseError", py.get_type::<ParseError>())?;
 
     Ok(())

--- a/src/mail_parser.rs
+++ b/src/mail_parser.rs
@@ -87,12 +87,66 @@ fn disposition_token(part: &ParsedMail<'_>, kind: &DispositionType) -> Option<St
     })
 }
 
+/// One mailbox from an address header.
+#[derive(Debug, Clone)]
+pub(crate) struct Address {
+    pub(crate) display_name: Option<String>,
+    pub(crate) address: String,
+}
+
+impl Address {
+    fn from_single(info: &SingleInfo) -> Self {
+        Self {
+            display_name: info.display_name.clone(),
+            address: info.addr.clone(),
+        }
+    }
+}
+
+/// Parse one address header into a flat list of mailboxes.
+///
+/// RFC 5322 groups (`To: team: a@x, b@x;`) are flattened to their members: the
+/// group name is structure, and callers want the mailboxes.
+///
+/// Takes the header rather than its value so `addrparse_header` can tokenize
+/// RFC 2047 encoded-words separately from the address syntax. Parsing an
+/// already-decoded string would let a decoded display name containing `,` or
+/// `<` corrupt the address split.
+///
+/// A header that fails to parse yields an empty list rather than an error --
+/// mailparse rejects an address with no `@`, and a malformed `To:` must not fail
+/// an otherwise good message. The raw value stays available through `headers`.
+fn parse_addresses(header: Option<&MailHeader<'_>>) -> Vec<Address> {
+    let Some(header) = header else {
+        return Vec::new();
+    };
+    let Ok(parsed) = addrparse_header(header) else {
+        return Vec::new();
+    };
+
+    let mut addresses = Vec::new();
+    for entry in parsed.iter() {
+        match entry {
+            MailAddr::Single(info) => addresses.push(Address::from_single(info)),
+            MailAddr::Group(group) => {
+                addresses.extend(group.addrs.iter().map(Address::from_single));
+            }
+        }
+    }
+    addresses
+}
+
 #[derive(Debug)]
 pub(crate) struct Mail {
     pub(crate) subject: String,
     pub(crate) text_plain: Vec<String>,
     pub(crate) text_html: Vec<String>,
     pub(crate) date: String,
+    pub(crate) from_: Option<Address>,
+    pub(crate) to: Vec<Address>,
+    pub(crate) cc: Vec<Address>,
+    pub(crate) bcc: Vec<Address>,
+    pub(crate) reply_to: Vec<Address>,
     pub(crate) attachments: Vec<Attachment>,
     pub(crate) headers: HashMap<String, Vec<String>>,
 }
@@ -141,6 +195,17 @@ impl<'a> Mail {
             .get_headers()
             .get_first_value("Date")
             .unwrap_or_default();
+
+        // Address headers are parsed from their first occurrence, like Subject
+        // and Date. `From` is a single mailbox in practice, so it is exposed as
+        // one value; the first mailbox is taken if a message declares several.
+        let from_ = parse_addresses(mail.get_headers().get_first_header("From"))
+            .into_iter()
+            .next();
+        let to = parse_addresses(mail.get_headers().get_first_header("To"));
+        let cc = parse_addresses(mail.get_headers().get_first_header("Cc"));
+        let bcc = parse_addresses(mail.get_headers().get_first_header("Bcc"));
+        let reply_to = parse_addresses(mail.get_headers().get_first_header("Reply-To"));
 
         let mut attachments = vec![];
         let mut text_plain = vec![];
@@ -210,6 +275,11 @@ impl<'a> Mail {
             text_plain,
             text_html,
             date,
+            from_,
+            to,
+            cc,
+            bcc,
+            reply_to,
             attachments,
             headers,
         })

--- a/tests/test_addresses.py
+++ b/tests/test_addresses.py
@@ -1,0 +1,122 @@
+"""Tests for the typed address fields (from_/to/cc/bcc/reply_to).
+
+Each is a list of ``PyAddress`` (``from_`` is a single value or ``None``) parsed
+from the first occurrence of its header.
+
+Contract:
+- RFC 5322 groups are flattened to their member mailboxes; the group name is
+  structure and is not exposed.
+- RFC 2047 encoded-words in display names are decoded, including inside a quoted
+  name.
+- A display name is ``None`` when the header carries a bare address.
+- An address header that does not parse yields an empty list (or ``None`` for
+  ``from_``) rather than raising. mailparse rejects an address with no ``@``, so
+  that is the malformed case exercised here. The raw value stays in ``headers``.
+"""
+
+import pytest
+
+from fast_mail_parser import PyMail, parse_email
+
+
+def _parse(header_line: str) -> PyMail:
+    raw = f"Subject: addresses\r\n{header_line}\r\n\r\nbody\r\n"
+    return parse_email(raw.encode("utf-8"))
+
+
+# header value -> expected [(display_name, address), ...] for `To`
+CASES = {
+    "bare address": (
+        "a@example.com",
+        [(None, "a@example.com")],
+    ),
+    "display name": (
+        "foo bar <foo@bar.com>",
+        [("foo bar", "foo@bar.com")],
+    ),
+    "quoted display name containing a comma": (
+        '"Doe, Jane" <jane@example.com>',
+        [("Doe, Jane", "jane@example.com")],
+    ),
+    "multiple recipients, mixed forms": (
+        "foo <ba@r.com>, jo@e.com, baz <qu@ux.com>",
+        [("foo", "ba@r.com"), (None, "jo@e.com"), ("baz", "qu@ux.com")],
+    ),
+    "group is flattened to its members": (
+        "bar-group: foo <foo@bar.com>, baz@bar.com;",
+        [("foo", "foo@bar.com"), (None, "baz@bar.com")],
+    ),
+    "single alongside a group": (
+        "joe@bloe.com, bar-group: foo <foo@bar.com>;",
+        [(None, "joe@bloe.com"), ("foo", "foo@bar.com")],
+    ),
+    "empty group yields nothing": (
+        "empty-group:;",
+        [],
+    ),
+    "rfc 2047 encoded display name": (
+        "=?UTF-8?B?0JjQvNGPLCDQpNCw0LzQuNC70LjRjw==?= <foobar@example.com>",
+        [("Имя, Фамилия", "foobar@example.com")],
+    ),
+    "rfc 2047 inside a quoted display name": (
+        '"=?utf-8?q?G=C3=B6tz?= C" <g@c.de>',
+        [("Götz C", "g@c.de")],
+    ),
+    "malformed address without @ yields nothing": (
+        "not-an-address",
+        [],
+    ),
+}
+
+
+@pytest.mark.parametrize("name", list(CASES), ids=list(CASES))
+def test__to_header_parses_to_expected_mailboxes(name: str):
+    value, expected = CASES[name]
+    mail = _parse(f"To: {value}")
+
+    assert [(a.display_name, a.address) for a in mail.to] == expected
+
+
+def test__malformed_header_still_available_raw():
+    # Never an exception for a bad To: in an otherwise good mail -- and the raw
+    # value is not lost, just unparsed.
+    mail = _parse("To: not-an-address")
+
+    assert mail.to == []
+    assert mail.headers["To"] == ["not-an-address"]
+    assert mail.subject == "addresses"  # the rest of the message parsed fine
+
+
+def test__from_is_a_single_address():
+    mail = _parse("From: Jane Doe <jane@example.com>")
+
+    assert mail.from_ is not None
+    assert mail.from_.display_name == "Jane Doe"
+    assert mail.from_.address == "jane@example.com"
+
+
+def test__from_is_none_when_absent_or_unparseable():
+    assert _parse("Subject: x").from_ is None
+    assert _parse("From: nonsense").from_ is None
+
+
+def test__cc_bcc_and_reply_to_are_parsed():
+    mail = _parse(
+        "Cc: c@example.com\r\n"
+        "Bcc: Blind <b@example.com>\r\n"
+        "Reply-To: reply-group: r1@example.com, r2@example.com;"
+    )
+
+    assert [a.address for a in mail.cc] == ["c@example.com"]
+    assert [(a.display_name, a.address) for a in mail.bcc] == [("Blind", "b@example.com")]
+    assert [a.address for a in mail.reply_to] == ["r1@example.com", "r2@example.com"]
+
+
+def test__absent_address_headers_are_empty_lists():
+    mail = _parse("Subject: nothing else")
+
+    assert mail.to == []
+    assert mail.cc == []
+    assert mail.bcc == []
+    assert mail.reply_to == []
+    assert mail.from_ is None

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -17,12 +17,17 @@ import pytest
 import fast_mail_parser
 from fast_mail_parser import ParseError, PyAttachment, PyMail, parse_email
 
-EXPECTED_EXPORTS = {"parse_email", "ParseError", "PyMail", "PyAttachment"}
+EXPECTED_EXPORTS = {"parse_email", "ParseError", "PyMail", "PyAttachment", "PyAddress"}
 EXPECTED_MAIL_ATTRS = {
     "subject",
     "text_plain",
     "text_html",
     "date",
+    "from_",
+    "to",
+    "cc",
+    "bcc",
+    "reply_to",
     "attachments",
     "headers",
 }


### PR DESCRIPTION
Part **1 of #98**. Additive only. #98 stays open for part 2 (`date_parsed`).

## Why

`mailparse` parsed these already and the binding layer discarded them, so consumers had to dig the raw value out of `headers` and hand-roll RFC 5322 address parsing — display names, quoted strings containing commas, groups, comments. That's the classic one-off-regex trap.

```python
mail.from_.display_name        # 'Jane Doe'   (None for a bare address)
mail.from_.address             # 'jane@example.com'
[a.address for a in mail.to]   # ['a@example.com', 'b@example.com']
```

`PyAddress` is `display_name: str | None` + `address: str`. `from_` carries the trailing underscore because `from` is a Python keyword.

## The API choice that matters

Parsing goes through **`addrparse_header`, not `addrparse`**. The string form wraps its input in a single opaque `HeaderToken::Text`; the header form runs `normalized_tokens`, so RFC 2047 encoded-words are tokenized separately from the address syntax.

That distinction is load-bearing, and the test corpus proves it. One case uses an encoded display name that decodes to **`Имя, Фамилия`** — a name containing a comma. Parse the already-decoded string and it splits into two bogus mailboxes; parse the header and it stays one. I only found this because mailparse's own encoded-word tests all use the header form, which was the hint worth chasing.

## Behavior

- **Groups are flattened** to their member mailboxes (`To: team: a@x, b@x;` → two addresses). The group name is structure; callers want the addresses.
- **Never raises.** A header that doesn't parse yields an empty list, or `None` for `from_`. A malformed `To:` cannot fail an otherwise good message, and the raw value stays in `headers`. "Malformed" concretely means *no `@`* — that's what mailparse actually rejects (`addrparse("foo <bar>").is_err()`).
- Parsed from the **first occurrence** of each header, consistent with `subject`/`date`.

## Tests

Table-driven per the issue's acceptance list. Every expectation is **grounded in mailparse's own unit tests** rather than assumed — I read its test suite to confirm each shape before asserting it:

bare address · display name · quoted name containing a comma · mixed multi-recipient · group flattening · single alongside group · empty group · encoded-word name · encoded-word inside a quoted name · malformed (no `@`) · absent headers

Plus: the malformed value is still retrievable from `headers` and the rest of the message parses fine.

## Acceptance (#98, part 1)

- [x] Fixtures covering plain, display-name, quoted display-name with commas, multiple recipients, groups, RFC 2047-encoded display names, malformed → empty-list-plus-raw (table-driven)
- [x] Stubs updated; `PyAddress` registered on the module and re-exported from `__init__.py` (without which it is not importable)
- [x] README table + usage section; CHANGELOG entry
- [x] All existing attributes unchanged

`EXPECTED_MAIL_ATTRS` and `EXPECTED_EXPORTS` deliberately freeze the public surface, so both move for an addition.

Not this PR: `date_parsed` needs a new pyo3 feature for datetime conversion — its own change.