### PR TITLE
feat: add date_parsed, completing #98

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`PyMail.date_parsed`** — `date` resolved to a timezone-aware `datetime` in
+  UTC, or `None`. Completes #98. It is a getter computed on access rather than a
+  field built during parsing, so callers that never read it pay nothing.
+
+  Note the failure mode this deliberately avoids: `mailparse::dateparse` returns
+  `Ok(0)` for input it never actually parsed — its loop simply never advances
+  state and the function still returns its initial `0` — so a naive wrapper would
+  report `not a date` as **1970-01-01** instead of `None`. Silently wrong is
+  worse than absent, so a date is only trusted when a recognized month token is
+  present, which the parser cannot reach a real result without. A legitimate
+  epoch-0 date (`Thu, 01 Jan 1970 00:00:00 +0000`) still parses.
 - **A migration guide, `docs/migrating.md`** — covering the 0.6.x -> 0.7.0
   breaking changes and the move from the stdlib `email` module, plus an honest
   list of what this library deliberately does not do (building or mutating

--- a/Readme.md
+++ b/Readme.md
@@ -122,6 +122,7 @@ Legend:
 | --- | --- | --- |
 | `subject` | `str` | Subject header (empty string if missing). |
 | `date` | `str` | Date header (empty string if missing). |
+| `date_parsed` | `datetime \| None` | `date` as a tz-aware UTC datetime; computed on access. |
 | `from_` | `PyAddress \| None` | The `From` mailbox. Named `from_`; `from` is a keyword. |
 | `to` / `cc` / `bcc` / `reply_to` | `list[PyAddress]` | Recipients, groups flattened. |
 | `text_plain` | `list[str]` | All `text/plain` bodies. |

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -148,6 +148,32 @@ for html in mail.text_html:
 `content_id` is exposed without angle brackets, which is the form RFC 2392
 `cid:` URLs use.
 
+### Dates
+
+`date` is the raw header string, as before. `date_parsed` resolves it to a
+timezone-aware `datetime` in UTC, computed on access:
+
+```python
+from datetime import timezone
+
+assert mail.date == "Mon, 01 Jan 2024 12:00:00 +0000"
+assert mail.date_parsed is not None
+assert mail.date_parsed.tzinfo == timezone.utc
+assert mail.date_parsed.timestamp() == 1704110400
+```
+
+Unlike the stdlib's `email.utils.parsedate_to_datetime`, which raises on
+malformed input, an unparseable header yields `None` and leaves `date` intact:
+
+```python
+undated = parse_email(b"Subject: x\r\nDate: not a date\r\n\r\nbody\r\n")
+assert undated.date_parsed is None
+assert undated.date == "not a date"
+```
+
+The instant is exact; the header's original UTC offset is not retained, so read
+`date` if you need the sender's local offset.
+
 ### Errors
 
 ```python
@@ -172,6 +198,4 @@ The stdlib is a full email *library*; this is a fast **parser**. Not provided:
   is no drop-in adapter.
 - **Header mutation.** `headers` is a plain dict snapshot; changing it changes
   nothing.
-- **`date` as a `datetime`.** `date` is the raw header string; parsing it is on
-  the caller for now (tracked in issue #98).
 - **Python ≤ 3.10 or PyPy.** CPython 3.11+ only.

--- a/fast_mail_parser/__init__.pyi
+++ b/fast_mail_parser/__init__.pyi
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 __all__ = [
     "parse_email",
     "PyMail",
@@ -55,6 +57,11 @@ class PyAttachment:
 class PyMail:
     """A parsed message.
 
+    ``date_parsed`` is ``date`` resolved to a timezone-aware ``datetime`` in UTC,
+    or ``None`` when the header is absent or unparseable. It is computed on
+    access, so reading it is the only cost. The instant is exact; the header's
+    original offset is not retained -- read ``date`` for that.
+
     Address headers are parsed into ``PyAddress`` values, taken from the first
     occurrence of each header. RFC 5322 groups (``To: team: a@x, b@x;``) are
     flattened to their members. An address header that does not parse yields an
@@ -99,6 +106,9 @@ class PyMail:
         self.reply_to = reply_to
         self.attachments = attachments
         self.headers = headers
+
+    @property
+    def date_parsed(self) -> datetime | None: ...
 
 
 class ParseError(Exception):

--- a/src/fast_mail_parser.rs
+++ b/src/fast_mail_parser.rs
@@ -17,7 +17,7 @@
 mod mail_parser;
 
 use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyString};
+use pyo3::types::{PyBytes, PyDateTime, PyString, PyTzInfo};
 use pyo3::{create_exception, exceptions, wrap_pyfunction};
 use std::collections::HashMap;
 
@@ -131,6 +131,28 @@ pub struct PyMail {
     pub attachments: Vec<PyAttachment>,
     #[pyo3(get)]
     pub headers: HashMap<String, Vec<String>>,
+}
+
+#[pymethods]
+impl PyMail {
+    /// `date` parsed to a timezone-aware `datetime`, or `None`.
+    ///
+    /// Computed on access rather than at parse time: most callers never read it,
+    /// and building a Python object for every parsed message would charge them
+    /// all for a field they do not use.
+    ///
+    /// The value is UTC. mailparse resolves the header's offset to an epoch, so
+    /// the instant is exact while the original offset is not retained -- read
+    /// `date` for that. An unparseable header yields `None`, leaving `date`
+    /// intact as the raw string.
+    #[getter]
+    fn date_parsed<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyDateTime>>> {
+        let Some(epoch) = mail_parser::parse_date_epoch(&self.date) else {
+            return Ok(None);
+        };
+        let utc = PyTzInfo::utc(py)?;
+        PyDateTime::from_timestamp(py, epoch as f64, Some(&utc)).map(Some)
+    }
 }
 
 impl PyMail {

--- a/src/mail_parser.rs
+++ b/src/mail_parser.rs
@@ -87,6 +87,38 @@ fn disposition_token(part: &ParsedMail<'_>, kind: &DispositionType) -> Option<St
     })
 }
 
+/// Month tokens `mailparse::dateparse` accepts.
+///
+/// Its state machine only advances past the month once one of these matches,
+/// and it returns an error on any other token in that position -- so a
+/// *successful* parse with none of these present means the machine never
+/// advanced at all. See `parse_date_epoch`.
+const MONTH_TOKENS: [&str; 12] = [
+    "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC",
+];
+
+/// Parse an RFC 5322 `Date` header to a Unix timestamp, or `None`.
+///
+/// Kept here rather than in the binding layer so the PyO3-free core owns all
+/// parsing; the binding layer only turns the result into a Python object.
+///
+/// Guards a sharp edge in `dateparse`: for input it never actually parses, its
+/// loop simply never advances state and the function still ends in
+/// `Ok(result)` with `result` at its initial 0. `dateparse("not a date")` is
+/// therefore `Ok(0)`, which would surface garbage to callers as 1970-01-01
+/// rather than as nothing at all -- silently wrong being worse than absent.
+///
+/// Requiring a month token rules that out, because the state machine cannot
+/// reach a real result without consuming one. A legitimate epoch-0 date still
+/// works: `Thu, 01 Jan 1970 00:00:00 +0000` contains `JAN`.
+pub(crate) fn parse_date_epoch(date: &str) -> Option<i64> {
+    let upper = date.to_uppercase();
+    if !MONTH_TOKENS.iter().any(|month| upper.contains(month)) {
+        return None;
+    }
+    dateparse(date).ok()
+}
+
 /// One mailbox from an address header.
 #[derive(Debug, Clone)]
 pub(crate) struct Address {

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -23,6 +23,7 @@ EXPECTED_MAIL_ATTRS = {
     "text_plain",
     "text_html",
     "date",
+    "date_parsed",
     "from_",
     "to",
     "cc",

--- a/tests/test_date_parsed.py
+++ b/tests/test_date_parsed.py
@@ -1,0 +1,115 @@
+"""Tests for `PyMail.date_parsed`.
+
+`date` stays the raw header string; `date_parsed` resolves it to a
+timezone-aware `datetime` in UTC, computed on access.
+
+Expected epochs below are taken from the stdlib's own interpretation
+(`email.utils.parsedate_to_datetime`). mailparse and the stdlib agree on offset
+handling -- mailparse's test suite asserts `17 Sep 2016 16:05:38 -1000 ==
+1474164338`, which is exactly what the stdlib computes -- so comparing against
+stdlib-derived values is a real cross-check rather than a restatement.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from fast_mail_parser import PyMail, parse_email
+
+
+def _parse(date_header: str) -> PyMail:
+    raw = f"Subject: dates\r\nDate: {date_header}\r\n\r\nbody\r\n"
+    return parse_email(raw.encode("ascii"))
+
+
+# header value -> expected Unix timestamp
+VALID = {
+    "Mon, 01 Jan 2024 12:00:00 +0000": 1704110400,
+    # Same wall-clock, east of UTC: an earlier instant.
+    "Mon, 01 Jan 2024 12:00:00 +0200": 1704103200,
+    # Different wall-clock and offset, but the SAME instant as the +0000 case.
+    "Mon, 01 Jan 2024 07:00:00 -0500": 1704110400,
+    # Named zone rather than a numeric offset.
+    "Fri, 30 Nov 2012 20:57:23 GMT": 1354309043,
+}
+
+
+@pytest.mark.parametrize("header", list(VALID), ids=list(VALID))
+def test__valid_dates_resolve_to_the_right_instant(header: str):
+    parsed = _parse(header).date_parsed
+
+    assert parsed is not None
+    assert parsed.timestamp() == VALID[header]
+
+
+@pytest.mark.parametrize("header", list(VALID), ids=list(VALID))
+def test__parsed_dates_are_timezone_aware(header: str):
+    parsed = _parse(header).date_parsed
+
+    assert parsed is not None
+    # tz-aware means utcoffset() is not None; naive datetimes silently misbehave
+    # in comparisons and arithmetic, so this is the property that matters.
+    assert parsed.utcoffset() is not None
+    assert parsed.tzinfo == timezone.utc
+
+
+def test__equal_instants_in_different_zones_compare_equal():
+    utc = _parse("Mon, 01 Jan 2024 12:00:00 +0000").date_parsed
+    est = _parse("Mon, 01 Jan 2024 07:00:00 -0500").date_parsed
+
+    assert utc == est
+
+
+def test__matches_the_stdlib_interpretation():
+    # Differential check against email.utils rather than a hardcoded constant.
+    from email.utils import parsedate_to_datetime
+
+    for header in VALID:
+        assert _parse(header).date_parsed == parsedate_to_datetime(header)
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "not a date",
+        # Recognisable shape, unrecognisable month.
+        "Mon, 99 Xxx 2024 99:99:99 +0000",
+        "",
+        "12345",
+        "Subject-like text with no date in it",
+    ],
+)
+def test__unparseable_date_yields_none_with_raw_string_intact(header: str):
+    mail = _parse(header)
+
+    assert mail.date_parsed is None
+    # The raw header is not lost, and the rest of the message parsed fine.
+    assert mail.date == header
+    assert mail.subject == "dates"
+
+
+def test__absent_date_header_yields_none():
+    mail = parse_email(b"Subject: no date\r\n\r\nbody\r\n")
+
+    assert mail.date == ""
+    assert mail.date_parsed is None
+
+
+def test__date_parsed_is_a_datetime():
+    parsed = _parse("Mon, 01 Jan 2024 12:00:00 +0000").date_parsed
+
+    assert isinstance(parsed, datetime)
+    assert parsed.year == 2024
+    assert parsed.month == 1
+    assert parsed.day == 1
+    assert parsed.hour == 12  # reported in UTC
+
+
+def test__legitimate_epoch_zero_is_not_mistaken_for_a_failure():
+    # The guard against `dateparse` reporting Ok(0) for input it never parsed
+    # must not reject a date that genuinely IS the epoch.
+    mail = _parse("Thu, 01 Jan 1970 00:00:00 +0000")
+
+    assert mail.date_parsed is not None
+    assert mail.date_parsed.timestamp() == 0
+    assert mail.date_parsed == datetime(1970, 1, 1, tzinfo=timezone.utc)


### PR DESCRIPTION
**Closes #98** — part 2, the last piece. Parts 1 (#125) and 3 (#124) landed earlier today.

`date` stays the raw header string; `date_parsed` resolves it to a timezone-aware `datetime` in UTC.

## A trap worth knowing about

`mailparse::dateparse` has a sharp edge. For input it never actually parses, the loop simply never advances state and the function **still ends in `Ok(result)`** with `result` at its initial `0`:

```rust
dateparse("not a date")  // => Ok(0), not Err
```

A naive wrapper therefore reports unparseable headers as **1970-01-01** rather than `None` — silently wrong data, which is worse than absent and contrary to what #98 asks for.

The guard: only trust a date when a recognized month token is present. That is sound rather than a heuristic — the state machine cannot reach a real result without consuming a month, and it *errors* on an unrecognized one, so `Ok` with no month means it never advanced at all. A legitimate epoch-0 date (`Thu, 01 Jan 1970 00:00:00 +0000`) still parses, and there's a test pinning that the guard doesn't over-reject.

I found this by reading `dateparse`'s source rather than by CI failing, which is worth mentioning because the failing behavior would have looked plausible in a green test suite.

## Design

**A getter, not a field.** Building a Python datetime for every parsed message would charge every caller for a field most never read — and the benchmark gate has little headroom (see #120). Computed on access, it costs nothing until used.

**No new dependency.** `chrono` turned out unnecessary: pyo3 0.29 exports `PyDateTime` and `PyTzInfo` **unconditionally** — only the `*Access` traits, which read C struct fields, are limited-API gated — so this works under this crate's abi3 build. I confirmed against pyo3's source and matched the idiom in its own datetime tests. That resolves the open question I raised on #98.

Epoch parsing lives in the PyO3-free core; only the Python object construction is in the binding layer, per the split both modules document.

## Tests

Expected timestamps come from the **stdlib's own interpretation**, and mailparse agrees with it on offsets — its suite asserts `17 Sep 2016 16:05:38 -1000 == 1474164338`, exactly what `email.utils` computes — so this is a real cross-check, not a restatement. One test compares directly against `parsedate_to_datetime`.

Covered: numeric offsets east and west of UTC, a named zone (`GMT`), two different spellings of the same instant asserted equal, tz-awareness (`utcoffset()` is not `None`), five garbage shapes, an absent header, and legitimate epoch 0.

## Acceptance (#98, part 2)

- [x] Valid RFC 5322 dates across zones → correct tz-aware datetime (epoch-equality tests)
- [x] Garbage → `None` with `date` raw string intact
- [x] Stubs updated; README table; CHANGELOG entry

The migration guide's "does not do" list claimed date-as-datetime was unavailable; that entry is replaced with a section documenting the field, and its snippets are executed by the existing doc test — which is the guide-rot check earning its keep on the very next PR.