### PR TITLE
deps: bump pinned encoding_rs 0.8.30 -> 0.8.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bumped the pinned `encoding_rs` 0.8.30 -> 0.8.35 (lockfile only; `charset`
+  already allowed it via `^0.8.22`). 0.8.30 dates from 2021 and this crate does
+  the charset decoding for every text part, i.e. it runs on untrusted input.
+  0.8.30 also declared only `license-file = "COPYRIGHT"` with no SPDX `license`
+  field, which registries and licence tooling report as non-standard; 0.8.35
+  declares `(Apache-2.0 OR MIT) AND BSD-3-Clause` properly.
 - CI: `ruff.toml` targeted `py39` while `requires-python` is `>= 3.11`, which
   silently narrowed the pyupgrade rules — the lint reported "All checks passed"
   while four findings sat waiting at the correct target. Corrected, and the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,9 +32,9 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.30"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]


### PR DESCRIPTION
Lockfile only. Found while investigating why `deny.toml` is configured but unenforced.

`charset` requires `encoding_rs = "0.8.22"` — i.e. `^0.8.22` — so 0.8.35 was always permitted. The pin was just stale, and dependabot's cargo updates don't reach a transitive lock-only entry like this.

## Why move it

**It runs on untrusted input.** encoding_rs does the charset decoding for every text part, reached from `decode_charset` on the main parse path. 0.8.30 is from 2021 — taking five years of fixes in that position is the conservative choice. `cargo audit` is green on both, so this isn't a known-CVE fix.

**Its licence metadata is malformed.** 0.8.30 declares only `license-file = "COPYRIGHT"` with no SPDX `license` field, which is why crates.io reports it as `non-standard`:

```
encoding_rs 0.8.30: non-standard
encoding_rs 0.8.34: (Apache-2.0 OR MIT) AND BSD-3-Clause
encoding_rs 0.8.35: (Apache-2.0 OR MIT) AND BSD-3-Clause
```

That blocks the supply-chain tooling this repo has configured but not yet wired up (see the note below).

## Verified before pushing

I can't run `cargo` here, so a hand-edited lockfile needed checking rather than hoping:

- **Checksum** is the sha256 of the published `.crate`: `75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3`.
- **Resolved dependency set is unchanged.** Both versions take only `cfg-if` non-optionally. The optional slots differ (`packed_simd` → `any_all_workaround`) but neither is enabled, and the lock entry lists just `cfg-if` before and after.

CI is the final check: a wrong checksum or an inconsistent lock fails the build outright.

## A nice side effect

The gate reworked in #128 makes this bump's performance effect **measurable rather than guessed** — the base comparison reports the delta on a decode-heavy workload directly. Under the old absolute-ratio gate, a real few-percent change from a decoder bump would have been indistinguishable from runner noise.

## Related finding, deliberately not in this PR

`deny.toml` is fully configured but **cargo-deny never runs** (its own header says so). Wiring it up needs two policy calls I shouldn't make unilaterally:

- `0BSD` is missing from the licence allowlist, yet **mailparse** and **quoted_printable** are both `0BSD` — so the policy as written would reject the core dependency.
- `encoding_rs` needed a clarification entry, which *this* bump removes the need for.

I checked all 22 crates in the tree against the allowlist; those were the only genuine gaps (`MIT/Apache-2.0` entries are the legacy slash form, which cargo-deny reads as `OR`). Worth a follow-up issue rather than a blind CI job that fails on merge.