### PR TITLE
feat: parse_many for batch parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`parse_many`** — batch parsing in one FFI call, in parallel, results in input
+  order (#96). Each slot is a `PyMail` or a `ParseError` *instance*, returned
+  rather than raised, so one malformed message does not cost the caller the rest
+  of the batch; `raise_on_error=True` restores fail-fast. `threads` caps the
+  worker count. The GIL is released for the whole batch rather than per message.
+
+  Implemented on `std::thread::scope` with a shared atomic cursor rather than a
+  thread-pool dependency: it adds nothing to the lockfile or the licence
+  allowlist, and the cursor gives dynamic work distribution, which is the
+  property that matters when message sizes are uneven — static chunking stalls a
+  worker that draws several large messages.
+
+  Note that every parsed message is materialised before returning, so large
+  workloads should be chunked at the caller.
 - **A `ParseError` hierarchy** (part of #100): `HeaderParseError`,
   `MimeStructureError` and `DecodeError`, all inheriting from `ParseError` so
   `except ParseError` keeps catching everything. Failures are categorised where

--- a/Readme.md
+++ b/Readme.md
@@ -210,6 +210,36 @@ for cid in re.findall(r'cid:([^"\'>\s]+)', mail.text_html[0]):
 distinguishes an absent header (`None`) from an explicit `inline` — the two are
 different statements about intent.
 
+### Parsing a batch
+
+`parse_many` parses a whole batch in one call, in parallel, releasing the GIL for
+the batch rather than per message:
+
+```python
+from fast_mail_parser import ParseError, parse_many
+
+results = parse_many(payloads)              # list[str | bytes] in, results in input order
+results = parse_many(payloads, threads=8)   # cap the workers; default is the machine's
+```
+
+Each slot is a `PyMail` **or** a `ParseError` instance — returned, not raised —
+so one malformed message does not cost you the rest of the batch, and inputs zip
+cleanly to outcomes:
+
+```python
+for payload, outcome in zip(payloads, parse_many(payloads)):
+    if isinstance(outcome, ParseError):
+        quarantine(payload, reason=str(outcome))
+    else:
+        index(outcome)
+```
+
+Pass `raise_on_error=True` to raise the first failure instead.
+
+**Chunk large workloads.** Every parsed message is materialised before the call
+returns, so a batch of ten thousand one-megabyte mails holds essentially all of it
+decoded at once. Feed it in chunks of a few hundred rather than a whole mailbox.
+
 ### Error handling
 
 `parse_email` raises a subtype of `ParseError`, chosen by what actually went

--- a/fast_mail_parser/__init__.py
+++ b/fast_mail_parser/__init__.py
@@ -7,10 +7,12 @@ from .fast_mail_parser import (
     PyAttachment,
     PyMail,
     parse_email,
+    parse_many,
 )
 
 __all__ = [
     "parse_email",
+    "parse_many",
     "PyMail",
     "PyAttachment",
     "PyAddress",

--- a/fast_mail_parser/__init__.pyi
+++ b/fast_mail_parser/__init__.pyi
@@ -2,6 +2,7 @@ from datetime import datetime
 
 __all__ = [
     "parse_email",
+    "parse_many",
     "PyMail",
     "PyAttachment",
     "PyAddress",
@@ -157,3 +158,28 @@ def parse_email(payload: str | bytes) -> PyMail:
     all of them.
     """
 
+
+def parse_many(
+    payloads: list[str | bytes],
+    *,
+    threads: int | None = None,
+    raise_on_error: bool = False,
+) -> list[PyMail | ParseError]:
+    """Parse a batch of messages in one call, in parallel, in input order.
+
+    Each slot of the result is either a ``PyMail`` or a ``ParseError``
+    *instance* -- returned, not raised -- so one malformed message does not cost
+    the caller the rest of the batch, and inputs zip cleanly to outcomes::
+
+        for payload, outcome in zip(payloads, parse_many(payloads)):
+            if isinstance(outcome, ParseError):
+                ...
+
+    Pass ``raise_on_error=True`` to raise the first failure instead.
+
+    ``threads`` caps the worker count; the default is the machine's parallelism.
+    The GIL is released for the whole batch rather than per message.
+
+    Every parsed message is materialised before returning, so chunk large
+    workloads at the caller.
+    """

--- a/src/fast_mail_parser.rs
+++ b/src/fast_mail_parser.rs
@@ -18,9 +18,10 @@ mod mail_parser;
 
 use mailparse::MailParseError;
 use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyDateTime, PyString, PyTzInfo};
+use pyo3::types::{PyBytes, PyDateTime, PyList, PyString, PyTzInfo};
 use pyo3::{create_exception, exceptions, wrap_pyfunction};
 use std::collections::HashMap;
+use std::num::NonZeroUsize;
 
 create_exception!(fast_mail_parser, ParseError, exceptions::PyException);
 
@@ -282,9 +283,61 @@ pub fn parse_email(py: Python<'_>, payload: Py<PyAny>) -> PyResult<PyMail> {
     Ok(PyMail::from_mail(mail))
 }
 
+/// Parse a batch of messages in one call, in parallel, preserving input order.
+///
+/// Accepts the same `str`/`bytes` inputs as `parse_email`. Each slot of the
+/// result is either a `PyMail` or a `ParseError` **instance** -- returned, not
+/// raised -- so one malformed message cannot cost the caller the rest of the
+/// batch, and inputs zip cleanly to outcomes. `raise_on_error=True` restores
+/// fail-fast behaviour for callers who prefer it.
+///
+/// `threads` caps the worker count; the default is the machine's parallelism.
+///
+/// Memory: every parsed message is materialised before returning. A batch of ten
+/// thousand one-megabyte mails holds essentially all of it decoded at once, so
+/// chunk large workloads at the caller.
+#[pyfunction]
+#[pyo3(signature = (payloads, *, threads = None, raise_on_error = false))]
+pub fn parse_many(
+    py: Python<'_>,
+    payloads: Vec<Py<PyAny>>,
+    threads: Option<usize>,
+    raise_on_error: bool,
+) -> PyResult<Py<PyList>> {
+    // Convert every payload to owned bytes *before* releasing the GIL: this
+    // touches Python objects, and nothing may borrow from one while detached.
+    let messages: Vec<Vec<u8>> = payloads
+        .iter()
+        .map(|payload| payload_to_bytes(payload, py))
+        .collect::<PyResult<_>>()?;
+
+    let workers = threads.and_then(NonZeroUsize::new);
+
+    // The whole batch parses with the GIL released, so other Python threads keep
+    // running for its full duration rather than per message.
+    let parsed = py.detach(|| mail_parser::parse_many(&messages, workers));
+
+    let items = PyList::empty(py);
+    for result in parsed {
+        match result {
+            Ok(mail) => items.append(Py::new(py, PyMail::from_mail(mail))?)?,
+            Err(error) => {
+                let err = to_py_err(error);
+                if raise_on_error {
+                    return Err(err);
+                }
+                // The exception object itself, not a raise.
+                items.append(err.value(py))?;
+            }
+        }
+    }
+    Ok(items.unbind())
+}
+
 #[pymodule]
 fn fast_mail_parser(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(parse_email, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_many, m)?)?;
     m.add_class::<PyMail>()?;
     m.add_class::<PyAttachment>()?;
     m.add_class::<PyAddress>()?;

--- a/src/mail_parser.rs
+++ b/src/mail_parser.rs
@@ -100,7 +100,10 @@ pub(crate) fn parse_many(
             // than a malformed-input case. Resuming the unwind keeps the
             // behaviour identical to the single-message path, where PyO3 turns a
             // panic into a Python exception instead of losing it.
-            .map(|handle| handle.join().unwrap_or_else(std::panic::resume_unwind))
+            .map(|handle| match handle.join() {
+                Ok(results) => results,
+                Err(payload) => std::panic::resume_unwind(payload),
+            })
             .collect()
     });
 

--- a/src/mail_parser.rs
+++ b/src/mail_parser.rs
@@ -13,6 +13,9 @@
 use charset::{decode_ascii, Charset};
 use mailparse::*;
 use std::collections::HashMap;
+use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
 
 // DoS hardening: `parse_email` runs on untrusted input. The two constants below
 // bound otherwise-unbounded resource use. Both limits sit far above any
@@ -36,6 +39,81 @@ pub(crate) const ERR_MIME_DEPTH: &str = "MIME nesting exceeds maximum allowed de
 
 pub(crate) fn parse_email(payload: &[u8]) -> Result<Mail, MailParseError> {
     Mail::new(payload)
+}
+
+/// Parse a batch of messages in parallel, preserving input order.
+///
+/// One result per input, each independently `Ok` or `Err`, so a single malformed
+/// message cannot fail the batch.
+///
+/// Uses `std::thread::scope` and a shared atomic cursor rather than a thread
+/// pool crate. Two reasons: it adds no dependency -- which keeps the lockfile
+/// and the licence allowlist untouched -- and the cursor gives *dynamic* work
+/// distribution, which is the property that actually matters here. Static
+/// chunking would stall a worker that happened to draw several large messages,
+/// and real mail batches are very uneven in size.
+///
+/// `threads` caps the worker count; `None` uses the machine's parallelism.
+/// Callers with a batch smaller than the thread count do not spawn idle workers.
+pub(crate) fn parse_many(
+    payloads: &[Vec<u8>],
+    threads: Option<NonZeroUsize>,
+) -> Vec<Result<Mail, MailParseError>> {
+    if payloads.is_empty() {
+        return Vec::new();
+    }
+
+    let available = threads
+        .or_else(|| thread::available_parallelism().ok())
+        .map_or(1, NonZeroUsize::get);
+    // Never more workers than there is work for them to do.
+    let workers = available.min(payloads.len()).max(1);
+
+    if workers == 1 {
+        return payloads.iter().map(|payload| Mail::new(payload)).collect();
+    }
+
+    let cursor = AtomicUsize::new(0);
+    let collected: Vec<Vec<(usize, Result<Mail, MailParseError>)>> = thread::scope(|scope| {
+        let handles: Vec<_> = (0..workers)
+            .map(|_| {
+                scope.spawn(|| {
+                    // Each worker claims indices until the batch is exhausted and
+                    // keeps its own results, so no synchronisation is needed on
+                    // the output and no `unsafe` is involved.
+                    let mut mine = Vec::new();
+                    loop {
+                        let index = cursor.fetch_add(1, Ordering::Relaxed);
+                        if index >= payloads.len() {
+                            break;
+                        }
+                        mine.push((index, Mail::new(&payloads[index])));
+                    }
+                    mine
+                })
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            // A worker only panics if the parser does, which is a bug rather
+            // than a malformed-input case. Resuming the unwind keeps the
+            // behaviour identical to the single-message path, where PyO3 turns a
+            // panic into a Python exception instead of losing it.
+            .map(|handle| handle.join().unwrap_or_else(std::panic::resume_unwind))
+            .collect()
+    });
+
+    // Restore input order. Slots are filled exactly once, so no gaps.
+    let mut ordered: Vec<Option<Result<Mail, MailParseError>>> =
+        (0..payloads.len()).map(|_| None).collect();
+    for (index, result) in collected.into_iter().flatten() {
+        ordered[index] = Some(result);
+    }
+    ordered
+        .into_iter()
+        .map(|slot| slot.expect("every index is claimed exactly once"))
+        .collect()
 }
 
 /// Decode already-transfer-decoded `body` bytes into a `String` using the part's

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -19,6 +19,7 @@ from fast_mail_parser import ParseError, PyAttachment, PyMail, parse_email
 
 EXPECTED_EXPORTS = {
     "parse_email",
+    "parse_many",
     "ParseError",
     "HeaderParseError",
     "MimeStructureError",

--- a/tests/test_parse_many.py
+++ b/tests/test_parse_many.py
@@ -1,0 +1,172 @@
+"""Tests for `parse_many`, the batch API.
+
+Contract:
+- One result per input, in input order.
+- Each slot is a `PyMail` or a `ParseError` *instance* -- returned, not raised --
+  so one malformed message does not cost the caller the rest of the batch.
+- `raise_on_error=True` raises the first failure instead.
+- `threads` caps the worker count.
+- The GIL is released for the whole batch, not per message.
+"""
+
+import threading
+import time
+
+import pytest
+
+from fast_mail_parser import DecodeError, ParseError, PyMail, parse_email, parse_many
+
+
+def _message(subject: str) -> bytes:
+    return (
+        f"Subject: {subject}\r\n"
+        "From: sender@example.com\r\n"
+        "Content-Type: text/plain; charset=utf-8\r\n"
+        "\r\n"
+        f"body of {subject}\r\n"
+    ).encode()
+
+
+BROKEN = (
+    b"Subject: broken\r\n"
+    b"Content-Type: text/plain; charset=utf-8\r\n"
+    b"Content-Transfer-Encoding: base64\r\n"
+    b"\r\n"
+    b"!!!! not base64 !!!!\r\n"
+)
+
+
+# --- ordering and basic shape -------------------------------------------------
+
+
+def test__empty_batch_returns_empty_list():
+    assert parse_many([]) == []
+
+
+def test__results_are_in_input_order():
+    payloads = [_message(f"msg-{i:03d}") for i in range(50)]
+
+    results = parse_many(payloads)
+
+    assert len(results) == len(payloads)
+    assert [r.subject for r in results] == [f"msg-{i:03d}" for i in range(50)]
+
+
+def test__accepts_mixed_str_and_bytes():
+    payloads = [_message("as-bytes"), _message("as-str").decode("utf-8")]
+
+    results = parse_many(payloads)
+
+    assert [r.subject for r in results] == ["as-bytes", "as-str"]
+    assert all(isinstance(r, PyMail) for r in results)
+
+
+def test__matches_parse_email_one_by_one():
+    payloads = [_message(f"m{i}") for i in range(10)]
+
+    batch = parse_many(payloads)
+    single = [parse_email(p) for p in payloads]
+
+    assert [m.subject for m in batch] == [m.subject for m in single]
+    assert [m.text_plain for m in batch] == [m.text_plain for m in single]
+
+
+# --- per-item errors ----------------------------------------------------------
+
+
+def test__one_malformed_message_does_not_fail_the_batch():
+    payloads = [_message("first"), BROKEN, _message("third")]
+
+    results = parse_many(payloads)
+
+    assert len(results) == 3
+    assert results[0].subject == "first"
+    assert isinstance(results[1], ParseError), "the error belongs in its own slot"
+    assert results[2].subject == "third"
+
+
+def test__the_error_slot_holds_the_specific_subtype():
+    results = parse_many([BROKEN])
+
+    assert isinstance(results[0], DecodeError)
+    assert isinstance(results[0], ParseError)
+    assert "Message parsing error" in str(results[0])
+
+
+def test__errors_land_in_the_right_slots():
+    # Broken at every third position, so a mis-ordered implementation shows up.
+    payloads = [BROKEN if i % 3 == 0 else _message(f"ok-{i}") for i in range(12)]
+
+    results = parse_many(payloads)
+
+    for index, result in enumerate(results):
+        if index % 3 == 0:
+            assert isinstance(result, ParseError), f"slot {index} should be an error"
+        else:
+            assert result.subject == f"ok-{index}", f"slot {index} misplaced"
+
+
+def test__raise_on_error_raises_the_first_failure():
+    payloads = [_message("fine"), BROKEN, _message("also fine")]
+
+    with pytest.raises(DecodeError):
+        parse_many(payloads, raise_on_error=True)
+
+
+def test__raise_on_error_is_quiet_when_everything_parses():
+    payloads = [_message("a"), _message("b")]
+
+    results = parse_many(payloads, raise_on_error=True)
+
+    assert [r.subject for r in results] == ["a", "b"]
+
+
+# --- threads ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("threads", [1, 2, 4, 64])
+def test__thread_cap_does_not_change_results(threads: int):
+    payloads = [_message(f"t-{i}") for i in range(30)]
+
+    results = parse_many(payloads, threads=threads)
+
+    assert [r.subject for r in results] == [f"t-{i}" for i in range(30)]
+
+
+def test__batch_smaller_than_the_thread_cap_is_fine():
+    # Must not spawn idle workers or mis-handle the short batch.
+    results = parse_many([_message("only")], threads=32)
+
+    assert [r.subject for r in results] == ["only"]
+
+
+# --- the GIL is released for the batch ----------------------------------------
+
+
+def test__gil_is_released_for_the_duration_of_the_batch():
+    # A Python thread must keep making progress while a large batch parses. If
+    # the GIL were held for the batch, this counter would barely move.
+    # Pattern follows the single-message GIL test from #91.
+    payloads = [_message(f"gil-{i}") * 20 for i in range(400)]
+    counter = 0
+    stop = False
+
+    def spin():
+        nonlocal counter
+        while not stop:
+            counter += 1
+            time.sleep(0)
+
+    ticker = threading.Thread(target=spin, daemon=True)
+    ticker.start()
+    try:
+        before = counter
+        parse_many(payloads)
+        progressed = counter - before
+    finally:
+        stop = True
+        ticker.join(timeout=5)
+
+    assert progressed > 0, (
+        "a Python thread made no progress during the batch, so the GIL was held"
+    )


### PR DESCRIPTION
Closes **#96** — the roadmap's highest-priority item, and the first of Phase 1.

One FFI call for a whole batch, parsed in parallel, results in input order, GIL released once for the batch rather than per message.

```python
results = parse_many(payloads)                # in input order
results = parse_many(payloads, threads=8)     # cap the workers

for payload, outcome in zip(payloads, results):
    if isinstance(outcome, ParseError):
        quarantine(payload, reason=str(outcome))
```

Each slot is a `PyMail` **or** a `ParseError` *instance* — returned, not raised — so one malformed message can't cost the caller the rest of the batch. The slot carries the specific subtype from #135, so a corrupt attachment is distinguishable from unparseable bytes without re-parsing. `raise_on_error=True` restores fail-fast.

## Why not rayon, which the issue suggested

Two reasons, and the second is the substantive one.

**It adds no dependency.** That matters more than usual here: adding a Rust dependency means hand-writing its transitive tree into `Cargo.lock` with correct checksums (no `cargo` available to me), and the supply-chain gate from #132 reads that file.

**A shared atomic cursor gives the property rayon is actually wanted for.** The alternative to work-stealing isn't "slower parallelism", it's *static chunking* — which stalls a worker that happens to draw several large messages. Real mail batches are very uneven in size, so that matters. A claim-next-index loop gets dynamic distribution in a few lines of `std`:

```rust
let index = cursor.fetch_add(1, Ordering::Relaxed);
if index >= payloads.len() { break; }
mine.push((index, Mail::new(&payloads[index])));
```

Each worker keeps its own results and they're merged by index afterwards, so there's no synchronisation on the output and no `unsafe`.

If a future need appears that `std` genuinely can't serve — nested parallelism, say — rayon can be revisited then, with the lockfile work done deliberately.

## Edge cases handled

- Workers never outnumber the batch (a 1-message batch with `threads=32` doesn't spawn 32 workers).
- A single-worker batch skips threading altogether.
- A worker panic **resumes the unwind** rather than dropping results, so behaviour matches the single-message path where PyO3 converts it to a Python exception.
- Payloads are converted to owned bytes *before* the GIL is released — nothing may borrow from a Python object while detached.

## Tests

Ordering under load, mixed `str`/`bytes`, equivalence with `parse_email` message-by-message, an error in its own slot, the specific subtype in that slot, `raise_on_error` both ways, thread caps including one larger than the batch, and the GIL-release check from #91 (a Python thread must keep progressing during a large batch).

One deliberate choice: errors are placed at **scattered positions** (every third) rather than one in the middle, so a mis-ordered implementation is caught rather than passing by luck.

## Acceptance (#96)

- [x] Order-preserved results for mixed `str`/`bytes`
- [x] Per-item errors; `raise_on_error=True` raises the first failure
- [x] `threads` caps the worker count; default documented
- [x] GIL released for the batch duration (thread-progress test)
- [x] Stubs / `__all__` updated; mypy --strict, ruff clean
- [x] README batch section with the chunking guidance; CHANGELOG entry
- [ ] **Benchmark vs `ThreadPoolExecutor` recorded** — I'll post measured numbers in a comment below rather than add a permanent large-batch benchmark to the gate job, which would slow every PR for a figure that only matters here. Flagging it as the one criterion not met in-tree.

Deviations from the issue text: `std` instead of rayon (above), and `threads`/`raise_on_error` are keyword-only, since positional booleans at a call site read poorly.