### PR TITLE
test: pin two packaging invariants that fail silently

### DIFF
--- a/tests/test_packaging_invariants.py
+++ b/tests/test_packaging_invariants.py
@@ -1,0 +1,81 @@
+"""Invariants the project relies on but never checked.
+
+Both of these are silent when broken: nothing raises, no test elsewhere notices,
+and the damage shows up outside CI -- in a consumer's type checker, or in a
+fixture that no longer matches the generator that is supposed to reproduce it.
+"""
+
+import functools
+import importlib.util
+import pathlib
+
+import pytest
+
+import fast_mail_parser as runtime
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+RFC_DIR = REPO / "tests" / "data" / "rfc"
+GENERATOR = REPO / "tests" / "generate_rfc_corpus.py"
+
+
+# --- PEP 561: the stub is only honoured if py.typed ships --------------------
+
+
+def test__py_typed_ships_with_the_installed_package():
+    # Without this marker, PEP 561 says type checkers must ignore __init__.pyi
+    # entirely -- so the stub, and the test that keeps it honest, would both be
+    # checking something no consumer ever sees. Asserted against the *installed*
+    # package, since that is what gets shipped.
+    installed = pathlib.Path(runtime.__file__).parent
+
+    assert (installed / "py.typed").is_file(), (
+        f"py.typed missing from the installed package at {installed}; "
+        "type checkers will ignore __init__.pyi"
+    )
+
+
+def test__the_stub_ships_with_the_installed_package():
+    installed = pathlib.Path(runtime.__file__).parent
+
+    assert (installed / "__init__.pyi").is_file(), (
+        "__init__.pyi is not packaged, so consumers get no types at all"
+    )
+
+
+# --- the RFC corpus must still be what its generator produces ----------------
+
+
+@functools.lru_cache(maxsize=1)
+def _load_generator():
+    # Loaded by path rather than imported: conftest.py pops the rootdir from
+    # sys.path, so `import generate_rfc_corpus` is not reliable here.
+    spec = importlib.util.spec_from_file_location("generate_rfc_corpus", GENERATOR)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize("name", sorted(_load_generator().BUILDERS))
+def test__committed_fixture_matches_its_generator(name: str):
+    # generate_rfc_corpus.py promises deterministic output so the corpus can be
+    # regenerated and reviewed as a diff. That only holds if nobody has
+    # hand-edited a fixture in the meantime, which nothing was checking.
+    builder = _load_generator().BUILDERS[name]
+    path = RFC_DIR / f"{name}.eml"
+
+    assert path.is_file(), f"{name} is in BUILDERS but has no committed fixture"
+    assert path.read_bytes() == builder().as_bytes(), (
+        f"{name}.eml differs from what generate_rfc_corpus.py produces -- either "
+        "it was hand-edited, or the generator changed without the corpus being "
+        "regenerated"
+    )
+
+
+def test__every_committed_fixture_has_a_builder():
+    committed = {path.stem for path in RFC_DIR.glob("*.eml")}
+    builders = set(_load_generator().BUILDERS)
+
+    assert committed == builders, (
+        f"orphaned fixtures {sorted(committed - builders)}, "
+        f"builders with no fixture {sorted(builders - committed)}"
+    )


### PR DESCRIPTION
Tests only. Both invariants hold today; neither was checked, and both break **quietly** — nothing raises, no other test notices, and the damage lands outside CI.

## 1. `py.typed` must ship

PEP 561: a type checker must **ignore** `__init__.pyi` unless the marker file is present. So if `py.typed` ever stopped being packaged — a maturin or pyproject change would do it — consumers would silently get no types at all, and both the stub *and* the test added in #154 to keep it honest would be validating something nobody sees.

Asserted against the **installed** package rather than the source tree, since that's what actually ships. (Also checks the stub itself is packaged, for the same reason.)

## 2. The RFC corpus must still be what its generator produces

`generate_rfc_corpus.py` promises deterministic output precisely so the corpus can be regenerated and reviewed as a diff — its docstring says so. That only holds while nobody has hand-edited a fixture, which nothing verified.

Compared **in memory** per fixture against `builder().as_bytes()`, so the test writes nothing to the filesystem. Plus a one-to-one check between fixtures and builders, so an orphan in either direction fails.

Worth noting the generator is loaded by path rather than imported: `conftest.py` pops the rootdir from `sys.path`, so `import generate_rfc_corpus` isn't reliable from a test.

## It can go red

Appended a single byte to `rfc5322_plain.eml`:

```
AssertionError: rfc5322_plain.eml differs from what generate_rfc_corpus.py
produces -- either it was hand-edited, or the generator changed without the
corpus being regenerated
```

18 passed again once restored.