### PR TITLE
build(deps-dev): bump mail-parser 3.15.0 -> 4.6.4, and regenerate the table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Bumped the benchmark baseline `mail-parser` 3.15.0 -> 4.6.4 (test dependency
+  only). The published comparison table names the version it was measured
+  against, so it is regenerated alongside.
 - **`parse_many`** — batch parsing in one FFI call, in parallel, results in input
   order (#96). Each slot is a `PyMail` or a `ParseError` *instance*, returned
   rather than raised, so one malformed message does not cost the caller the rest

--- a/Readme.md
+++ b/Readme.md
@@ -102,18 +102,19 @@ attachments with their payloads decoded — on the same message:
 
 | Library | Work performed | Min time | Relative |
 | --- | --- | --- | --- |
-| **fast_mail_parser** | parse + decode bodies + decode attachments | 1.40 ms | 1.00x |
-| mail-parser | `from_string` + `.parse()` + read attributes | 11.90 ms | 8.50x |
-| stdlib `email` | `message_from_bytes` + walk + `get_content` / `get_payload` | 14.01 ms | 10.01x |
+| **fast_mail_parser** | parse + decode bodies + decode attachments | 2.09 ms | 1.00x |
+| mail-parser | `from_string` + `.parse()` + read attributes | 13.45 ms | 6.44x |
+| stdlib `email` | `message_from_bytes` + walk + `get_content` / `get_payload` | 17.93 ms | 8.59x |
 
 Corpus: `tests/data/large_message.eml` (multipart/mixed, 6 MIME parts, 2 base64
 attachments). CPython 3.12.14 on Linux x86_64 (GitHub Actions `ubuntu-latest`),
-mail-parser 3.15.0, minimum of 45+ rounds.
+mail-parser 4.6.4, minimum of 31+ rounds.
 
 **These ratios move with the hardware, so treat them as a magnitude rather than a
-constant.** The identical comparison on an Apple Silicon laptop gives 5.25x and
-6.42x instead of 8.50x and 10.01x: the interpreted parsers and the Rust extension
-do not scale together across CPUs. Regenerate the table for your own machine with
+constant.** An earlier run of this same comparison on a faster CI runner recorded
+8.50x and 10.01x rather than 6.44x and 8.59x, and an Apple Silicon laptop gives
+5.25x and 6.42x: the interpreted parsers and the Rust extension do not scale
+together across CPUs. Regenerate the table for your own machine with
 `make bench-table`, which prints its own methodology line; CI also renders it
 into the job summary of every benchmark run.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
-test = ["pytest>=7.4.4,<9.2.0", "pytest-benchmark==5.2.3", "mail-parser==3.15.0"]
+test = ["pytest>=7.4.4,<9.2.0", "pytest-benchmark==5.2.3", "mail-parser==4.6.4"]
 
 [project.urls]
 Homepage = "https://github.com/namecheap/fast_mail_parser"


### PR DESCRIPTION
Supersedes #142. Test dependency only — no shipped code changes.

## Why by hand

#142 could no longer be rebased: **#141 edited the same `test = [...]` line** in `pyproject.toml`, so dependabot's branch conflicted and `gh pr update-branch` returned *"Cannot update PR branch due to conflicts"*. Dependabot can't resolve that itself.

Carrying it manually also lets the **consequence travel with the bump**: the published comparison table states the baseline version it was measured against, so bumping mail-parser without regenerating the table would leave the README quoting numbers for a version no longer installed.

Numbers here come from #142's own CI run — i.e. exactly this dependency set.

## On the ratios dropping

8.50x/10.01x → 6.44x/8.59x, but that is **not** like-for-like: that run measured `fast_mail_parser` at 2.09 ms against 1.40 ms in the earlier one, so the runner was substantially slower. The library effect and the runner effect can't be separated from a single pair of runs, so I haven't attributed the change to mail-parser 4.x.

The note beside the table now cites **both** CI figures alongside the laptop ones, rather than implying the difference is the library.

## The other two dependabot PRs

- **#139** (pyo3 0.29.0 → 0.29.2) — rebased and merged. Its benchmark failure did not survive the rebase: **+16.1% before, +1.6% after**, same change. Worth knowing about the gate: the "~0.3% within-job noise" in `check_benchmark.py` was measured by re-running the benchmark against *one* build. The gate builds *two* binaries and measures them minutes apart, so it also carries whatever the runner does in between. A lone red gate deserves a re-run before being treated as a verdict — real effects have reproduced consistently (+30% twice on #135, +30/+31% on the toolchain A/B).
- **#141** (pytest-benchmark 4.0.0 → 5.2.3) — merged. A major bump of the tool whose JSON `check_benchmark.py` parses, so the passing benchmark gate on that PR was the thing worth checking; it confirms the report schema still reads.