### PR TITLE
ci: point ruff at py311 to match requires-python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- CI: `ruff.toml` targeted `py39` while `requires-python` is `>= 3.11`, which
+  silently narrowed the pyupgrade rules — the lint reported "All checks passed"
+  while four findings sat waiting at the correct target. Corrected, and the
+  findings fixed (test files only; no library change).
 - **CI: the benchmark gate now compares against the base revision** instead of
   gating an absolute ratio against pure-Python `mail-parser`. Both revisions are
   built and measured in the same job, so between-runner variance cancels.

--- a/ruff.toml
+++ b/ruff.toml
@@ -2,7 +2,10 @@
 # Sensible, not-overly-strict rule set: pycodestyle errors (E), pyflakes (F),
 # import sorting (I), pyupgrade (UP), and flake8-bugbear (B).
 line-length = 100
-target-version = "py39"
+# Must track `requires-python` in pyproject.toml (>= 3.11). A stale, lower
+# value silently narrows the pyupgrade (UP) rules: at py39 this file reported
+# "All checks passed" while four UP findings were waiting at py311.
+target-version = "py311"
 
 # The Python surface is the thin fast_mail_parser/ wrapper; the Rust extension
 # is built into it. Test data/fixtures are not linted.

--- a/tests/benchmark/test_read_message.py
+++ b/tests/benchmark/test_read_message.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 
 def test__mail_parser___parse_message(large_message: str, benchmark: Callable):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
 

--- a/tests/test_date_parsed.py
+++ b/tests/test_date_parsed.py
@@ -10,7 +10,7 @@ handling -- mailparse's test suite asserts `17 Sep 2016 16:05:38 -1000 ==
 stdlib-derived values is a real cross-check rather than a restatement.
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -50,7 +50,7 @@ def test__parsed_dates_are_timezone_aware(header: str):
     # tz-aware means utcoffset() is not None; naive datetimes silently misbehave
     # in comparisons and arithmetic, so this is the property that matters.
     assert parsed.utcoffset() is not None
-    assert parsed.tzinfo == timezone.utc
+    assert parsed.tzinfo == UTC
 
 
 def test__equal_instants_in_different_zones_compare_equal():
@@ -112,4 +112,4 @@ def test__legitimate_epoch_zero_is_not_mistaken_for_a_failure():
 
     assert mail.date_parsed is not None
     assert mail.date_parsed.timestamp() == 0
-    assert mail.date_parsed == datetime(1970, 1, 1, tzinfo=timezone.utc)
+    assert mail.date_parsed == datetime(1970, 1, 1, tzinfo=UTC)


### PR DESCRIPTION
Found while sweeping for unfiled problems. Config and tests only — no library change.

## The problem

`ruff.toml` declared `target-version = "py39"` while `requires-python` is `>= 3.11`.

That value is not cosmetic: it selects which pyupgrade (`UP`) rules apply. So the stale setting **silently narrowed the lint** — `ruff check .` reported *"All checks passed"* while four findings were waiting at the correct target:

| File | Rule | Finding |
| --- | --- | --- |
| `tests/benchmark/test_read_message.py` | UP035 | `Callable` imported from `typing` |
| `tests/conftest.py` | UP035 | `Callable` imported from `typing` |
| `tests/test_date_parsed.py` (×2) | UP017 | `datetime.timezone.utc` → `datetime.UTC` |

Two of those are in files that predate today, so this had been hiding real findings rather than just being untidy — which is the argument for treating it as a bug and not a nit.

## The fix

Corrected to `py311`, findings fixed, and the config now carries a comment stating the value must track `requires-python`, so the next minimum bump doesn't quietly re-open the gap.

`datetime.UTC` is 3.11+, matching the declared minimum, and the test matrix covers 3.11–3.14.

## Verification

Run locally with ruff 0.16.4 rather than discovered in CI:

```
$ ruff check .                          # committed config
All checks passed!

$ ruff check . --target-version py311   # the honest target
Found 4 errors.

$ ruff check .                          # after this PR
All checks passed!
```

## Also noticed, not fixed here

`deny.toml` is fully configured but **cargo-deny never runs** — its own header says *"There is no cargo-deny CI job wired up yet"*. So the license allowlist and advisory policy are declared and unenforced. That's a separate change (and #102's acceptance criteria already assume `cargo deny` is green), so I've left it alone rather than bundle it.