### PR TITLE
ci: gate the benchmark on the base revision, not an absolute ratio

### DIFF
--- a/.github/scripts/check_benchmark.py
+++ b/.github/scripts/check_benchmark.py
@@ -1,77 +1,156 @@
 #!/usr/bin/env python3
 """Performance quality gate for CI.
 
-Reads a pytest-benchmark JSON report and fails the build unless
-``fast_mail_parser`` is at least ``BENCH_MIN_SPEEDUP`` times faster than the
-pure-Python ``mail-parser`` baseline.
+Reads pytest-benchmark JSON reports and fails the build on a performance
+regression. Two checks, in order of authority:
 
-The comparison uses each benchmark's *minimum* time, not the mean: on shared CI
-runners the min is the least noise-prone metric (the cleanest observed run), so
-the gate is reproducible and does not flake. Both libraries are benchmarked on
-the same runner in the same run, so the *ratio* is independent of the runner's
-absolute speed (the README reports ~8x). Getting faster always passes; only a
-regression below the configured floor fails.
+1. **Regression against the comparison base** (primary). When a base report is
+   supplied, ``fast_mail_parser`` must not be more than
+   ``BENCH_MAX_REGRESSION_PCT`` slower than the same benchmark run against the
+   base revision's build, measured **in the same job on the same runner**.
+
+2. **Absolute sanity floor** (secondary). ``fast_mail_parser`` must still be at
+   least ``BENCH_MIN_SPEEDUP`` times faster than the pure-Python
+   ``mail-parser``. This is a catastrophic-drift net, not the real gate -- see
+   below for why it cannot be tight.
+
+Why the base comparison is the primary check
+--------------------------------------------
+The absolute ratio was the gate, and it flaked. Measured on this project:
+
+- Within a single job, four consecutive runs of the same binary spread **0.3%**
+  (1.895-1.902 ms).
+- Between jobs, the same source spread **26%** (1.885-2.378 ms), while the
+  pure-Python baseline barely moved (14.2-14.5 ms).
+
+So the noise is between runner VMs, not in the measurement, and the two
+implementations do not scale together -- the Rust extension is far more
+sensitive to the runner's CPU than the interpreted baseline. An absolute floor
+therefore sits inside the between-runner noise band: tight enough to catch a
+real regression means flaking on honest changes, and loose enough not to flake
+means missing the ~26% class of regression that motivated this (see issue #120).
+
+Comparing two builds in the same job cancels that, because both measurements see
+the same CPU in the same thermal state. At 0.3% noise a few-percent threshold is
+meaningful.
+
+The comparison uses each benchmark's *minimum* time, not the mean: the min is
+the cleanest observed run and the least noise-prone metric.
 
 Usage:
-    python check_benchmark.py [benchmark.json]
+    python check_benchmark.py HEAD.json [BASE.json]
 
 Environment:
-    BENCH_MIN_SPEEDUP   Minimum required speedup ratio (default: 4.0).
+    BENCH_MAX_REGRESSION_PCT  Max tolerated slowdown vs base, percent (default: 7).
+    BENCH_MIN_SPEEDUP         Absolute sanity floor vs mail-parser (default: 5.0).
 """
 import json
 import os
 import sys
 
 
-def min_for(benchmarks, predicate, label):
+def _min_for(benchmarks, predicate, label, path):
     matches = [b for b in benchmarks if predicate(b["name"])]
     if not matches:
-        sys.exit(f"::error::benchmark for {label} not found in report")
+        sys.exit(f"::error::benchmark for {label} not found in {path}")
     if len(matches) > 1:
         names = ", ".join(b["name"] for b in matches)
-        sys.exit(f"::error::ambiguous benchmark match for {label}: {names}")
+        sys.exit(f"::error::ambiguous benchmark match for {label} in {path}: {names}")
     return matches[0]["stats"]["min"]
 
 
-def main():
-    path = sys.argv[1] if len(sys.argv) > 1 else "benchmark.json"
-    threshold = float(os.environ.get("BENCH_MIN_SPEEDUP", "4.0"))
-
+def read_report(path):
+    """Return (fast_seconds, baseline_seconds) from a pytest-benchmark report."""
     with open(path) as fh:
         benchmarks = json.load(fh)["benchmarks"]
