### PR TITLE
docs: add a migration guide with CI-executed snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A migration guide, `docs/migrating.md`** — covering the 0.6.x -> 0.7.0
+  breaking changes and the move from the stdlib `email` module, plus an honest
+  list of what this library deliberately does not do (building or mutating
+  messages, `Message` compatibility, header mutation). Every Python snippet in it
+  is extracted and executed against the built wheel by
+  `tests/test_docs_snippets.py`, in document order in one shared namespace, so a
+  snippet that drifts from the API fails CI rather than misleading a reader
+  (part of #103).
 - **Typed address fields on `PyMail`:** `from_` (a `PyAddress` or `None`) plus
   `to`, `cc`, `bcc` and `reply_to` (lists of `PyAddress`), each with
   `display_name: str | None` and `address: str`. `mailparse` already parsed these

--- a/Readme.md
+++ b/Readme.md
@@ -54,6 +54,10 @@ print(email.text_plain[0])
 That is the whole surface for the common case. See [Usage](#usage) for the full
 API, and [Python support](#python-support) for wheel coverage.
 
+Coming from the stdlib `email` module, or upgrading from 0.6.x? See the
+[migration guide](https://github.com/namecheap/fast_mail_parser/blob/master/docs/migrating.md) — its snippets are
+executed in CI, so they cannot go stale.
+
 ## Why the name changed
 
 The `fast-mail-parser` name on PyPI belongs to a PyPI account this project no

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -1,0 +1,177 @@
+# Migrating to fast_mail_parser
+
+Two audiences: people **upgrading from 0.6.x**, where two breaking changes
+landed in 0.7.0, and people **coming from the stdlib `email` module**.
+
+Every Python block below is executed by `tests/test_docs_snippets.py` against the
+built wheel, in document order and in one shared namespace. A snippet that stops
+working fails CI, so nothing here can rot.
+
+## Setup
+
+```python
+from fast_mail_parser import ParseError, parse_email
+
+raw = (
+    b"From: Jane Doe <jane@example.com>\r\n"
+    b"To: ops@example.com, \"Doe, John\" <john@example.com>\r\n"
+    b"Subject: Quarterly report\r\n"
+    b"Date: Mon, 01 Jan 2024 12:00:00 +0000\r\n"
+    b"Received: from mx1.example.com by mx2.example.com\r\n"
+    b"Received: from relay.example.com by mx1.example.com\r\n"
+    b"MIME-Version: 1.0\r\n"
+    b'Content-Type: multipart/mixed; boundary="b1"\r\n'
+    b"\r\n"
+    b"--b1\r\n"
+    b"Content-Type: text/plain; charset=utf-8\r\n"
+    b"\r\n"
+    b"The report is attached.\r\n"
+    b"--b1\r\n"
+    b"Content-Type: text/plain; charset=utf-8\r\n"
+    b'Content-Disposition: attachment; filename="notes.txt"\r\n'
+    b"\r\n"
+    b"attached notes\r\n"
+    b"--b1--\r\n"
+)
+
+mail = parse_email(raw)
+```
+
+`parse_email` accepts `bytes` or `str`. Prefer `bytes`: reading a `.eml` in text
+mode can mangle a message whose body is raw UTF-8 under 8BITMIME.
+
+## Upgrading from 0.6.x
+
+### `headers` is now `dict[str, list[str]]`
+
+Previously a repeated header kept only its **last** value, so every earlier
+`Received`, `DKIM-Signature` and `Received-SPF` was silently discarded. Each key
+now maps to every value it appeared with, in order.
+
+```python
+# 0.7.0 — all hops, in message order
+assert mail.headers["Received"] == [
+    "from mx1.example.com by mx2.example.com",
+    "from relay.example.com by mx1.example.com",
+]
+
+# Single-valued headers are one-element lists, so you never branch on the type.
+assert mail.headers["Subject"] == ["Quarterly report"]
+```
+
+To migrate, index the list:
+
+```python
+# before:  subject = mail.headers["Subject"]
+# after:
+subject = mail.headers["Subject"][0]
+
+# ...or, tolerating a missing header:
+sender = mail.headers.get("From", [""])[0]
+```
+
+`subject` and `date` are unaffected — they are read from the parsed headers
+directly, not out of this map.
+
+### `attachments` no longer contains body parts or MIME containers
+
+Previously every node of the MIME tree was reported, so a one-image message
+returned four "attachments": the image, both text bodies, and the
+`multipart/mixed` container. Bodies and attachments are now disjoint.
+
+```python
+# One real attachment, not four nodes.
+assert len(mail.attachments) == 1
+assert mail.attachments[0].filename == "notes.txt"
+
+# The body is in text_plain, and the attachment's text is NOT mixed into it.
+assert "The report is attached." in mail.text_plain[0]
+assert not any("attached notes" in part for part in mail.text_plain)
+```
+
+Classification follows RFC 2183: a part is body text when it is `text/plain` or
+`text/html` **and** is not marked `Content-Disposition: attachment`. If you
+previously filtered containers out by hand, delete that code.
+
+```python
+# before: [a for a in mail.attachments if a.filename] or similar hand-filtering
+# after:
+attachments = mail.attachments
+```
+
+## Coming from the stdlib `email` module
+
+| Task | stdlib `email` | fast_mail_parser |
+| --- | --- | --- |
+| Parse | `email.message_from_bytes(raw, policy=policy.default)` | `parse_email(raw)` |
+| Subject | `msg["Subject"]` | `mail.subject` |
+| One header | `msg["X"]` | `mail.headers["X"][0]` |
+| All values of a header | `msg.get_all("Received")` | `mail.headers["Received"]` |
+| Sender | `msg["From"]` (a string) | `mail.from_` (parsed) |
+| Recipients | `msg["To"]` (a string) | `mail.to` (parsed list) |
+| Plain body | `msg.get_body(("plain",)).get_content()` | `mail.text_plain[0]` |
+| Attachments | `msg.iter_attachments()` | `mail.attachments` |
+| Failure mode | varies; often silent | raises `ParseError` |
+
+### Addresses are parsed, not handed back as strings
+
+The stdlib gives you the raw header and leaves RFC 5322 syntax to you. Note the
+second recipient below: a quoted display name containing a comma, which naive
+splitting on `,` gets wrong.
+
+```python
+assert mail.from_ is not None
+assert mail.from_.display_name == "Jane Doe"
+assert mail.from_.address == "jane@example.com"
+
+assert [(a.display_name, a.address) for a in mail.to] == [
+    (None, "ops@example.com"),
+    ("Doe, John", "john@example.com"),
+]
+```
+
+RFC 5322 groups (`To: team: a@x, b@x;`) are flattened to their members. A header
+that does not parse yields an empty list — or `None` for `from_` — rather than
+raising, and the raw value stays in `headers`.
+
+### Resolving inline images
+
+```python
+import re
+
+by_cid = {a.content_id: a for a in mail.attachments if a.content_id}
+for html in mail.text_html:
+    for cid in re.findall(r'cid:([^"\'>\s]+)', html):
+        attachment = by_cid.get(cid)
+```
+
+`content_id` is exposed without angle brackets, which is the form RFC 2392
+`cid:` URLs use.
+
+### Errors
+
+```python
+handled = False
+try:
+    parse_email(b" unexpected continuation\r\n\r\nbody")
+except ParseError:
+    handled = True
+assert handled
+```
+
+A malformed transfer encoding also raises `ParseError` rather than silently
+yielding an empty body.
+
+## What this library does not do
+
+The stdlib is a full email *library*; this is a fast **parser**. Not provided:
+
+- **Building or mutating messages.** There is no `set_content`, no serialization.
+  Use `email.message.EmailMessage` to construct mail.
+- **A `Message`-compatible object.** The API is deliberately its own shape; there
+  is no drop-in adapter.
+- **Header mutation.** `headers` is a plain dict snapshot; changing it changes
+  nothing.
+- **`date` as a `datetime`.** `date` is the raw header string; parsing it is on
+  the caller for now (tracked in issue #98).
+- **Python ≤ 3.10 or PyPy.** CPython 3.11+ only.

--- a/tests/test_docs_snippets.py
+++ b/tests/test_docs_snippets.py
@@ -1,0 +1,52 @@
+"""Executes the Python snippets in docs/migrating.md against the built wheel.
+
+A migration guide whose snippets have drifted from the API is worse than no
+guide, so the document is the test: every ```python block is extracted and
+executed in document order in one shared namespace, exactly as a reader
+following the guide top-to-bottom would.
+
+The snippets carry their own assertions about the behaviour being explained, so
+this covers both "the code still runs" and "the claims are still true".
+"""
+
+import pathlib
+import re
+
+import pytest
+
+GUIDE = pathlib.Path(__file__).resolve().parent.parent / "docs" / "migrating.md"
+
+
+def _python_blocks(text: str) -> list[str]:
+    return re.findall(r"```python\n(.*?)```", text, re.S)
+
+
+def test__guide_exists_and_has_snippets():
+    assert GUIDE.is_file(), f"missing {GUIDE}"
+    blocks = _python_blocks(GUIDE.read_text(encoding="utf-8"))
+    assert len(blocks) >= 5, f"expected several snippets, found {len(blocks)}"
+
+
+def test__every_snippet_runs_in_document_order():
+    # One shared namespace: later snippets build on `mail` from the setup block,
+    # which is how the guide reads.
+    namespace: dict[str, object] = {}
+    for index, source in enumerate(_python_blocks(GUIDE.read_text(encoding="utf-8"))):
+        try:
+            exec(compile(source, f"docs/migrating.md[block {index}]", "exec"), namespace)
+        except Exception as exc:
+            pytest.fail(
+                f"snippet {index} in docs/migrating.md failed: "
+                f"{type(exc).__name__}: {exc}\n---\n{source}"
+            )
+
+    # The setup block must have produced the objects the guide talks about.
+    assert "mail" in namespace
+
+
+def test__guide_does_not_document_removed_apis():
+    # Guards against the guide describing the pre-0.7.0 shapes it exists to
+    # migrate people away from.
+    text = GUIDE.read_text(encoding="utf-8")
+    for stale in ("dict[str, str]", "multipart/mixed container is reported"):
+        assert stale not in text, f"guide still references removed behaviour: {stale}"


### PR DESCRIPTION
Part of **#103** (item 2, the migration guide). Documentation only — no API change.

## Why now

0.7.0 carries two breaking changes. Shipping them without an upgrade path makes every consumer rediscover both by trial, which is exactly the "migrating is a research project" problem #103 describes.

The guide covers:

- **0.6.x → 0.7.0**: `headers` becoming `dict[str, list[str]]` (and the one-index migration), and `attachments` no longer containing body parts or MIME containers — including "if you filtered containers out by hand, delete that code".
- **stdlib `email` → this library**: a task-by-task table, plus why parsed addresses matter (the example recipient is `"Doe, John" <john@example.com>` — a quoted display name containing a comma, which naive `,`-splitting gets wrong).
- **`cid:` resolution** and error handling.
- **What this library does not do**: building or mutating messages, `Message` compatibility, header mutation, `date` as a `datetime`, Python ≤ 3.10 / PyPy. A parser is not a mail library and the guide says so.

## The document is the test

#103 asks for runnable snippets on the grounds that snippets which rot are worse than none. So rather than trusting them, `tests/test_docs_snippets.py` extracts every ` ```python ` block and executes it **in document order in one shared namespace** — the way a reader following top-to-bottom would — against the wheel CI just built.

The snippets carry their own `assert`s about the behaviour being explained, so this verifies the *claims* are still true, not merely that the code parses. If someone renames `from_` or reverts `headers`, this fails.

A third test guards the guide against describing the pre-0.7.0 shapes it exists to migrate people away from.

## Scope

Deliberately just the guide. The rest of #103 stays open:

- the differential parity suite against stdlib,
- `docs/compatibility.md` divergence table,
- the expanded benchmark table + `make bench-table`.

A differential suite needs iteration against real output to classify each divergence as bug / intentional / gray-zone. That is not something to land blind, and guessing the classifications would defeat the point of the suite.