### PR TITLE
docs: record the thread-safety invariant the #101 audit rests on

### DIFF
--- a/src/mail_parser.rs
+++ b/src/mail_parser.rs
@@ -5,6 +5,19 @@
 //! Python or PyO3, so it can be exercised and unit-tested independently of any
 //! Python runtime.
 //!
+//! ## Thread-safety invariant
+//!
+//! This module holds **no shared mutable state**: no `static mut`, no
+//! `OnceCell`/`OnceLock`, no `thread_local`, no interior mutability, and no
+//! `unsafe`. Every `static` here is a `const`. `parse_email` is a pure function
+//! of `&[u8]`, and `parse_many`'s workers each keep their own results,
+//! coordinating only through an atomic cursor.
+//!
+//! That is load-bearing, not incidental. It is what makes the free-threaded
+//! safety audit on issue #101 hold, and it is why `parse_many` needs no locking.
+//! **Introducing shared mutable state here -- a decode cache being the obvious
+//! candidate, see issue #97 -- invalidates that audit and must re-open it.**
+//!
 //! The companion `fast_mail_parser` module is the **PyO3 binding layer**:
 //! `PyMail`/`PyAttachment` wrap these core types and convert them into Python
 //! objects. Keeping the two models separate decouples the parsing logic from the


### PR DESCRIPTION
Documentation only — a module doc comment.

The free-threaded safety audit I just posted on #101 concluded this crate holds **no shared mutable state**: no `static mut`, no `OnceCell`/`OnceLock`, no `thread_local`, no interior mutability, no `unsafe`, and every `static` a `const`.

That conclusion currently lives in an issue comment — where the person most likely to invalidate it will never look.

The obvious way to break it is to add a **decode cache**, which is exactly what the lazy-parsing work in #97 proposes, and #101 already names that as *the* shared-state risk. So the invariant now sits in the module that has to keep it, stating plainly that introducing shared mutable state re-opens the audit.

It also explains why `parse_many` needs no locking — otherwise a surprising property of a function that spawns threads, and one a future reader might "fix" by adding a `Mutex` that isn't needed.