### PR TITLE
docs: say when parse_many helps, with measured numbers

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -241,6 +241,29 @@ Pass `raise_on_error=True` to raise the first failure instead.
 returns, so a batch of ten thousand one-megabyte mails holds essentially all of it
 decoded at once. Feed it in chunks of a few hundred rather than a whole mailbox.
 
+#### When it helps
+
+`parse_email` already releases the GIL, so a Python thread pool over it is
+already parallel. What `parse_many` removes on top of that is per-call FFI and
+scheduling overhead — which is proportional to the **number** of messages, while
+its one cost, copying each payload before parsing starts, is proportional to
+**total bytes**. Measured against `ThreadPoolExecutor(max_workers=4)` +
+`parse_email` on a 4-vCPU runner, best of 5:
+
+| Messages | Size each | Total | vs thread pool |
+| --- | --- | --- | --- |
+| 2000 | 1 KB | 2.1 MB | **12x faster** |
+| 400 | 50 KB | 20 MB | 1.2x slower |
+| 200 | 786 KB | 157 MB | 1.5x slower |
+
+So **use `parse_many` for many small messages** — the mail-pipeline case, where
+messages are usually single-digit KB. For a few very large messages a thread pool
+is currently faster, because the serial copy dominates. Removing that copy is
+tracked in [#96](https://github.com/namecheap/fast_mail_parser/issues/96).
+
+These are ratios on one machine; re-measure for your own mix rather than trusting
+the crossover point.
+
 ### Error handling
 
 `parse_email` raises a subtype of `ParseError`, chosen by what actually went

--- a/fast_mail_parser/__init__.pyi
+++ b/fast_mail_parser/__init__.pyi
@@ -182,4 +182,10 @@ def parse_many(
 
     Every parsed message is materialised before returning, so chunk large
     workloads at the caller.
+
+    Best suited to **many small messages**: the overhead it removes scales with
+    the message count, while its one cost -- copying each payload before parsing
+    begins -- scales with total bytes. For a few very large messages a Python
+    thread pool over ``parse_email`` is currently faster. See the README for
+    measured figures.
     """


### PR DESCRIPTION
Docs only. Follows the size sweep on #96.

## The gap

The batch section explained *how* to call `parse_many` and warned about memory, but said nothing about *when* it is the right tool — and it turns out to be strongly regime-dependent, which nobody could infer from the API.

Measured against `ThreadPoolExecutor(max_workers=4)` + `parse_email`, 4-vCPU runner, best of 5:

| Messages | Size each | Total | vs thread pool |
| --- | --- | --- | --- |
| 2000 | 1 KB | 2.1 MB | **12x faster** |
| 400 | 50 KB | 20 MB | 1.2x slower |
| 200 | 786 KB | 157 MB | 1.5x slower |

## Why that shape

`parse_email` already releases the GIL, so a Python thread pool over it is *already* parallel. What `parse_many` additionally removes is per-call FFI and scheduling overhead — proportional to the **number** of messages. Its one cost, copying every payload before parsing begins, is proportional to **total bytes**.

Two effects pulling opposite ways: many small messages win big, a few large ones lose.

## Why I'm documenting it rather than just fixing it

Because I got this wrong myself, twice, and a user could easily repeat it.

My first benchmark used 200 × 786 KB — close to the worst case the API can be handed — and I concluded from it that the feature didn't deliver its purpose, reopened #96, and put that in the v0.7.0 release notes. It delivers **12x** in the regime it was actually written for: mail pipelines, where messages are usually single-digit KB.

An API whose performance inverts across its input range needs that written down, not just optimised later.

The stub carries a shorter version of the same warning, and both point at #96 for the large-message work (removing the serial copy). Numbers are labelled as one machine's ratios with advice to re-measure, since the crossover point isn't portable.

I'll also correct the v0.7.0 release notes, which currently mention only the pessimistic half.