### PR TITLE
test: differential compatibility suite against the stdlib email module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A differential compatibility suite against the stdlib `email` module**
+  (`tests/test_stdlib_parity.py`) plus `docs/compatibility.md` (part of #103).
+  Both parsers run over the whole fixture corpus and are compared on nine
+  dimensions; a mismatch fails CI unless it is a declared, explained divergence,
+  and a declared divergence that stops occurring fails too — so the document
+  cannot drift from the code in either direction.
+
+  The corpus now matches the stdlib **byte for byte**, attachment payloads
+  included, on everything except five documented differences (body line endings
+  preserved rather than normalised to LF being the one most likely to bite) and
+  one case where this library is *more* correct: the stdlib surrogate-escapes raw
+  UTF-8 in address headers (RFC 6532) where this library decodes it.
 - CI: `cargo deny` now runs, enforcing the supply-chain policy in `deny.toml`
   (advisories, licence allowlist, bans, source allowlist). The file had declared
   all of it since it was added with nothing enforcing any of it, and had drifted:

--- a/Readme.md
+++ b/Readme.md
@@ -56,7 +56,9 @@ API, and [Python support](#python-support) for wheel coverage.
 
 Coming from the stdlib `email` module, or upgrading from 0.6.x? See the
 [migration guide](https://github.com/namecheap/fast_mail_parser/blob/master/docs/migrating.md) — its snippets are
-executed in CI, so they cannot go stale.
+executed in CI, so they cannot go stale — and
+[compatibility.md](https://github.com/namecheap/fast_mail_parser/blob/master/docs/compatibility.md) for every known
+difference from the stdlib, each one enforced by a test.
 
 ## Why the name changed
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,116 @@
+# Compatibility with the stdlib `email` module
+
+Every difference between this library and Python's `email` module, on the surface
+both of them model.
+
+This page is not hand-maintained prose. `tests/test_stdlib_parity.py` parses the
+whole fixture corpus with both parsers and compares them on nine dimensions —
+subject, `text_plain`, `text_html`, attachments (mimetype, filename, decoded
+bytes), the header multiset, `from`, `to`, `cc`, and the date instant. A mismatch
+fails CI **unless** it is listed below with a reason, and a reason listed here
+that no longer occurs also fails. So the table cannot drift from reality in
+either direction.
+
+## Where they agree
+
+Everything not listed further down — which includes the entire generated RFC
+corpus (RFC 5322 plain, multipart alternative/mixed/related, nested multipart,
+base64 and quoted-printable bodies, RFC 2047 encoded subjects, RFC 2231 encoded
+filenames, RFC 6532 UTF-8 headers, 8bit bodies, folded headers, empty bodies)
+matching **byte for byte**, attachment payloads included.
+
+That is a recent state of affairs. Before the RFC 2183 classification fix, this
+library reported every MIME node as an attachment and collapsed repeated headers
+to their last value, so the structural dimensions diverged on nearly every
+multipart message.
+
+## Where they differ
+
+### 1. Raw UTF-8 in headers — this library is more correct
+
+| | |
+| --- | --- |
+| Fixture | `rfc6532_utf8_headers` |
+| Dimension | `from` |
+| stdlib | `('\udcd0\udc9e\udcd1\udc82…', '\udcd0\udcbe…@…')` — lone surrogates |
+| this library | `('Отправитель', 'отправитель@пример.рф')` |
+
+RFC 6532 permits raw UTF-8 in header values. `email` with `policy=default`
+surrogate-escapes those bytes rather than decoding them, so `.addresses` yields
+unusable lone surrogates. This library decodes them.
+
+If you are migrating *to* the stdlib, this one will cost you.
+
+### 2. `headers` returns raw values; the stdlib normalises structured ones
+
+| | |
+| --- | --- |
+| Fixture | `attachment_message` |
+| Dimension | `headers` |
+| stdlib | `Date: Wed, 24 Apr 2019 10:05:02 +0200` |
+| this library | `Date: Wed, 24 Apr 2019 10:05:02 +0200 (CEST)` |
+
+`headers` gives values as they appeared, unfolded and RFC 2047-decoded, and
+nothing more. The stdlib additionally parses structured headers and re-emits a
+canonical form, dropping the RFC 5322 comment `(CEST)`.
+
+Use `date_parsed` when you want an interpreted value; use `headers` when you want
+what the sender actually wrote.
+
+### 3. Address headers are re-serialised in `headers`
+
+| | |
+| --- | --- |
+| Fixture | `large_message` |
+| Dimension | `headers` |
+| stdlib | `From: Example Sender <sender@example.com>` |
+| this library | `From: "Example Sender"<sender@example.com>` |
+
+The underlying `mailparse` crate re-emits an address header's display name
+quoted and without the space before the angle bracket. The two are equivalent
+per RFC 5322 but not textually identical.
+
+**Prefer the typed `from_` / `to` / `cc` fields** over parsing `headers`
+yourself; they are unaffected. This is arguably a wart rather than a decision,
+and is a candidate to raise upstream.
+
+### 4. Body line endings are preserved, not normalised
+
+| | |
+| --- | --- |
+| Fixture | `valid_message` |
+| Dimensions | `text_plain`, `text_html` |
+| stdlib | `"…browser (…)\n\n\n** What's New?\n"` |
+| this library | `"…browser (…)\r\n\r\n\r\n** What's New?\r\n"` |
+
+The stdlib's text content manager normalises line endings to `LF`. This library
+returns the body as it arrived, so a message transmitted with `CRLF` keeps
+`CRLF`.
+
+This is the divergence most likely to surprise you in practice, because it
+affects every multi-line body from a real mail server. If you are comparing
+strings or splitting lines, normalise first:
+
+```python
+body = mail.text_plain[0].replace("\r\n", "\n")
+```
+
+### 5. Folded headers unfold to a single space
+
+| | |
+| --- | --- |
+| Fixture | `valid_message` |
+| Dimension | `headers` |
+| stdlib | `i=1; mx.google.com;       dkim=pass …` |
+| this library | `i=1; mx.google.com; dkim=pass …` |
+
+RFC 5322 folding whitespace is semantically a single space, which is what this
+library emits. The stdlib preserves the original run of spaces from the
+continuation lines. Both are valid unfoldings; they are not string-equal.
+
+## Deliberately not modelled
+
+The comparison covers what both libraries expose. It does not cover what only the
+stdlib does, because this is a parser rather than a mail library: constructing or
+mutating messages, serialising them back out, `Message`-compatible objects, or
+header mutation. See the [migration guide](migrating.md) for that list.

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -188,6 +188,14 @@ assert handled
 A malformed transfer encoding also raises `ParseError` rather than silently
 yielding an empty body.
 
+## Known differences from the stdlib
+
+Structurally the two agree byte for byte across the RFC corpus. Five documented
+differences remain — most importantly, **body line endings are preserved rather
+than normalised to `LF`** — and one case where this library is the more correct
+of the two. See [compatibility.md](compatibility.md); every row there is enforced
+by `tests/test_stdlib_parity.py`.
+
 ## What this library does not do
 
 The stdlib is a full email *library*; this is a fast **parser**. Not provided:

--- a/tests/test_stdlib_parity.py
+++ b/tests/test_stdlib_parity.py
@@ -1,0 +1,149 @@
+"""Differential compatibility suite: fast_mail_parser vs the stdlib `email`.
+
+Every fixture is parsed by both this library and `email` (policy=default), and
+the two are compared on the surface they both model: subject, body text,
+attachments, headers, addresses, and the date instant.
+
+The point is not that the two agree everywhere -- it is that **every** place they
+disagree is accounted for. A mismatch is only tolerated if it appears in
+`DIVERGENCES` with a reason, so a new, unexplained difference fails this test.
+That makes the stdlib a standing oracle for the correctness backlog rather than a
+one-off comparison, and keeps docs/compatibility.md honest: each row there is a
+key in that table.
+
+`STALE` guards the other direction -- a divergence declared here but no longer
+observed means the table is describing the past, so that fails too.
+"""
+
+import email
+import email.policy
+import glob
+import os
+
+import pytest
+
+from fast_mail_parser import parse_email
+
+FIXTURES = sorted(
+    glob.glob(os.path.join(os.path.dirname(__file__), "data", "rfc", "*.eml"))
+)
+
+# (fixture, dimension) -> why the two legitimately differ.
+#
+# Populated from observed behaviour; every entry is a documented, deliberate
+# difference, not a to-do. Anything not listed here must match.
+DIVERGENCES: dict[tuple[str, str], str] = {}
+
+
+def _name(path: str) -> str:
+    return os.path.splitext(os.path.basename(path))[0]
+
+
+def _stdlib_view(raw: bytes) -> dict[str, object]:
+    message = email.message_from_bytes(raw, policy=email.policy.default)
+
+    plain: list[str] = []
+    html: list[str] = []
+    attachments: list[tuple[str, str, bytes]] = []
+
+    for part in message.walk():
+        if part.get_content_maintype() == "multipart":
+            continue
+        content_type = part.get_content_type()
+        # RFC 2183: an explicit `attachment` disposition means the part is a
+        # file whatever its media type. This mirrors what the parser does.
+        is_body = (
+            part.get_content_disposition() != "attachment"
+            and content_type in ("text/plain", "text/html")
+        )
+        if is_body:
+            (plain if content_type == "text/plain" else html).append(
+                part.get_content()
+            )
+        else:
+            payload = part.get_payload(decode=True) or b""
+            attachments.append((content_type, part.get_filename() or "", payload))
+
+    return {
+        "subject": str(message["Subject"] or ""),
+        "text_plain": tuple(plain),
+        "text_html": tuple(html),
+        "attachments": sorted(attachments),
+        "headers": sorted((k, str(v)) for k, v in message.items()),
+    }
+
+
+def _fmp_view(raw: bytes) -> dict[str, object]:
+    mail = parse_email(raw)
+    return {
+        "subject": mail.subject,
+        "text_plain": tuple(mail.text_plain),
+        "text_html": tuple(mail.text_html),
+        "attachments": sorted(
+            (a.mimetype, a.filename, a.content) for a in mail.attachments
+        ),
+        "headers": sorted(
+            (name, value) for name, values in mail.headers.items() for value in values
+        ),
+    }
+
+
+DIMENSIONS = ("subject", "text_plain", "text_html", "attachments", "headers")
+
+
+def _render(value: object) -> str:
+    text = repr(value)
+    return text if len(text) <= 300 else text[:300] + "..."
+
+
+def test__every_divergence_from_the_stdlib_is_accounted_for():
+    unexplained: list[str] = []
+    observed: set[tuple[str, str]] = set()
+
+    for path in FIXTURES:
+        name = _name(path)
+        raw = open(path, "rb").read()
+        stdlib, fmp = _stdlib_view(raw), _fmp_view(raw)
+
+        for dimension in DIMENSIONS:
+            if stdlib[dimension] == fmp[dimension]:
+                continue
+            observed.add((name, dimension))
+            if (name, dimension) in DIVERGENCES:
+                continue
+            unexplained.append(
+                f"\n{name} / {dimension}\n"
+                f"    stdlib: {_render(stdlib[dimension])}\n"
+                f"    fmp:    {_render(fmp[dimension])}"
+            )
+
+    stale = sorted(set(DIVERGENCES) - observed)
+
+    report = []
+    if unexplained:
+        report.append(
+            f"{len(unexplained)} unexplained divergence(s) from the stdlib. "
+            "Fix the parser, or add an entry to DIVERGENCES explaining why the "
+            "difference is intended (and add the row to docs/compatibility.md):"
+            + "".join(unexplained)
+        )
+    if stale:
+        report.append(
+            "\nDIVERGENCES entries that no longer occur (remove them, and the "
+            f"matching docs/compatibility.md rows): {stale}"
+        )
+    if report:
+        pytest.fail("\n".join(report))
+
+
+@pytest.mark.parametrize("path", FIXTURES, ids=_name)
+def test__both_parsers_accept_every_fixture(path: str):
+    # A fixture that only one side can parse is itself a compatibility finding.
+    raw = open(path, "rb").read()
+
+    assert _stdlib_view(raw) is not None
+    assert _fmp_view(raw) is not None
+
+
+def test__corpus_is_not_empty():
+    assert len(FIXTURES) >= 10, f"expected the RFC corpus, found {len(FIXTURES)}"

--- a/tests/test_stdlib_parity.py
+++ b/tests/test_stdlib_parity.py
@@ -24,8 +24,15 @@ import pytest
 
 from fast_mail_parser import parse_email
 
-FIXTURES = sorted(
-    glob.glob(os.path.join(os.path.dirname(__file__), "data", "rfc", "*.eml"))
+_DATA = os.path.join(os.path.dirname(__file__), "data")
+
+# The generated RFC corpus plus the hand-written fixtures, which are closer to
+# real-world mail and so likelier to surface a genuine divergence.
+# invalid_message.eml is excluded: it exists to fail parsing.
+FIXTURES = sorted(glob.glob(os.path.join(_DATA, "rfc", "*.eml"))) + sorted(
+    path
+    for path in glob.glob(os.path.join(_DATA, "*.eml"))
+    if os.path.basename(path) != "invalid_message.eml"
 )
 
 # (fixture, dimension) -> why the two legitimately differ.
@@ -70,7 +77,37 @@ def _stdlib_view(raw: bytes) -> dict[str, object]:
         "text_html": tuple(html),
         "attachments": sorted(attachments),
         "headers": sorted((k, str(v)) for k, v in message.items()),
+        "from": _stdlib_addresses(message, "From")[:1],
+        "to": _stdlib_addresses(message, "To"),
+        "cc": _stdlib_addresses(message, "Cc"),
+        "date": _stdlib_date(message),
     }
+
+
+def _stdlib_addresses(message, key: str) -> list[tuple[str | None, str]]:
+    """Mailboxes for one address header. `.addresses` already flattens groups."""
+    header = message[key]
+    if header is None:
+        return []
+    try:
+        return [
+            (address.display_name or None, address.addr_spec)
+            for address in header.addresses
+        ]
+    except (AttributeError, ValueError):
+        # A header the stdlib could not parse structurally.
+        return []
+
+
+def _stdlib_date(message) -> float | None:
+    header = message["Date"]
+    if header is None:
+        return None
+    try:
+        parsed = header.datetime
+    except (AttributeError, ValueError):
+        return None
+    return parsed.timestamp() if parsed is not None else None
 
 
 def _fmp_view(raw: bytes) -> dict[str, object]:
@@ -85,10 +122,28 @@ def _fmp_view(raw: bytes) -> dict[str, object]:
         "headers": sorted(
             (name, value) for name, values in mail.headers.items() for value in values
         ),
+        "from": (
+            [(mail.from_.display_name, mail.from_.address)] if mail.from_ else []
+        ),
+        "to": [(a.display_name, a.address) for a in mail.to],
+        "cc": [(a.display_name, a.address) for a in mail.cc],
+        "date": (
+            mail.date_parsed.timestamp() if mail.date_parsed is not None else None
+        ),
     }
 
 
-DIMENSIONS = ("subject", "text_plain", "text_html", "attachments", "headers")
+DIMENSIONS = (
+    "subject",
+    "text_plain",
+    "text_html",
+    "attachments",
+    "headers",
+    "from",
+    "to",
+    "cc",
+    "date",
+)
 
 
 def _render(value: object) -> str:

--- a/tests/test_stdlib_parity.py
+++ b/tests/test_stdlib_parity.py
@@ -39,7 +39,50 @@ FIXTURES = sorted(glob.glob(os.path.join(_DATA, "rfc", "*.eml"))) + sorted(
 #
 # Populated from observed behaviour; every entry is a documented, deliberate
 # difference, not a to-do. Anything not listed here must match.
-DIVERGENCES: dict[tuple[str, str], str] = {}
+DIVERGENCES: dict[tuple[str, str], str] = {
+    # fast_mail_parser is the more correct of the two here. RFC 6532 permits raw
+    # UTF-8 in header values; `email` with policy=default surrogate-escapes those
+    # bytes instead of decoding them, so `.addresses` yields lone surrogates
+    # ('\udcd0\udc9e...') where this library yields 'Отправитель'.
+    ("rfc6532_utf8_headers", "from"): (
+        "stdlib surrogate-escapes raw UTF-8 (RFC 6532) in address headers; "
+        "this library decodes it"
+    ),
+    # `headers` exposes header values as they appeared, only unfolded and
+    # RFC 2047-decoded. The stdlib additionally *normalises* structured headers,
+    # so a Date carrying an RFC 5322 comment loses it: '... +0200 (CEST)' becomes
+    # '... +0200'. Use `date_parsed` for an interpreted value.
+    ("attachment_message", "headers"): (
+        "stdlib strips RFC 5322 comments from structured headers "
+        "(Date '+0200 (CEST)' -> '+0200'); this library returns the raw value"
+    ),
+    # mailparse re-emits an address header's display name quoted and without the
+    # space before the angle bracket: 'Example Sender <a@b>' comes back as
+    # '"Example Sender"<a@b>'. Semantically equivalent per RFC 5322, textually
+    # not. Prefer the typed `from_`/`to` fields over parsing `headers` yourself.
+    ("large_message", "headers"): (
+        "mailparse re-serialises address-header display names as "
+        '\'"Name"<addr>\'; the stdlib preserves the original spelling'
+    ),
+    # The stdlib's text content manager normalises line endings to LF. This
+    # library returns the body as it appeared on the wire, so a message
+    # transmitted with CRLF keeps CRLF.
+    ("valid_message", "text_plain"): (
+        "stdlib normalises body line endings to LF; this library preserves the "
+        "wire form (CRLF)"
+    ),
+    ("valid_message", "text_html"): (
+        "stdlib normalises body line endings to LF; this library preserves the "
+        "wire form (CRLF)"
+    ),
+    # Both unfold folded headers, but differently: RFC 5322 folding whitespace is
+    # semantically a single space, which is what this library emits. The stdlib
+    # keeps the original run of spaces from the continuation lines.
+    ("valid_message", "headers"): (
+        "on unfolding, this library collapses folding whitespace to one space; "
+        "the stdlib preserves the original run"
+    ),
+}
 
 
 def _name(path: str) -> str:


### PR DESCRIPTION
Part of **#103** — item 1, the parity suite and its divergence table. Item 3 (the expanded benchmark table) is untouched, so #103 stays open.

## What it does

Both parsers run over the whole fixture corpus — the generated RFC set plus the hand-written messages, which are closer to real mail — compared on nine dimensions: subject, `text_plain`, `text_html`, attachments (mimetype, filename, **decoded bytes**), the header multiset, `from`, `to`, `cc`, and the date instant.

## The design point: the table can't drift

A mismatch fails **unless** it's declared in `DIVERGENCES` with a reason. And a declared divergence that *stops* occurring also fails. So `docs/compatibility.md` describes the present in both directions — it can't rot into fiction, and it can't quietly accumulate stale entries.

The failure message prints every unexplained divergence at once with both sides rendered, so classifying a batch takes one CI run rather than one run per finding. That's how the six below were found in a single pass.

## What it found

The corpus matches the stdlib **byte for byte**, attachment payloads included, except for six differences — all discovered by this suite rather than assumed:

| # | Where | Difference |
| --- | --- | --- |
| 1 | `rfc6532_utf8_headers` / `from` | **We're more correct.** RFC 6532 permits raw UTF-8 in headers; the stdlib surrogate-escapes it, yielding lone surrogates (`'\udcd0\udc9e…'`) where we yield `'Отправитель'` |
| 2 | `attachment_message` / `headers` | stdlib normalises structured headers, dropping RFC 5322 comments: `+0200 (CEST)` → `+0200` |
| 3 | `large_message` / `headers` | mailparse re-serialises display names as `"Name"<addr>` |
| 4–5 | `valid_message` / `text_plain`, `text_html` | stdlib normalises line endings to `LF`; we return the wire form, so `CRLF` survives |
| 6 | `valid_message` / `headers` | we collapse folding whitespace to one space; stdlib keeps the original run |

Worth pulling out:

- **#1 is the stdlib being wrong**, not us. Anyone migrating *away* from this library loses correct RFC 6532 handling — that belongs in a compatibility doc.
- **#4/#5 is the one that will actually bite people.** It affects every multi-line body from a real mail server. The doc gives the one-line fix.
- **#3 is a wart rather than a decision.** The typed `from_`/`to`/`cc` fields are unaffected and should be preferred over parsing `headers` by hand. Candidate to raise upstream with mailparse.

## Context worth recording

Structural parity is **recent**. Before the RFC 2183 classification fix earlier today, every multipart message diverged — every MIME node was reported as an attachment, and repeated headers collapsed to their last value. This suite would have failed loudly on nearly the whole corpus. It now stands as the regression oracle for that work.

## Acceptance (#103, item 1)

- [x] Parity suite over the corpus with every divergence classified; zero unclassified, enforced as a test failure
- [x] `docs/compatibility.md` with the divergence table, each row backed by a named fixture
- [x] Dimensions expand as roadmap items land — `from`/`to`/`cc` and `date` are compared because #98 landed today
- [x] ruff clean; CHANGELOG entry; linked from the README and the migration guide

Not this PR: the benchmark table with stdlib/mailparser columns and a `make bench-table` target.