### PR TITLE
ci: enforce the supply-chain policy that deny.toml already declared

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,6 +118,49 @@ jobs:
         run: cargo audit
 
   # ---------------------------------------------------------------------------
+  # Supply-chain policy. `deny.toml` had declared an advisory policy, a licence
+  # allowlist, ban rules and a source allowlist since it was added, with nothing
+  # enforcing any of them (#131) -- so the policy had drifted out of sync with
+  # the tree it was meant to govern.
+  #
+  # Like the cargo audit job, this sets RUSTUP_TOOLCHAIN=stable to override the
+  # 1.97.1 pin in rust-toolchain.toml: a supply-chain check should run current
+  # tooling regardless of which compiler the library is built with. It needs no
+  # Rust build at all, only the lockfile and the manifests.
+  #
+  # The version is pinned deliberately, and matters: 0.18.2 cannot parse the
+  # current RustSec database (it dies on RUSTSEC-2026-0066 with a TOML parse
+  # error), so an older cargo-deny fails on the advisories check no matter what
+  # this repository depends on.
+  # ---------------------------------------------------------------------------
+  supply-chain:
+    name: cargo deny
+    runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: stable
+      # Bump to upgrade cargo-deny.
+      CARGO_DENY_VERSION: "0.20.2"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: stable
+      - name: Install cargo-deny
+        run: |
+          v="$CARGO_DENY_VERSION"
+          base="https://github.com/EmbarkStudios/cargo-deny/releases/download/${v}"
+          asset="cargo-deny-${v}-x86_64-unknown-linux-musl.tar.gz"
+          curl -sSfL "$base/$asset" -o deny.tgz
+          curl -sSfL "$base/$asset.sha256" -o deny.tgz.sha256
+          # A supply-chain tool is exactly the wrong thing to install unverified.
+          echo "$(cat deny.tgz.sha256)  deny.tgz" | sha256sum -c -
+          tar xzf deny.tgz --strip-components=1 -C /usr/local/bin \
+            "cargo-deny-${v}-x86_64-unknown-linux-musl/cargo-deny"
+          cargo-deny --version
+      - name: cargo deny check
+        run: cargo deny check
+
+  # ---------------------------------------------------------------------------
   # Build once, test everywhere — the real merge gate. A single cp311-abi3
   # wheel is built (stable ABI, see pyo3/abi3-py311 in Cargo.toml), then that
   # SAME wheel is installed and tested on every supported CPython (3.11–3.14).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- CI: `cargo deny` now runs, enforcing the supply-chain policy in `deny.toml`
