### PR TITLE
docs: give the parse_many worst case its spread, not one number

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -261,8 +261,12 @@ messages are usually single-digit KB. For a few very large messages a thread poo
 is currently faster, because the serial copy dominates. Removing that copy is
 tracked in [#96](https://github.com/namecheap/fast_mail_parser/issues/96).
 
-These are ratios on one machine; re-measure for your own mix rather than trusting
-the crossover point.
+The size at which it flips is not portable, and neither is how much the bad case
+costs: the copy competes with memory bandwidth and the parse scales with cores.
+The 200 × 786 KB case above measures **1.5x slower** on that 4-vCPU runner but
+only **1.05x slower** on a 10-core laptop — near enough a wash. So treat the
+table as the shape of the trade-off, and measure your own mix before ruling
+`parse_many` out for large messages.
 
 ### Error handling
 


### PR DESCRIPTION
Docs only. Follows the confirmed measurement on #96.

The guidance quoted a single figure for the large-message case — **1.5x slower** — measured on a 4-vCPU CI runner. On a 10-core laptop the same comparison is **1.05x**, near enough a wash.

That difference changes a reader's decision: "1.5x slower" is a reason to avoid the API; "1.05x" isn't. And which one they see depends on their machine.

The mechanism is the same asymmetry already documented for the cross-library table — the copy competes with memory bandwidth while the parse scales with cores — so **the worst case is no more portable than the crossover point**. Publishing one number implied a precision the measurement doesn't have.

Both figures now appear, with the advice to measure rather than rule `parse_many` out on someone else's hardware.