-
-    fast = min_for(
-        benchmarks, lambda n: "fast_mail_parser" in n, "fast_mail_parser"
+    fast = _min_for(
+        benchmarks, lambda n: "fast_mail_parser" in n, "fast_mail_parser", path
     )
-    baseline = min_for(
+    baseline = _min_for(
         benchmarks,
         lambda n: "mail_parser" in n and "fast" not in n,
         "mail-parser (baseline)",
+        path,
     )
+    return fast, baseline
 
-    speedup = baseline / fast
-    fast_ms, base_ms = fast * 1e3, baseline * 1e3
 
-    summary = (
-        f"### Benchmark quality gate\n\n"
-        f"| Library | Min time | Speedup |\n"
-        f"|---|---|---|\n"
-        f"| fast_mail_parser | {fast_ms:.3f} ms | {speedup:.2f}x |\n"
-        f"| mail-parser (baseline) | {base_ms:.3f} ms | 1.00x |\n\n"
-        f"Required floor: **{threshold:.2f}x** — "
-        f"{'PASS ✅' if speedup >= threshold else 'FAIL ❌'}\n"
-    )
+def emit(summary):
     print(summary)
     step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
     if step_summary:
         with open(step_summary, "a") as fh:
             fh.write(summary)
 
-    if speedup < threshold:
-        sys.exit(
-            f"::error::performance regression: fast_mail_parser is only "
-            f"{speedup:.2f}x faster than mail-parser (floor is {threshold:.2f}x)"
+
+def main():
+    if len(sys.argv) < 2:
+        sys.exit("::error::usage: check_benchmark.py HEAD.json [BASE.json]")
+
+    head_path = sys.argv[1]
+    base_path = sys.argv[2] if len(sys.argv) > 2 else None
+
+    max_regression = float(os.environ.get("BENCH_MAX_REGRESSION_PCT", "7"))
+    floor = float(os.environ.get("BENCH_MIN_SPEEDUP", "5.0"))
+
+    head_fast, head_base = read_report(head_path)
+    head_ratio = head_base / head_fast
+
+    lines = [
+        "### Benchmark quality gate\n",
+        "| Revision | fast_mail_parser | mail-parser | Ratio |",
+        "|---|---|---|---|",
+        f"| this revision | {head_fast * 1e3:.3f} ms | {head_base * 1e3:.3f} ms "
+        f"| {head_ratio:.2f}x |",
+    ]
+
+    failures = []
+
+    if base_path:
+        base_fast, base_baseline = read_report(base_path)
+        lines.append(
+            f"| comparison base | {base_fast * 1e3:.3f} ms "
+            f"| {base_baseline * 1e3:.3f} ms | {base_baseline / base_fast:.2f}x |"
         )
+        # Positive = this revision is slower than the base.
+        delta_pct = (head_fast / base_fast - 1.0) * 100
+        verdict = "PASS ✅" if delta_pct <= max_regression else "FAIL ❌"
+        lines.append(
+            f"\n**Change vs base: {delta_pct:+.1f}%** "
+            f"(tolerated: +{max_regression:.0f}%) — {verdict}\n"
+        )
+        lines.append(
+            "_Both revisions are built and measured in this job on this runner, "
+            "so between-runner variance (~26% historically) does not enter the "
+            "comparison; within-job noise is ~0.3%._\n"
+        )
+        if delta_pct > max_regression:
+            failures.append(
+                f"performance regression: this revision is {delta_pct:+.1f}% "
+                f"slower than the base (tolerated +{max_regression:.0f}%)"
+            )
+    else:
+        lines.append(
+            "\n_No base report supplied — regression check skipped, absolute "
+            "floor only._\n"
+        )
+
+    floor_verdict = "PASS ✅" if head_ratio >= floor else "FAIL ❌"
+    lines.append(
+        f"Absolute sanity floor: **{floor:.2f}x** vs mail-parser — {floor_verdict}\n"
+    )
+    if head_ratio < floor:
+        failures.append(
+            f"absolute floor breached: only {head_ratio:.2f}x faster than "
+            f"mail-parser (floor is {floor:.2f}x)"
+        )
+
+    emit("\n".join(lines) + "\n")
+
+    for failure in failures:
+        print(f"::error::{failure}", file=sys.stderr)
+    if failures:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -173,12 +173,22 @@ jobs:
         run: make test
 
   # ---------------------------------------------------------------------------
-  # Benchmark quality gate. The benchmark used to run inside every matrix cell
-  # (6x redundant, slow). It now runs once here and acts as a performance gate:
-  # fast_mail_parser must stay at least BENCH_MIN_SPEEDUP times faster than the
-  # pure-Python mail-parser baseline (README reports ~8x). The ratio is measured
-  # on the same runner in the same run, so it is hardware-independent and stable.
-  # Getting faster always passes; only regressions below the floor fail.
+  # Benchmark quality gate. Builds BOTH this revision and the comparison base in
+  # this job and compares them, because an absolute ratio against the
+  # pure-Python baseline could not be gated reliably:
+  #
+  #   within one job, 4 runs of the same binary spread  0.3%  (1.895-1.902 ms)
+  #   between jobs,   the same source spread           26%    (1.885-2.378 ms)
+  #
+  # while mail-parser barely moved (14.2-14.5 ms). The noise is between runner
+  # VMs, and the two implementations do not scale together -- the Rust extension
+  # is far more CPU-sensitive than the interpreted baseline. So an absolute floor
+  # sat inside the noise band: tight enough to catch the ~26% regression class of
+  # #120 meant flaking on honest PRs, and loose enough not to flake meant missing
+  # it. Two builds measured on the same runner cancel that.
+  #
+  # The absolute ratio is still reported, and still gated, but only as a loose
+  # catastrophic-drift net well below the observed range.
   # ---------------------------------------------------------------------------
   benchmark:
     name: Benchmark quality gate
@@ -188,6 +198,9 @@ jobs:
     if: github.event_name != 'push'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The base revision must be checkoutable for the comparison below.
+          fetch-depth: 0
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
@@ -195,28 +208,80 @@ jobs:
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: 1.97.1
-      # Cache the cargo registry and build artifacts so `make install` reuses
-      # compiled crates across runs instead of rebuilding from scratch (#47).
+      # Cache the cargo registry and build artifacts so the two builds below
+      # reuse compiled crates instead of starting from scratch (#47).
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
-      - name: Install the package + test dependencies
+
+      - name: Resolve the comparison base
+        id: base
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          make install
-          make install-test
-      - name: Run benchmark
-        run: pytest -v tests/benchmark --benchmark-min-rounds=25 --benchmark-json=benchmark.json
+          if [ -n "$PR_BASE_SHA" ]; then
+            base="$PR_BASE_SHA"
+          else
+            # workflow_dispatch: compare against the default branch. Falling
+            # back to HEAD (which disables the comparison below) is better than
+            # failing the job if the ref is unavailable.
+            base="$(git rev-parse origin/master 2>/dev/null || git rev-parse HEAD)"
+          fi
+          echo "sha=$base" >> "$GITHUB_OUTPUT"
+          if [ "$base" = "$(git rev-parse HEAD)" ]; then
+            # Dispatching on master itself: nothing to compare against, so run
+            # the absolute check alone rather than diffing a revision with
+            # itself.
+            echo "compare=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "compare=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "comparison base: $base"
+
+      - name: Benchmark this revision
+        run: |
+          python -m venv "$RUNNER_TEMP/venv-head"
+          "$RUNNER_TEMP/venv-head/bin/pip" install -q --upgrade pip
+          "$RUNNER_TEMP/venv-head/bin/pip" install -q ".[test]"
+          "$RUNNER_TEMP/venv-head/bin/pytest" -q tests/benchmark \
+            --benchmark-min-rounds=25 --benchmark-json=head.json
+
+      - name: Benchmark the comparison base
+        if: steps.base.outputs.compare == 'true'
+        env:
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+        run: |
+          # Each revision is built and measured in its own tree and venv, so the
+          # base build cannot be shadowed by this revision's sources.
+          git worktree add "$RUNNER_TEMP/base" "$BASE_SHA"
+          python -m venv "$RUNNER_TEMP/venv-base"
+          "$RUNNER_TEMP/venv-base/bin/pip" install -q --upgrade pip
+          "$RUNNER_TEMP/venv-base/bin/pip" install -q "$RUNNER_TEMP/base[test]"
+          cd "$RUNNER_TEMP/base"
+          "$RUNNER_TEMP/venv-base/bin/pytest" -q tests/benchmark \
+            --benchmark-min-rounds=25 \
+            --benchmark-json="$GITHUB_WORKSPACE/base.json"
+
       - name: Enforce performance gate
         env:
-          # Gate on min-time ratio. The optimized parser measures ~7.8–8.7x on
-          # CI; the ratio swings with the runner's CPU (the pure-Python baseline
-          # scales differently than the Rust extension), so the README's ~8x is
-          # the typical figure, not a hard floor. Gate at 7x — below the observed
-          # range so legitimate (perf-neutral) PRs don't flake, while still
-          # catching real regressions.
-          BENCH_MIN_SPEEDUP: "7.0"
-        run: python .github/scripts/check_benchmark.py benchmark.json
-      - name: Upload benchmark report
+          # Primary gate: slowdown against the base, measured on this runner.
+          # Within-job noise is ~0.3%, so a few percent is a real signal.
+          BENCH_MAX_REGRESSION_PCT: "7"
+          # Secondary: catastrophic-drift net only. Deliberately far below the
+          # observed 6.3-7.7x range so it cannot flake; the base comparison is
+          # what actually catches regressions.
+          BENCH_MIN_SPEEDUP: "5.0"
+        run: |
+          if [ "${{ steps.base.outputs.compare }}" = "true" ]; then
+            python .github/scripts/check_benchmark.py head.json base.json
+          else
+            python .github/scripts/check_benchmark.py head.json
+          fi
+
+      - name: Upload benchmark reports
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: benchmark-json
-          path: benchmark.json
+          path: |
+            head.json
+            base.json
+          if-no-files-found: warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **CI: the benchmark gate now compares against the base revision** instead of
+  gating an absolute ratio against pure-Python `mail-parser`. Both revisions are
+  built and measured in the same job, so between-runner variance cancels.
+
+  The old gate was measurably unreliable. Four consecutive runs of the same
+  binary in one job spread **0.3%** (1.895-1.902 ms), while the same source
+  across jobs spread **26%** (1.885-2.378 ms) — and `mail-parser` barely moved
+  (14.2-14.5 ms), so the two implementations do not scale together and the ratio
+  moved with the runner's CPU. A 7.0x floor therefore sat inside the noise band:
+  it failed honest PRs, and any floor loose enough to stop flaking would also
+  have missed the ~26% regression class it existed to catch (#120).
+
+  The absolute ratio is still reported and still gated, but only as a loose
+  catastrophic-drift net (5.0x) far below the observed range. The regression
+  threshold against the base is +7%, which is ~20x the measured within-job noise.
+
+
 ## [0.7.0] - 2026-08-26
 
 ### Breaking


### PR DESCRIPTION
Addresses the flakiness documented on #120. CI only — no library change.

## The gate was failing honest PRs

It fired on #124 at 6.27x, then **passed the identical commit at 7.26x** on re-run, with the pure-Python baseline byte-stable across both. The change under test was not the cause.

## I measured it rather than guessing a new number

| Scope | fast_mail_parser | Spread |
| --- | --- | --- |
| **Within one job**, 4 runs of the same binary | 1.895 – 1.902 ms | **0.3%** |
| **Between jobs**, same source, today | 1.885 – 2.378 ms | **26%** |

`mail-parser` sat at 14.2–14.5 ms throughout.

Two conclusions:

1. **The noise is between runner VMs**, not in the measurement — so repetition, more rounds, or best-of-N cannot fix it.
2. **The two implementations don't scale together.** The Rust extension is far more CPU-sensitive than the interpreted baseline, so their *ratio* moves with the hardware. That is why an absolute floor is unfixable: tight enough to catch the ~26% regression class of #120 means sitting inside the noise band, and loose enough to stop flaking means missing that class entirely. There is no good number.

## Compare like with like

Build **both this revision and the base in the same job** and diff them. Both measurements then see the same CPU in the same thermal state, where noise is ~0.3% and a **+7%** threshold is real signal — ~20x the noise, comfortably inside the regression class worth catching.

The absolute ratio is still computed and reported, and still gated, but only as a **catastrophic-drift net at 5.0x** — far below the observed 6.3–7.7x range, so it cannot flake.

Each revision builds in its own worktree and venv, so the base build can't be shadowed by this revision's sources. Dispatching on master itself runs the absolute check alone rather than diffing a revision with itself.

## Verified locally

The gate script is pure Python, so its logic is tested against synthetic reports rather than discovered in CI — six shapes, all behaving as intended:

| Case | Expected | Result |
| --- | --- | --- |
| no regression (−0.5%) | pass | ✅ |
| +3% vs base | pass | ✅ |
| +26% vs base (the #120 class) | **fail** | ✅ |
| **the exact historical flake** (6.27x absolute, 0% vs base) | **pass** | ✅ |
| catastrophic drift (3.6x absolute) | **fail** | ✅ |
| single-argument mode | pass | ✅ |

Row 4 is the point of the change: that shape used to fail and now passes. Row 3 confirms detection is not lost in the process.

## Cost

Two Rust builds instead of one in this job. `Swatinem/rust-cache` covers the registry, and this job already ran in ~45s.

## Note on this PR's own gate run

This PR's base is master, whose `check_benchmark.py` takes one argument — but the *workflow* is taken from the PR branch, so the new two-argument invocation and the new script land together. The first real exercise of the comparison is this PR itself.