+  (advisories, licence allowlist, bans, source allowlist). The file had declared
+  all of it since it was added with nothing enforcing any of it, and had drifted:
+  `0BSD` was missing from the allowlist while `mailparse` -- the crate this
+  library is built on -- and its `quoted_printable` dependency are both 0BSD, so
+  the policy as written rejected the core dependency. `0BSD` is now allowed, with
+  the reasoning recorded next to it (#131).
+- The crate now declares `license = "Apache-2.0"` as an SPDX expression rather
+  than only pointing at the licence file, so tooling can classify it.
 - Bumped the pinned `encoding_rs` 0.8.30 -> 0.8.35 (lockfile only; `charset`
   already allowed it via `^0.8.22`). 0.8.30 dates from 2021 and this crate does
   the charset decoding for every text part, i.e. it runs on untrusted input.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,11 @@ rust-version = "1.83"
 version = "0.7.0"
 authors = ["Andrii Sokyrko <wartwvister@gmail.com>"]
 readme = "Readme.md"
+# Both fields: `license` is the SPDX expression tooling reads (cargo-deny warns
+# `no-license-field` without it, which is the same defect that made
+# encoding_rs 0.8.30 unclassifiable), while `license-file` is kept so the file
+# itself stays attached to the package.
+license = "Apache-2.0"
 license-file = "LICENSE"
 homepage = "https://github.com/namecheap/fast_mail_parser"
 repository = "https://github.com/namecheap/fast_mail_parser"

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,7 @@
 # cargo-deny configuration.
 #
-# Starter config for local and future-CI supply-chain checks. There is no
-# cargo-deny CI job wired up yet (out of scope); run it locally with:
+# Enforced by the "cargo deny" job in .github/workflows/test.yml. Run it locally
+# with:
 #   cargo install cargo-deny --locked
 #   cargo deny check
 #
@@ -20,6 +20,13 @@ yanked = "warn"
 [licenses]
 version = 2
 allow = [
+    # BSD Zero Clause: permissive, OSI-approved, and imposes strictly fewer
+    # obligations than MIT (no attribution requirement), so allowing it follows
+    # from allowing MIT. Required rather than aspirational: `mailparse` -- the
+    # crate this library is built on -- and its `quoted_printable` dependency
+    # are both 0BSD, so the policy rejected the core dependency until this was
+    # added.
+    "0BSD",
     "MIT",
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",


### PR DESCRIPTION
Closes #131.

`deny.toml` has declared an advisory policy, a licence allowlist, ban rules and a source allowlist since it was added — with nothing running any of it. Its own header admitted as much. An unenforced policy drifts, and this one had.

I ran cargo-deny in a throwaway CI job first rather than wiring a blocking gate and finding out on merge. Three things needed fixing, all confirmed empirically:

## 1. The policy rejected the core dependency

```
error[rejected]: failed to satisfy license requirements
  mailparse-0.16.1/Cargo.toml:37          license = "0BSD"
  quoted_printable-0.5.1/Cargo.toml:34    license = "0BSD"
```

`mailparse` is the crate this library is built on. `0BSD` was simply missing from the allowlist.

It's permissive, OSI-approved, and imposes **strictly fewer** obligations than MIT — no attribution requirement — so allowing it follows from allowing MIT, which the policy already did. This aligns the written policy with five years of shipped practice rather than expanding it. The reasoning is recorded beside the entry.

## 2. cargo-deny's version is load-bearing

My first attempt used 0.18.2, which **cannot parse the current RustSec database**:

```
failed to load advisory database: parse error:
  .../astral-tokio-tar/RUSTSEC-2026-0066.md: TOML parse error at line 5, column 8
```

It never reaches this repository's dependencies — an older binary fails the advisories check no matter what we depend on. Pinned to **0.20.2**, with that reason recorded so a future "let's not churn the pin" doesn't quietly reintroduce it.

## 3. Our own manifest was unclassifiable

```
warning[no-license-field]: license expression was not specified in manifest
  for crate 'fast_mail_parser = 0.7.0'
```

`Cargo.toml` declared only `license-file = "LICENSE"` — precisely the defect that made `encoding_rs 0.8.30` unclassifiable in #130. Slightly awkward to have criticised a dependency for it while carrying it ourselves.

Added `license = "Apache-2.0"` (matching the LICENSE file and the PyPI classifier), keeping `license-file` so the file stays attached to the package.

## Result

```
advisories ok, bans ok, licenses ok, sources ok
```

Remaining output is warnings only — `license-not-encountered` for allowlist entries kept deliberately for future dependencies.

## The gate can actually fail

This was the criterion I put on #131: *"a green check that cannot go red is worse than no check."* Both directions are verified from real runs — **without** the `0BSD` entry it produced the two errors above; **with** it, clean.

## Job design

Follows the existing `cargo audit` job's precedent in setting `RUSTUP_TOOLCHAIN=stable`, overriding the 1.97.1 pin from #119 — a supply-chain check should see current tooling whatever the library is compiled with. It needs no Rust build at all, only the lockfile and manifests, so it's cheap.

cargo-deny is installed from a pinned prebuilt release with its **published sha256 verified**, on the grounds that a supply-chain tool is the wrong thing to install unverified.