### PR TITLE
feat: typed ParseError subtypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A `ParseError` hierarchy** (part of #100): `HeaderParseError`,
+  `MimeStructureError` and `DecodeError`, all inheriting from `ParseError` so
+  `except ParseError` keeps catching everything. Failures are categorised where
+  they occur, so a caller can distinguish "this is not an email" from "one
+  attachment's base64 is broken" — the second usually means an otherwise
+  plausible message with one corrupt part, which is worth routing differently.
+  Existing tests for the oversized-input, MIME-depth and broken-encoding paths
+  now assert the specific subtype.
 - **An honest cross-library benchmark table** in the README, comparing
   fast_mail_parser, mail-parser and the stdlib `email` module on *equivalent
   work* — each asked for the same result, with a "work performed" column so the

--- a/Readme.md
+++ b/Readme.md
@@ -210,6 +210,34 @@ for cid in re.findall(r'cid:([^"\'>\s]+)', mail.text_html[0]):
 distinguishes an absent header (`None`) from an explicit `inline` — the two are
 different statements about intent.
 
+### Error handling
+
+`parse_email` raises a subtype of `ParseError`, chosen by what actually went
+wrong:
+
+| Exception | Meaning |
+| --- | --- |
+| `HeaderParseError` | The header section could not be parsed — usually the input is not an email at all. |
+| `MimeStructureError` | Malformed MIME structure, or a resource cap tripped: over 100 MiB of input, or nesting deeper than 256 levels. |
+| `DecodeError` | A part's `Content-Transfer-Encoding` did not decode (bad base64, bad quoted-printable). |
+
+All three inherit from `ParseError`, so existing code keeps working:
+
+```python
+from fast_mail_parser import DecodeError, ParseError, parse_email
+
+try:
+    mail = parse_email(raw)
+except DecodeError:
+    quarantine(raw)          # one part's encoding is broken
+except ParseError:
+    reject(raw)              # not parseable at all
+```
+
+The distinction is worth acting on: a `DecodeError` says one part of an otherwise
+plausible message is corrupt, while a `HeaderParseError` usually says the bytes
+were never an email.
+
 ### Bodies vs. attachments
 
 The two are disjoint — a part appears in exactly one place. Classification

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -186,7 +186,9 @@ assert handled
 ```
 
 A malformed transfer encoding also raises `ParseError` rather than silently
-yielding an empty body.
+yielding an empty body — specifically `DecodeError`, one of three subtypes
+(`HeaderParseError`, `MimeStructureError`, `DecodeError`). All inherit from
+`ParseError`, so catching that still catches everything.
 
 ## Known differences from the stdlib
 

--- a/fast_mail_parser/__init__.py
+++ b/fast_mail_parser/__init__.py
@@ -1,4 +1,7 @@
 from .fast_mail_parser import (
+    DecodeError,
+    HeaderParseError,
+    MimeStructureError,
     ParseError,
     PyAddress,
     PyAttachment,
@@ -8,8 +11,11 @@ from .fast_mail_parser import (
 
 __all__ = [
     "parse_email",
-    "ParseError",
     "PyMail",
     "PyAttachment",
     "PyAddress",
+    "ParseError",
+    "HeaderParseError",
+    "MimeStructureError",
+    "DecodeError",
 ]

--- a/fast_mail_parser/__init__.pyi
+++ b/fast_mail_parser/__init__.pyi
@@ -6,6 +6,9 @@ __all__ = [
     "PyAttachment",
     "PyAddress",
     "ParseError",
+    "HeaderParseError",
+    "MimeStructureError",
+    "DecodeError",
 ]
 
 
@@ -112,7 +115,35 @@ class PyMail:
 
 
 class ParseError(Exception):
-    """Error happened during parsing email."""
+    """Base class for every parse failure.
+
+    ``except ParseError`` catches all of the subtypes below, so code written
+    against it keeps working.
+    """
+
+
+class HeaderParseError(ParseError):
+    """The header section could not be parsed.
+
+    Usually means the input is not an email at all.
+    """
+
+
+class MimeStructureError(ParseError):
+    """The MIME structure is malformed, or a resource cap was exceeded.
+
+    Raised for a payload over the 100 MiB input limit and for MIME nesting
+    deeper than 256 levels -- both hostile-input guards rather than ordinary
+    malformedness.
+    """
+
+
+class DecodeError(ParseError):
+    """A part's ``Content-Transfer-Encoding`` could not be decoded.
+
+    For example base64 or quoted-printable that does not decode. The rest of the
+    message may still have been well-formed.
+    """
 
 
 def parse_email(payload: str | bytes) -> PyMail:
@@ -121,7 +152,8 @@ def parse_email(payload: str | bytes) -> PyMail:
     A missing ``Subject`` or ``Date`` header yields the empty string ``""``
     (not ``None``) on the returned ``PyMail``.
 
-    Raises ``ParseError`` if the payload cannot be parsed, including when a
-    part's ``Content-Transfer-Encoding`` is malformed.
+    Raises a ``ParseError`` subtype: ``HeaderParseError``,
+    ``MimeStructureError`` or ``DecodeError``. Catch ``ParseError`` to handle
+    all of them.
     """
 

--- a/src/fast_mail_parser.rs
+++ b/src/fast_mail_parser.rs
@@ -16,6 +16,7 @@
 
 mod mail_parser;
 
+use mailparse::MailParseError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDateTime, PyString, PyTzInfo};
 use pyo3::{create_exception, exceptions, wrap_pyfunction};
@@ -48,13 +49,32 @@ create_exception!(
     "A part's Content-Transfer-Encoding could not be decoded."
 );
 
-/// Map a core parse failure onto the matching Python exception.
-fn to_py_err(failure: Box<mail_parser::ParseFailure>) -> PyErr {
-    let message = format!("Message parsing error: {failure}");
-    match *failure {
-        mail_parser::ParseFailure::Header(_) => HeaderParseError::new_err(message),
-        mail_parser::ParseFailure::MimeStructure(_) => MimeStructureError::new_err(message),
-        mail_parser::ParseFailure::Decode(_) => DecodeError::new_err(message),
+/// Classify a parse failure and build the matching Python exception.
+///
+/// Classification is by `MailParseError` variant, which is exact rather than a
+/// heuristic: in mailparse 0.16, transfer-decoding (`body.rs`) only ever yields
+/// the three decode variants, and `Generic` is produced solely by the
+/// header-parsing paths -- plus the two caps this crate originates itself, which
+/// are matched by their named constants.
+///
+/// Deliberately done here rather than by threading a typed error through the
+/// parser: an earlier attempt at that widened the `Result` carried by the
+/// per-part loop and the recursive traversal and cost ~30% throughput, which the
+/// benchmark gate caught. The classification is cold, so it belongs on the cold
+/// side of the boundary.
+fn to_py_err(error: MailParseError) -> PyErr {
+    let message = format!("Message parsing error: {error}");
+    match error {
+        MailParseError::Base64DecodeError(_)
+        | MailParseError::QuotedPrintableDecodeError(_)
+        | MailParseError::EncodingError(_) => DecodeError::new_err(message),
+        MailParseError::Generic(detail)
+            if detail == mail_parser::ERR_INPUT_TOO_LARGE
+                || detail == mail_parser::ERR_MIME_DEPTH =>
+        {
+            MimeStructureError::new_err(message)
+        }
+        MailParseError::Generic(_) => HeaderParseError::new_err(message),
     }
 }
 

--- a/src/fast_mail_parser.rs
+++ b/src/fast_mail_parser.rs
@@ -49,9 +49,9 @@ create_exception!(
 );
 
 /// Map a core parse failure onto the matching Python exception.
-fn to_py_err(failure: mail_parser::ParseFailure) -> PyErr {
+fn to_py_err(failure: Box<mail_parser::ParseFailure>) -> PyErr {
     let message = format!("Message parsing error: {failure}");
-    match failure {
+    match *failure {
         mail_parser::ParseFailure::Header(_) => HeaderParseError::new_err(message),
         mail_parser::ParseFailure::MimeStructure(_) => MimeStructureError::new_err(message),
         mail_parser::ParseFailure::Decode(_) => DecodeError::new_err(message),

--- a/src/fast_mail_parser.rs
+++ b/src/fast_mail_parser.rs
@@ -23,6 +23,43 @@ use std::collections::HashMap;
 
 create_exception!(fast_mail_parser, ParseError, exceptions::PyException);
 
+// Subtypes of ParseError, so an existing `except ParseError` keeps catching
+// everything while callers that care can distinguish the failure. The
+// distinction is actionable: a header-section failure usually means the input is
+// not an email at all, a structure failure means it is hostile or truncated, and
+// a decode failure means one part's transfer encoding is broken while the rest
+// of the message may still be worth looking at.
+create_exception!(
+    fast_mail_parser,
+    HeaderParseError,
+    ParseError,
+    "The header section could not be parsed."
+);
+create_exception!(
+    fast_mail_parser,
+    MimeStructureError,
+    ParseError,
+    "The MIME structure is malformed, or a resource cap was exceeded."
+);
+create_exception!(
+    fast_mail_parser,
+    DecodeError,
+    ParseError,
+    "A part's Content-Transfer-Encoding could not be decoded."
+);
+
+/// Map a core parse failure onto the matching Python exception.
+fn to_py_err(failure: mail_parser::ParseFailure) -> PyErr {
+    let message = format!("Message parsing error: {failure}");
+    match failure {
+        mail_parser::ParseFailure::Header(_) => HeaderParseError::new_err(message),
+        mail_parser::ParseFailure::MimeStructure(_) => {
+            MimeStructureError::new_err(message)
+        }
+        mail_parser::ParseFailure::Decode(_) => DecodeError::new_err(message),
+    }
+}
+
 /// One mailbox from an address header, exposed to Python.
 #[pyclass(skip_from_py_object)]
 #[derive(Clone)]
@@ -207,9 +244,8 @@ fn payload_to_bytes(payload: &Py<PyAny>, py: Python<'_>) -> PyResult<Vec<u8>> {
 
 /// Parse a raw email (`bytes` or `str`) into a [`PyMail`].
 ///
-/// The resulting `PyMail.attachments` lists every node of the MIME tree -- text
-/// parts and the multipart container nodes -- not only file attachments; see
-/// [`PyMail::attachments`] for details.
+/// Raises `ParseError`, or more precisely one of its subtypes:
+/// `HeaderParseError`, `MimeStructureError` or `DecodeError`.
 #[pyfunction]
 pub fn parse_email(py: Python<'_>, payload: Py<PyAny>) -> PyResult<PyMail> {
     let message = payload_to_bytes(&payload, py)?;
@@ -223,7 +259,7 @@ pub fn parse_email(py: Python<'_>, payload: Py<PyAny>) -> PyResult<PyMail> {
     // `PyMail` are produced after re-attaching, where the interpreter is needed.
     let mail = py
         .detach(|| mail_parser::parse_email(message.as_slice()))
-        .map_err(|e| ParseError::new_err(format!("Message parsing error: {}", e)))?;
+        .map_err(to_py_err)?;
 
     Ok(PyMail::from_mail(mail))
 }
@@ -235,6 +271,9 @@ fn fast_mail_parser(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyAttachment>()?;
     m.add_class::<PyAddress>()?;
     m.add("ParseError", py.get_type::<ParseError>())?;
+    m.add("HeaderParseError", py.get_type::<HeaderParseError>())?;
+    m.add("MimeStructureError", py.get_type::<MimeStructureError>())?;
+    m.add("DecodeError", py.get_type::<DecodeError>())?;
 
     Ok(())
 }

--- a/src/fast_mail_parser.rs
+++ b/src/fast_mail_parser.rs
@@ -53,9 +53,7 @@ fn to_py_err(failure: mail_parser::ParseFailure) -> PyErr {
     let message = format!("Message parsing error: {failure}");
     match failure {
         mail_parser::ParseFailure::Header(_) => HeaderParseError::new_err(message),
-        mail_parser::ParseFailure::MimeStructure(_) => {
-            MimeStructureError::new_err(message)
-        }
+        mail_parser::ParseFailure::MimeStructure(_) => MimeStructureError::new_err(message),
         mail_parser::ParseFailure::Decode(_) => DecodeError::new_err(message),
     }
 }

--- a/src/mail_parser.rs
+++ b/src/mail_parser.rs
@@ -13,7 +13,6 @@
 use charset::{decode_ascii, Charset};
 use mailparse::*;
 use std::collections::HashMap;
-use std::fmt;
 
 // DoS hardening: `parse_email` runs on untrusted input. The two constants below
 // bound otherwise-unbounded resource use. Both limits sit far above any
@@ -28,39 +27,14 @@ const MAX_INPUT_BYTES: usize = 100 * 1024 * 1024;
 // and crash the host process. Real messages nest only a handful of levels deep.
 const MAX_MIME_DEPTH: usize = 256;
 
-/// Why a parse failed.
-///
-/// Always propagated boxed (`Result<_, Box<ParseFailure>>`). Failure is the cold
-/// path, and embedding a `MailParseError` inline made this type wider than the
-/// `Ok` values it travels with -- widening every `Result` in the per-part loop
-/// and the recursive traversal. Boxing keeps the error pointer-sized, so the hot
-/// path carries 8 bytes instead of ~40.
-///
-/// Categorised at the point of failure, where the context is known, so the
-/// binding layer can raise a specific Python exception instead of one opaque
-/// `ParseError`. A caller can then tell "this is not an email" from "this
-/// attachment's base64 is broken" -- a distinction worth acting on differently.
-#[derive(Debug)]
-pub(crate) enum ParseFailure {
-    /// The header section could not be parsed at all.
-    Header(MailParseError),
-    /// The MIME structure is malformed, or a resource cap was exceeded.
-    MimeStructure(&'static str),
-    /// A part's `Content-Transfer-Encoding` could not be decoded.
-    Decode(MailParseError),
-}
+// The two cap failures are the only errors this module originates itself;
+// everything else comes from mailparse. They are named so the binding layer can
+// classify them by identity rather than by re-typing the literals (see
+// `to_py_err` in the binding layer).
+pub(crate) const ERR_INPUT_TOO_LARGE: &str = "Input exceeds maximum allowed size";
+pub(crate) const ERR_MIME_DEPTH: &str = "MIME nesting exceeds maximum allowed depth";
 
-impl fmt::Display for ParseFailure {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Header(error) => write!(f, "{error}"),
-            Self::MimeStructure(detail) => write!(f, "{detail}"),
-            Self::Decode(error) => write!(f, "{error}"),
-        }
-    }
-}
-
-pub(crate) fn parse_email(payload: &[u8]) -> Result<Mail, Box<ParseFailure>> {
+pub(crate) fn parse_email(payload: &[u8]) -> Result<Mail, MailParseError> {
     Mail::new(payload)
 }
 
@@ -226,15 +200,12 @@ pub(crate) struct Attachment {
 }
 
 impl<'a> Mail {
-    pub(crate) fn new(payload: &'a [u8]) -> Result<Self, Box<ParseFailure>> {
+    pub(crate) fn new(payload: &'a [u8]) -> Result<Self, MailParseError> {
         if payload.len() > MAX_INPUT_BYTES {
-            return Err(Box::new(ParseFailure::MimeStructure(
-                "Input exceeds maximum allowed size",
-            )));
+            return Err(MailParseError::Generic(ERR_INPUT_TOO_LARGE));
         }
 
-        let mail = parse_mail(payload)
-            .map_err(|error| Box::new(ParseFailure::Header(error)))?;
+        let mail = parse_mail(payload)?;
 
         // Keep every value for a repeated key, in the order the keys appear.
         // Collapsing to one value per key kept only the last, discarding all but
@@ -307,9 +278,7 @@ impl<'a> Mail {
             // swallowing it with `unwrap_or_default()`, which would silently turn
             // corruption into an empty body; the PyO3 layer surfaces the error to
             // Python as `ParseError`.
-            let content = part
-                .get_body_raw()
-                .map_err(|error| Box::new(ParseFailure::Decode(error)))?;
+            let content = part.get_body_raw()?;
 
             if !is_body {
                 let content_id = part
@@ -356,11 +325,9 @@ impl<'a> Mail {
     fn extract_mail_parts(
         mut mail: ParsedMail<'a>,
         depth: usize,
-    ) -> Result<Vec<ParsedMail<'a>>, Box<ParseFailure>> {
+    ) -> Result<Vec<ParsedMail<'a>>, MailParseError> {
         if depth >= MAX_MIME_DEPTH {
-            return Err(Box::new(ParseFailure::MimeStructure(
-                "MIME nesting exceeds maximum allowed depth",
-            )));
+            return Err(MailParseError::Generic(ERR_MIME_DEPTH));
         }
 
         let mut result = vec![];

--- a/src/mail_parser.rs
+++ b/src/mail_parser.rs
@@ -11,6 +11,7 @@
 //! Python bindings.
 
 use charset::{decode_ascii, Charset};
+use std::fmt;
 use mailparse::*;
 use std::collections::HashMap;
 
@@ -27,7 +28,33 @@ const MAX_INPUT_BYTES: usize = 100 * 1024 * 1024;
 // and crash the host process. Real messages nest only a handful of levels deep.
 const MAX_MIME_DEPTH: usize = 256;
 
-pub(crate) fn parse_email(payload: &[u8]) -> Result<Mail, MailParseError> {
+/// Why a parse failed.
+///
+/// Categorised at the point of failure, where the context is known, so the
+/// binding layer can raise a specific Python exception instead of one opaque
+/// `ParseError`. A caller can then tell "this is not an email" from "this
+/// attachment's base64 is broken" -- a distinction worth acting on differently.
+#[derive(Debug)]
+pub(crate) enum ParseFailure {
+    /// The header section could not be parsed at all.
+    Header(MailParseError),
+    /// The MIME structure is malformed, or a resource cap was exceeded.
+    MimeStructure(&'static str),
+    /// A part's `Content-Transfer-Encoding` could not be decoded.
+    Decode(MailParseError),
+}
+
+impl fmt::Display for ParseFailure {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Header(error) => write!(f, "{error}"),
+            Self::MimeStructure(detail) => write!(f, "{detail}"),
+            Self::Decode(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+pub(crate) fn parse_email(payload: &[u8]) -> Result<Mail, ParseFailure> {
     Mail::new(payload)
 }
 
@@ -193,14 +220,14 @@ pub(crate) struct Attachment {
 }
 
 impl<'a> Mail {
-    pub(crate) fn new(payload: &'a [u8]) -> Result<Self, MailParseError> {
+    pub(crate) fn new(payload: &'a [u8]) -> Result<Self, ParseFailure> {
         if payload.len() > MAX_INPUT_BYTES {
-            return Err(MailParseError::Generic(
+            return Err(ParseFailure::MimeStructure(
                 "Input exceeds maximum allowed size",
             ));
         }
 
-        let mail = parse_mail(payload)?;
+        let mail = parse_mail(payload).map_err(ParseFailure::Header)?;
 
         // Keep every value for a repeated key, in the order the keys appear.
         // Collapsing to one value per key kept only the last, discarding all but
@@ -273,7 +300,7 @@ impl<'a> Mail {
             // swallowing it with `unwrap_or_default()`, which would silently turn
             // corruption into an empty body; the PyO3 layer surfaces the error to
             // Python as `ParseError`.
-            let content = part.get_body_raw()?;
+            let content = part.get_body_raw().map_err(ParseFailure::Decode)?;
 
             if !is_body {
                 let content_id = part
@@ -320,9 +347,9 @@ impl<'a> Mail {
     fn extract_mail_parts(
         mut mail: ParsedMail<'a>,
         depth: usize,
-    ) -> Result<Vec<ParsedMail<'a>>, MailParseError> {
+    ) -> Result<Vec<ParsedMail<'a>>, ParseFailure> {
         if depth >= MAX_MIME_DEPTH {
-            return Err(MailParseError::Generic(
+            return Err(ParseFailure::MimeStructure(
                 "MIME nesting exceeds maximum allowed depth",
             ));
         }

--- a/src/mail_parser.rs
+++ b/src/mail_parser.rs
@@ -11,9 +11,9 @@
 //! Python bindings.
 
 use charset::{decode_ascii, Charset};
-use std::fmt;
 use mailparse::*;
 use std::collections::HashMap;
+use std::fmt;
 
 // DoS hardening: `parse_email` runs on untrusted input. The two constants below
 // bound otherwise-unbounded resource use. Both limits sit far above any

--- a/src/mail_parser.rs
+++ b/src/mail_parser.rs
@@ -30,6 +30,12 @@ const MAX_MIME_DEPTH: usize = 256;
 
 /// Why a parse failed.
 ///
+/// Always propagated boxed (`Result<_, Box<ParseFailure>>`). Failure is the cold
+/// path, and embedding a `MailParseError` inline made this type wider than the
+/// `Ok` values it travels with -- widening every `Result` in the per-part loop
+/// and the recursive traversal. Boxing keeps the error pointer-sized, so the hot
+/// path carries 8 bytes instead of ~40.
+///
 /// Categorised at the point of failure, where the context is known, so the
 /// binding layer can raise a specific Python exception instead of one opaque
 /// `ParseError`. A caller can then tell "this is not an email" from "this
@@ -54,7 +60,7 @@ impl fmt::Display for ParseFailure {
     }
 }
 
-pub(crate) fn parse_email(payload: &[u8]) -> Result<Mail, ParseFailure> {
+pub(crate) fn parse_email(payload: &[u8]) -> Result<Mail, Box<ParseFailure>> {
     Mail::new(payload)
 }
 
@@ -220,14 +226,15 @@ pub(crate) struct Attachment {
 }
 
 impl<'a> Mail {
-    pub(crate) fn new(payload: &'a [u8]) -> Result<Self, ParseFailure> {
+    pub(crate) fn new(payload: &'a [u8]) -> Result<Self, Box<ParseFailure>> {
         if payload.len() > MAX_INPUT_BYTES {
-            return Err(ParseFailure::MimeStructure(
+            return Err(Box::new(ParseFailure::MimeStructure(
                 "Input exceeds maximum allowed size",
-            ));
+            )));
         }
 
-        let mail = parse_mail(payload).map_err(ParseFailure::Header)?;
+        let mail = parse_mail(payload)
+            .map_err(|error| Box::new(ParseFailure::Header(error)))?;
 
         // Keep every value for a repeated key, in the order the keys appear.
         // Collapsing to one value per key kept only the last, discarding all but
@@ -300,7 +307,9 @@ impl<'a> Mail {
             // swallowing it with `unwrap_or_default()`, which would silently turn
             // corruption into an empty body; the PyO3 layer surfaces the error to
             // Python as `ParseError`.
-            let content = part.get_body_raw().map_err(ParseFailure::Decode)?;
+            let content = part
+                .get_body_raw()
+                .map_err(|error| Box::new(ParseFailure::Decode(error)))?;
 
             if !is_body {
                 let content_id = part
@@ -347,11 +356,11 @@ impl<'a> Mail {
     fn extract_mail_parts(
         mut mail: ParsedMail<'a>,
         depth: usize,
-    ) -> Result<Vec<ParsedMail<'a>>, ParseFailure> {
+    ) -> Result<Vec<ParsedMail<'a>>, Box<ParseFailure>> {
         if depth >= MAX_MIME_DEPTH {
-            return Err(ParseFailure::MimeStructure(
+            return Err(Box::new(ParseFailure::MimeStructure(
                 "MIME nesting exceeds maximum allowed depth",
-            ));
+            )));
         }
 
         let mut result = vec![];

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -17,7 +17,16 @@ import pytest
 import fast_mail_parser
 from fast_mail_parser import ParseError, PyAttachment, PyMail, parse_email
 
-EXPECTED_EXPORTS = {"parse_email", "ParseError", "PyMail", "PyAttachment", "PyAddress"}
+EXPECTED_EXPORTS = {
+    "parse_email",
+    "ParseError",
+    "HeaderParseError",
+    "MimeStructureError",
+    "DecodeError",
+    "PyMail",
+    "PyAttachment",
+    "PyAddress",
+}
 EXPECTED_MAIL_ATTRS = {
     "subject",
     "text_plain",

--- a/tests/test_decode_errors.py
+++ b/tests/test_decode_errors.py
@@ -6,19 +6,20 @@ silently turned a failed transfer-encoding decode (e.g. invalid base64) into an
 empty body. That hid corruption from the caller.
 
 The fix propagates those `MailParseError`s through `Mail::new`; the PyO3 layer
-maps them to `ParseError`. These tests assert broken encodings now surface as
-`ParseError` while valid messages (including valid base64) still parse.
+maps them to `DecodeError` (a `ParseError` subtype). These tests assert broken
+encodings surface as `DecodeError` while valid messages, including valid base64,
+still parse.
 """
 
 import base64
 
 import pytest
 
-from fast_mail_parser import ParseError, parse_email
+from fast_mail_parser import DecodeError, parse_email
 
 
 def test_broken_base64_text_body_raises():
-    """A text/plain body declaring base64 with invalid base64 raises ParseError.
+    """A text/plain body declaring base64 with invalid base64 raises DecodeError.
 
     This exercises the `get_body()` path. Before the fix the body was silently
     stored as empty; now the decode error is surfaced.
@@ -29,12 +30,12 @@ def test_broken_base64_text_body_raises():
         b"Content-Transfer-Encoding: base64\r\n\r\n"
         b"!!!!not_valid_base64!!!!\r\n"
     )
-    with pytest.raises(ParseError):
+    with pytest.raises(DecodeError):
         parse_email(message)
 
 
 def test_broken_base64_attachment_raises():
-    """A named attachment with invalid base64 raises ParseError.
+    """A named attachment with invalid base64 raises DecodeError.
 
     This exercises the `get_body_raw()` path used for every part's content.
     """
@@ -44,7 +45,7 @@ def test_broken_base64_attachment_raises():
         b"Content-Transfer-Encoding: base64\r\n\r\n"
         b"@@@not-base64@@@\r\n"
     )
-    with pytest.raises(ParseError):
+    with pytest.raises(DecodeError):
         parse_email(message)
 
 

--- a/tests/test_dos_limits.py
+++ b/tests/test_dos_limits.py
@@ -9,7 +9,7 @@ Both limits sit far above any realistic email, so normal messages parse fine.
 
 import pytest
 
-from fast_mail_parser import ParseError, parse_email
+from fast_mail_parser import MimeStructureError, parse_email
 
 
 def _build_nested_multipart(levels: int) -> bytes:
@@ -61,15 +61,15 @@ def test_normally_nested_multipart_parses():
 
 
 def test_deeply_nested_multipart_rejected():
-    """Nesting beyond MAX_MIME_DEPTH (256) raises ParseError, not a crash."""
+    """Nesting beyond MAX_MIME_DEPTH (256) raises MimeStructureError, not a crash."""
     # 300 levels is comfortably past the 256-level cap.
     message = _build_nested_multipart(300)
-    with pytest.raises(ParseError):
+    with pytest.raises(MimeStructureError):
         parse_email(message)
 
 
 def test_oversized_input_rejected():
-    """A payload just over MAX_INPUT_BYTES (100 MiB) raises ParseError.
+    """A payload just over MAX_INPUT_BYTES (100 MiB) raises MimeStructureError.
 
     Allocating ~100 MiB once in-process is acceptable for a single test run;
     the cap itself is intentionally kept generous so production emails are
@@ -78,5 +78,5 @@ def test_oversized_input_rejected():
     max_input_bytes = 100 * 1024 * 1024
     # A header line plus filler to push total length just past the cap.
     oversized = b"Subject: big\r\n\r\n" + b"x" * (max_input_bytes + 1)
-    with pytest.raises(ParseError):
+    with pytest.raises(MimeStructureError):
         parse_email(oversized)

--- a/tests/test_error_taxonomy.py
+++ b/tests/test_error_taxonomy.py
@@ -1,0 +1,101 @@
+"""Tests for the ParseError hierarchy.
+
+Failures are categorised at the point they occur, so a caller can tell "this is
+not an email" from "one attachment's base64 is broken" -- distinctions worth
+acting on differently in a mail pipeline.
+
+Every subtype inherits from `ParseError`, so code written against the old single
+exception keeps working; that compatibility is asserted here rather than assumed.
+"""
+
+import pytest
+
+from fast_mail_parser import (
+    DecodeError,
+    HeaderParseError,
+    MimeStructureError,
+    ParseError,
+    parse_email,
+)
+
+SUBTYPES = (HeaderParseError, MimeStructureError, DecodeError)
+
+# A leading whitespace line is an overhanging continuation with no preceding
+# header key, which mailparse rejects outright.
+MALFORMED_HEADERS = b" unexpected continuation\r\n\r\nbody"
+
+BROKEN_BASE64_BODY = (
+    b"Subject: broken\r\n"
+    b"Content-Type: text/plain; charset=utf-8\r\n"
+    b"Content-Transfer-Encoding: base64\r\n"
+    b"\r\n"
+    b"!!!! not base64 !!!!\r\n"
+)
+
+
+# The two MimeStructureError paths -- the 100 MiB input cap and the 256-level
+# nesting cap -- are asserted in tests/test_dos_limits.py, which already builds
+# those payloads. Rebuilding a 100 MiB buffer here purely to re-check the
+# exception type would double that cost for nothing.
+
+
+# --- the hierarchy itself ----------------------------------------------------
+
+
+@pytest.mark.parametrize("subtype", SUBTYPES, ids=lambda t: t.__name__)
+def test__every_subtype_inherits_parse_error(subtype: type):
+    assert issubclass(subtype, ParseError)
+
+
+@pytest.mark.parametrize("subtype", SUBTYPES, ids=lambda t: t.__name__)
+def test__subtypes_are_distinct(subtype: type):
+    others = [other for other in SUBTYPES if other is not subtype]
+    for other in others:
+        assert not issubclass(subtype, other), f"{subtype} must not be a {other}"
+
+
+# --- which failure raises which -----------------------------------------------
+
+
+def test__malformed_headers_raise_header_parse_error():
+    with pytest.raises(HeaderParseError):
+        parse_email(MALFORMED_HEADERS)
+
+
+def test__broken_transfer_encoding_raises_decode_error():
+    with pytest.raises(DecodeError):
+        parse_email(BROKEN_BASE64_BODY)
+
+
+# --- backwards compatibility --------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [MALFORMED_HEADERS, BROKEN_BASE64_BODY],
+    ids=["malformed_headers", "broken_base64"],
+)
+def test__catching_parse_error_still_catches_everything(payload: bytes):
+    # The contract existing callers were written against.
+    with pytest.raises(ParseError):
+        parse_email(payload)
+
+
+def test__a_decode_error_is_not_a_header_error():
+    # The point of the taxonomy: these two are told apart, not merged.
+    with pytest.raises(DecodeError):
+        parse_email(BROKEN_BASE64_BODY)
+
+    try:
+        parse_email(BROKEN_BASE64_BODY)
+    except ParseError as exc:
+        assert not isinstance(exc, HeaderParseError)
+        assert isinstance(exc, DecodeError)
+
+
+def test__messages_carry_the_underlying_detail():
+    try:
+        parse_email(BROKEN_BASE64_BODY)
+    except DecodeError as exc:
+        assert "Message parsing error" in str(exc)
+        assert str(exc) != "Message parsing error: "


### PR DESCRIPTION
Part of **#100** (item 1, the error taxonomy). Additive and backwards compatible. Items 2 and 3 — the `warnings` channel and `strict=True` — are untouched, so #100 stays open.

## Why

Error reporting was binary: one `ParseError` with a message string. That collapses three genuinely different situations, and a mail pipeline wants to treat them differently:

| Exception | Meaning | Reasonable response |
| --- | --- | --- |
| `HeaderParseError` | Header section did not parse | Input was probably never an email — reject |
| `MimeStructureError` | Malformed structure, or a cap tripped (>100 MiB, >256 levels) | Hostile or truncated — reject and maybe alert |
| `DecodeError` | One part's transfer encoding did not decode | Otherwise plausible message with a corrupt part — quarantine for review |

```python
try:
    mail = parse_email(raw)
except DecodeError:
    quarantine(raw)      # one part is corrupt
except ParseError:
    reject(raw)          # not parseable at all
```

All three subclass `ParseError`, so `except ParseError` keeps catching everything. That's **asserted, not assumed** — including a test that a decode failure is specifically *not* a header failure, since the whole point is that they're told apart.

## The interesting part: this cost 30% before it cost nothing

My first implementation threaded a typed `ParseFailure` enum through the parser, classifying at the point of failure. It was clean, and the benchmark gate rejected it:

| Design | Δ vs base |
| --- | --- |
| Typed error threaded through the parser | **+30.1%** ❌ |
| Same, but `Box`ed | **+12.1%** ❌ |
| Classified in the binding layer instead | **+0.4%** ✅ |

Wrapping `MailParseError` widened the `Result` carried by the per-part loop and the recursive MIME traversal. Boxing recovered most of it, which confirmed the mechanism — but not all, so the approach was wrong rather than merely unoptimised. **Paying for information that is only needed once, on failure, on every successful parse** is the wrong trade.

So classification moved to the cold side of the FFI boundary. The core is now byte-identical to master apart from naming two string constants.

## The classification is exact, not a heuristic

Checked against mailparse 0.16's source rather than assumed:

- Transfer-decoding lives in `body.rs` and only ever yields `Base64DecodeError`, `QuotedPrintableDecodeError` or `EncodingError` → **`DecodeError`**
- `Generic` is produced *solely* by the header-parsing paths in `lib.rs` → **`HeaderParseError`**
- Except the two caps this crate raises itself, matched by named shared constants → **`MimeStructureError`**

`addrparse`/`dateparse` also produce `Generic`, but this library already swallows those (`.ok()`), so they never reach the boundary.

## On the tests

I deliberately did **not** duplicate fixtures. The oversized-input, MIME-depth and broken-encoding paths already have payloads in `test_dos_limits.py` and `test_decode_errors.py`; those tests now assert the specific subtype instead of the base class. Rebuilding a 100 MiB buffer in a new file purely to re-check an exception type would have doubled that cost for nothing.

Net effect: existing tests got stronger rather than being shadowed by near-duplicates.

## Also

Fixes the **third** stale doc comment from the #122 classifier change — `parse_email`'s docstring still claimed the result "lists every node of the MIME tree". I corrected two in #123; this was the last.

## Footnote

This is the gate from #128 earning its cost. Under the previous absolute-ratio gate, whose between-runner noise was ~26%, a +30% regression would have been indistinguishable from a bad runner draw — and would very likely have shipped.