### PR TITLE
docs: say what invalid_message.eml actually is

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,24 @@ def valid_message(read_mail: Callable) -> str:
 
 @pytest.fixture
 def invalid_message(read_mail: Callable) -> str:
+    """A malformed real-world message that nonetheless PARSES.
+
+    The name is misleading and has cost real time: `parse_email` does not raise
+    on this file. It is malformed in that its header block is never terminated --
+    a folded continuation line (` hello`) is followed directly by the MIME
+    boundary with no blank line between them.
+
+    The consequence is silent: the boundary is consumed as a header field, so the
+    `multipart/alternative` declared in Content-Type finds zero parts and the body
+    disappears. `text_plain` comes back empty and `headers` contains one entry
+    whose key is the boundary delimiter. The stdlib recovers the body; we do not.
+    Tracked in #150.
+
+    So this is not a substitute for a parse failure. Use an inline payload with a
+    broken transfer encoding for that -- see `tests/test_error_taxonomy.py`.
+    The stdlib-parity suite excludes this fixture for the same reason: the two
+    parsers disagree about it rather than either rejecting it.
+    """
     return read_mail('tests/data/invalid_message.eml')
 
 


### PR DESCRIPTION
Documentation only — a fixture docstring.

## Why

The name promises a message that fails to parse. **It parses.** That cost me two wrong assumptions in a single day:

- a comment I added to the stdlib-parity suite ("it exists to fail parsing")
- a `parse_many` test that asserted it produces a `ParseError`, and failed in CI

Both are corrected in #149. But the fixture is consumed by **no test at all**, so nothing exercised or documented the discrepancy — which is precisely how a misleading name survives long enough to mislead twice.

## What it actually is

A real-world message whose header block is never terminated: a folded continuation line (` hello`) is followed directly by the MIME boundary with no blank line between them.

The consequence is silent. The boundary gets consumed as a header field, so the `multipart/alternative` declared in `Content-Type` finds zero parts, the body disappears, and `headers` gains an entry whose key is the boundary delimiter. The stdlib recovers the body; we don't. Tracked in **#150**.

## Also in the docstring

What to use *instead* for an actual parse failure (an inline broken transfer encoding — see `test_error_taxonomy.py`), and why the parity suite excludes this fixture: the two parsers disagree about it rather than either rejecting it.

Put in the file where the mistake is available to be made, rather than only in an issue — same reasoning as the thread-safety invariant in #147.