### PR TITLE
fix: reject parse_many(threads=0) instead of silently defaulting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `parse_many(payloads, threads=0)` now raises `ValueError` instead of silently
+  behaving as `threads=None`. Treating 0 as "the machine's default" hid caller
+  bugs: `threads=os.cpu_count() - 1` on a one-core machine, or an unset config
+  value, quietly got full parallelism. Pass `None` to ask for the default. A
+  negative value already raised `OverflowError` at conversion.
+
 ## [0.7.0] - 2026-08-26
 
 ### Breaking

--- a/Readme.md
+++ b/Readme.md
@@ -221,6 +221,7 @@ from fast_mail_parser import ParseError, parse_many
 
 results = parse_many(payloads)              # list[str | bytes] in, results in input order
 results = parse_many(payloads, threads=8)   # cap the workers; default is the machine's
+                                            # threads=0 raises; use None for the default
 ```
 
 Each slot is a `PyMail` **or** a `ParseError` instance — returned, not raised —

--- a/fast_mail_parser/__init__.pyi
+++ b/fast_mail_parser/__init__.pyi
@@ -178,7 +178,8 @@ def parse_many(
     Pass ``raise_on_error=True`` to raise the first failure instead.
 
     ``threads`` caps the worker count; the default is the machine's parallelism.
-    The GIL is released for the whole batch rather than per message.
+    ``threads=0`` raises ``ValueError`` -- pass ``None`` for the default. The GIL
+    is released for the whole batch rather than per message.
 
     Every parsed message is materialised before returning, so chunk large
     workloads at the caller.

--- a/src/fast_mail_parser.rs
+++ b/src/fast_mail_parser.rs
@@ -292,6 +292,7 @@ pub fn parse_email(py: Python<'_>, payload: Py<PyAny>) -> PyResult<PyMail> {
 /// fail-fast behaviour for callers who prefer it.
 ///
 /// `threads` caps the worker count; the default is the machine's parallelism.
+/// `threads=0` is rejected -- pass `None` to ask for the default.
 ///
 /// Memory: every parsed message is materialised before returning. A batch of ten
 /// thousand one-megabyte mails holds essentially all of it decoded at once, so
@@ -311,7 +312,19 @@ pub fn parse_many(
         .map(|payload| payload_to_bytes(payload, py))
         .collect::<PyResult<_>>()?;
 
-    let workers = threads.and_then(NonZeroUsize::new);
+    // `threads=0` is meaningless, and silently treating it as "the default"
+    // hides a caller bug: `threads=os.cpu_count() - 1` on a one-core machine, or
+    // an unset config value, would quietly get full parallelism instead. Reject
+    // it and let `None` be the way to ask for the default. `threads` is unsigned,
+    // so a negative value already raises OverflowError at conversion.
+    let workers = match threads {
+        Some(0) => {
+            return Err(exceptions::PyValueError::new_err(
+                "threads must be at least 1; pass threads=None for the default",
+            ));
+        }
+        other => other.and_then(NonZeroUsize::new),
+    };
 
     // The whole batch parses with the GIL released, so other Python threads keep
     // running for its full duration rather than per message.

--- a/tests/test_parse_many.py
+++ b/tests/test_parse_many.py
@@ -245,3 +245,47 @@ def test__gil_is_released_for_the_duration_of_the_batch():
     assert progressed > 0, (
         "a Python thread made no progress during the batch, so the GIL was held"
     )
+
+
+# --- argument contract -------------------------------------------------------
+
+
+def test__threads_zero_is_rejected():
+    # Silently meaning "the default" would hide a caller bug such as
+    # threads=os.cpu_count() - 1 on a one-core machine.
+    with pytest.raises(ValueError, match="threads must be at least 1"):
+        parse_many([_message("x")], threads=0)
+
+
+def test__negative_threads_is_rejected():
+    # `threads` is unsigned on the Rust side, so this fails at conversion.
+    with pytest.raises(OverflowError):
+        parse_many([_message("x")], threads=-1)
+
+
+def test__absurdly_large_thread_cap_is_harmless():
+    # Workers never outnumber the batch, so this must not try to spawn a billion.
+    results = parse_many([_message("a"), _message("b")], threads=10**9)
+
+    assert [r.subject for r in results] == ["a", "b"]
+
+
+@pytest.mark.parametrize(
+    "bad", [123, None, object()], ids=["int", "None", "object"]
+)
+def test__non_payload_entries_raise_type_error(bad: object):
+    with pytest.raises(TypeError):
+        parse_many([_message("ok"), bad])
+
+
+def test__a_sequence_other_than_a_list_is_accepted():
+    # The signature says list, but any Sequence works; a tuple is the common one.
+    results = parse_many((_message("a"), _message("b")))
+
+    assert [r.subject for r in results] == ["a", "b"]
+
+
+def test__threads_and_raise_on_error_are_keyword_only():
+    # Positional booleans at a call site read poorly, so they are keyword-only.
+    with pytest.raises(TypeError):
+        parse_many([_message("x")], 2)


### PR DESCRIPTION
`parse_many` shipped in 0.7.0 with **no coverage of its argument contract**. Probing it against the published wheel turned up one value that behaves badly:

| Argument | Behaviour | |
| --- | --- | --- |
| `threads=None` | default | ok |
| `threads=1` | one worker | ok |
| **`threads=0`** | **silently the default** | **wrong** |
| `threads=-1` | `OverflowError` | ok |
| `threads=10**9` | capped at batch size | ok |

## Why 0 should raise

Zero is not a meaningful worker count, and quietly promoting it to "the machine's parallelism" hides the bug at the call site rather than reporting it. Two realistic ways to get there:

```python
parse_many(batch, threads=os.cpu_count() - 1)   # 0 on a one-core box
parse_many(batch, threads=cfg.get("threads", 0)) # unset config
```

Both silently get **full parallelism** — the opposite of the caller's intent, and invisible. Now a `ValueError`, with `None` remaining the way to ask for the default.

Technically a behaviour change to a function one release old, but nothing can reasonably depend on `0` meaning "use every core".

## The rest of the contract was already sound

Now covered rather than assumed: negative rejected, an absurd cap harmless (workers never outnumber the batch — the guard I added in #143), non-payload entries raising `TypeError` with a clear message, a tuple accepted since any `Sequence` works, and `threads`/`raise_on_error` being keyword-only.

Worth noting a non-obvious one that is *correct*: a generator raises `TypeError` rather than being consumed, because the signature requires a `Sequence`. That's the right call for an API that needs a length up front, and the stub already says `list[str | bytes]`.

## Verification

Every case was probed against the published 0.7.0 wheel **before** writing the assertions, so the tests describe measured behaviour rather than expected behaviour.