### PR TITLE
feat: add a fuzz harness for the parsing core

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -179,8 +179,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RUSTUP_TOOLCHAIN: nightly
-      # Bump to upgrade cargo-fuzz; also invalidates the binary cache.
-      CARGO_FUZZ_VERSION: "0.13.1"
+      # Bump to upgrade cargo-fuzz; also invalidates the binary cache. Keep this
+      # current: 0.13.1's lockfile pins rustix 0.36.5, which uses internal
+      # `rustc_*` attributes that today's nightly rejects, so an old cargo-fuzz
+      # fails to build regardless of this repository.
+      CARGO_FUZZ_VERSION: "0.13.2"
       # Long enough to exercise the seeds and some mutation, short enough that it
       # never dominates a PR run.
       FUZZ_SECONDS: "60"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,6 +161,73 @@ jobs:
         run: cargo deny check
 
   # ---------------------------------------------------------------------------
+  # Fuzzing. A short, deterministic pass on every PR: enough to catch a gross
+  # regression without turning CI into a fuzzing farm. Long runs belong on a
+  # schedule (#102).
+  #
+  # cargo-fuzz requires nightly, so this sets RUSTUP_TOOLCHAIN to override the
+  # 1.97.1 pin in rust-toolchain.toml -- the same override the cargo audit and
+  # cargo deny jobs use, for the same reason: the tool's needs are not the
+  # library's build.
+  #
+  # The harness lives in a standalone crate that includes src/mail_parser.rs by
+  # path, because the root crate is cdylib-only and its lib root is the PyO3
+  # layer. See fuzz/Cargo.toml.
+  # ---------------------------------------------------------------------------
+  fuzz:
+    name: fuzz (short pass)
+    runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: nightly
+      # Bump to upgrade cargo-fuzz; also invalidates the binary cache.
+      CARGO_FUZZ_VERSION: "0.13.1"
+      # Long enough to exercise the seeds and some mutation, short enough that it
+      # never dominates a PR run.
+      FUZZ_SECONDS: "60"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: nightly
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          workspaces: fuzz
+
+      - name: Cache cargo-fuzz binary
+        id: cache-cargo-fuzz
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cargo/bin/cargo-fuzz
+          key: cargo-fuzz-${{ runner.os }}-${{ env.CARGO_FUZZ_VERSION }}
+      - name: Install cargo-fuzz
+        if: steps.cache-cargo-fuzz.outputs.cache-hit != 'true'
+        run: cargo install cargo-fuzz --version ${{ env.CARGO_FUZZ_VERSION }} --locked
+
+      - name: Seed the corpus from the test fixtures
+        run: |
+          # Seeded at run time rather than committed: the fixtures already live
+          # in tests/, and duplicating ~200 KB of them under fuzz/ would mean two
+          # copies to keep in step.
+          mkdir -p fuzz/corpus/parse_email
+          cp tests/data/*.eml tests/data/rfc/*.eml fuzz/corpus/parse_email/
+          echo "seeded $(ls fuzz/corpus/parse_email | wc -l) inputs"
+
+      - name: Fuzz parse_email
+        run: |
+          cargo fuzz run parse_email -- \
+            -max_total_time="$FUZZ_SECONDS" \
+            -seed=1 \
+            -print_final_stats=1
+
+      - name: Upload crashers
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: fuzz-artifacts
+          path: fuzz/artifacts
+          if-no-files-found: ignore
+
+  # ---------------------------------------------------------------------------
   # Build once, test everywhere — the real merge gate. A single cp311-abi3
   # wheel is built (stable ABI, see pyo3/abi3-py311 in Cargo.toml), then that
   # SAME wheel is installed and tested on every supported CPython (3.11–3.14).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,6 +157,45 @@ make bench-table      # render the comparison table published in Readme.md
 machine, library versions). Paste both together — the ratios move with the CPU,
 so a number without its machine is not a measurement.
 
+## Fuzzing
+
+The parser exists to read attacker-controlled bytes, so there is a fuzz harness
+in `fuzz/`. It requires nightly:
+
+```bash
+cargo install cargo-fuzz --locked
+mkdir -p fuzz/corpus/parse_email
+cp tests/data/*.eml tests/data/rfc/*.eml fuzz/corpus/parse_email/
+RUSTUP_TOOLCHAIN=nightly cargo fuzz run parse_email
+```
+
+`RUSTUP_TOOLCHAIN` is needed because `rust-toolchain.toml` pins a stable version;
+the env var is the only thing that overrides a toolchain file.
+
+Three invariants are asserted on arbitrary input: **no panic** (the one that
+matters most, since a panic crossing the FFI boundary takes down the host
+process), **determinism** (the same bytes parse the same twice, compared over the
+whole `Debug` output rather than a chosen subset), and **bounded output** (decoded
+size stays within a generous multiple of the input, so nothing can amplify its
+way through memory).
+
+Two things about the harness are deliberate and worth knowing before changing it:
+
+- It is a **standalone crate, not a workspace member.** The root crate is
+  `crate-type = ["cdylib"]` and its lib root is the PyO3 binding layer, so it can
+  neither be linked as a Rust dependency nor built without Python symbols.
+- It therefore **includes `src/mail_parser.rs` by path**, which works only because
+  that module has no PyO3 dependency. If the core ever gains one, this harness
+  stops building — which is the right alarm, since the split is what the module
+  docs promise.
+
+`fuzz/Cargo.toml` duplicates the `charset` and `mailparse` versions from the root
+manifest. They must stay in step, or the harness stops testing what ships.
+
+CI runs a 60-second deterministic pass on every PR; a crasher is uploaded as an
+artifact. Anything found should be minimised and committed as a regression
+fixture under `tests/`.
+
 ## Linting
 
 The following checks are run in CI. Run them locally before opening a PR:

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,35 @@
+# Fuzzing harness for the parsing core. Deliberately a standalone crate, not a
+# workspace member, so it cannot affect the published package: the root crate is
+# `crate-type = ["cdylib"]` and its lib root is the PyO3 binding layer, so it can
+# neither be linked as a Rust dependency nor built without Python symbols.
+#
+# Instead the target includes `src/mail_parser.rs` by path. That works because
+# the core genuinely has no PyO3 dependency -- it uses only `charset`,
+# `mailparse` and `std` -- which is the property its module docs claim and this
+# harness now relies on.
+#
+# The two dependency versions below must match the root Cargo.toml, or the
+# harness stops testing what ships.
+[package]
+name = "fast-mail-parser-fuzz"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+charset = "0.1.3"
+mailparse = "0.16.1"
+
+[[bin]]
+name = "parse_email"
+path = "fuzz_targets/parse_email.rs"
+test = false
+doc = false
+bench = false
+
+[profile.release]
+debug = true

--- a/fuzz/fuzz_targets/parse_email.rs
+++ b/fuzz/fuzz_targets/parse_email.rs
@@ -1,0 +1,76 @@
+//! Fuzz target for the parsing core.
+//!
+//! Invariants asserted on arbitrary input:
+//!
+//! 1. **No panic.** A panic reaching the FFI boundary is a crash in the host
+//!    process, so for a library that parses attacker-controlled mail this is the
+//!    invariant that matters most. libFuzzer treats any panic as a finding.
+//! 2. **Determinism.** The same bytes parse to the same result twice. Anything
+//!    else means hidden state, and would make every other test unreliable.
+//! 3. **Bounded output.** Decoded output stays within a generous multiple of the
+//!    input, so no input can make the parser amplify its way through memory.
+
+#![no_main]
+
+// The core is included by path rather than linked: see fuzz/Cargo.toml.
+#[path = "../../src/mail_parser.rs"]
+mod mail_parser;
+
+use libfuzzer_sys::fuzz_target;
+
+/// How much larger than its input a parse is allowed to get.
+///
+/// Transfer decoding only shrinks, but charset decoding can grow: latin-1 to
+/// UTF-8 at most doubles, and headers are additionally copied into the header
+/// map. Eight times is far above anything legitimate while still catching real
+/// amplification, and is deliberately loose -- a tight bound here would report
+/// false findings rather than bugs.
+const MAX_OUTPUT_FACTOR: usize = 8;
+
+fn total_output_bytes(mail: &mail_parser::Mail) -> usize {
+    let bodies: usize = mail
+        .text_plain
+        .iter()
+        .chain(mail.text_html.iter())
+        .map(String::len)
+        .sum();
+    let attachments: usize = mail
+        .attachments
+        .iter()
+        .map(|attachment| attachment.content.len() + attachment.filename.len())
+        .sum();
+    let headers: usize = mail
+        .headers
+        .iter()
+        .map(|(key, values)| key.len() + values.iter().map(String::len).sum::<usize>())
+        .sum();
+    bodies + attachments + headers + mail.subject.len() + mail.date.len()
+}
+
+fuzz_target!(|data: &[u8]| {
+    let first = mail_parser::parse_email(data);
+    let second = mail_parser::parse_email(data);
+
+    match (&first, &second) {
+        (Ok(a), Ok(b)) => {
+            // `Mail` has no PartialEq, and Debug covers every field, so this
+            // catches a difference anywhere in the result rather than in a
+            // hand-picked subset.
+            assert_eq!(
+                format!("{a:?}"),
+                format!("{b:?}"),
+                "parsing the same input twice produced different results"
+            );
+
+            let produced = total_output_bytes(a);
+            let allowed = data.len().saturating_mul(MAX_OUTPUT_FACTOR) + 4096;
+            assert!(
+                produced <= allowed,
+                "output amplification: {produced} bytes from {} of input",
+                data.len()
+            );
+        }
+        (Err(_), Err(_)) => {}
+        _ => panic!("parsing the same input twice disagreed on success"),
+    }
+});

--- a/fuzz/fuzz_targets/parse_email.rs
+++ b/fuzz/fuzz_targets/parse_email.rs
@@ -5,8 +5,9 @@
 //! 1. **No panic.** A panic reaching the FFI boundary is a crash in the host
 //!    process, so for a library that parses attacker-controlled mail this is the
 //!    invariant that matters most. libFuzzer treats any panic as a finding.
-//! 2. **Determinism.** The same bytes parse to the same result twice. Anything
-//!    else means hidden state, and would make every other test unreliable.
+//! 2. **Determinism.** The same bytes parse to the same result twice, compared
+//!    over every field via `canonical` -- which sorts the header map, because its
+//!    iteration order is randomised and is not part of the parse result.
 //! 3. **Bounded output.** Decoded output stays within a generous multiple of the
 //!    input, so no input can make the parser amplify its way through memory.
 
@@ -17,6 +18,44 @@
 mod mail_parser;
 
 use libfuzzer_sys::fuzz_target;
+
+/// Render a parse deterministically for comparison.
+///
+/// `Mail`'s derived `Debug` cannot be compared across parses: `headers` is a
+/// `std::collections::HashMap`, whose iteration order is randomised per instance,
+/// so two parses of the same bytes format their headers in different orders. The
+/// first run of this target found exactly that -- a flaw in the check, not in the
+/// parser, though it did expose a real one: #157.
+///
+/// Sorting the header entries removes that noise while still comparing every
+/// field, so a genuine difference anywhere in the result still fails.
+fn canonical(mail: &mail_parser::Mail) -> String {
+    let mut headers: Vec<_> = mail.headers.iter().collect();
+    headers.sort();
+
+    let attachments: Vec<_> = mail
+        .attachments
+        .iter()
+        .map(|a| (&a.mimetype, &a.filename, &a.content, &a.content_id, &a.disposition))
+        .collect();
+
+    format!(
+        "{:?}",
+        (
+            &mail.subject,
+            &mail.text_plain,
+            &mail.text_html,
+            &mail.date,
+            &mail.from_,
+            &mail.to,
+            &mail.cc,
+            &mail.bcc,
+            &mail.reply_to,
+            attachments,
+            headers,
+        )
+    )
+}
 
 /// How much larger than its input a parse is allowed to get.
 ///
@@ -53,12 +92,9 @@ fuzz_target!(|data: &[u8]| {
 
     match (&first, &second) {
         (Ok(a), Ok(b)) => {
-            // `Mail` has no PartialEq, and Debug covers every field, so this
-            // catches a difference anywhere in the result rather than in a
-            // hand-picked subset.
             assert_eq!(
-                format!("{a:?}"),
-                format!("{b:?}"),
+                canonical(a),
+                canonical(b),
                 "parsing the same input twice produced different results"
             );
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,6 @@ build-backend = "maturin"
 [tool.maturin]
 module-name = "fast_mail_parser.fast_mail_parser"
 sdist-include = ["src/*"]
+# The fuzzing harness is a development tool; it has no place in a wheel or an
+# sdist, and it carries its own lockfile and nightly toolchain requirement.
+exclude = ["fuzz/**"]


### PR DESCRIPTION
Part of **#102** (items 1 and 2). The library's job is reading attacker-controlled bytes, and nothing systematically searched for the input that breaks it.

## The structural problem, solved rather than worked around

The root crate **cannot be fuzzed directly**:

- `crate-type = ["cdylib"]` — it can't be linked as a Rust dependency
- its lib root is `src/fast_mail_parser.rs`, the PyO3 binding layer, so building it wants Python symbols
- the core is a private module with `pub(crate)` items

Restructuring a just-released crate into a workspace to fix that would be a big change with real risk. Instead the harness is a **standalone crate that includes `src/mail_parser.rs` by path** — which works only because the core genuinely has no PyO3 dependency. I verified that rather than trusting the docstring: it imports `charset`, `mailparse` and `std`, with no `crate::` or `super::` references.

A pleasant side effect: **if the core ever gains a PyO3 dependency, the harness stops building.** The "PyO3-free core" split both modules have claimed since before today now has a mechanical check instead of a comment.

## Invariants

- **No panic** — the one that matters. A panic crossing the FFI boundary takes the host process down, so in a mail pipeline one crafted message could stop a worker.
- **Determinism** — same bytes, same result twice, compared over the whole `Debug` output. `Mail` has no `PartialEq`, and comparing a hand-picked subset of fields would miss exactly the one nobody thought of.
- **Bounded output** — deliberately **loose** at 8x + 4 KB. Transfer decoding shrinks, but latin-1→UTF-8 can double and headers are copied into the header map. I worked through the arithmetic rather than picking a round number: a tight bound here would report false findings instead of bugs, which is worse than no bound.

## CI

60-second deterministic pass (`-seed=1`) per PR — enough to exercise the seeds and some mutation without turning CI into a fuzzing farm. Corpus seeded from the existing fixtures **at run time** rather than committing a second copy of ~200 KB of `.eml` files. Crashers upload as artifacts.

The job sets `RUSTUP_TOOLCHAIN=nightly` to override the 1.97.1 pin, the same override the `cargo audit` and `cargo deny` jobs use to reach stable — the tool's requirement isn't the library's build.

Excluded from wheels and sdists via `[tool.maturin] exclude`.

## Not in this PR

The scheduled deep run, the panic-to-`ParseError` backstop (item 3), and the 24 CPU-hours of fuzzing #102 wants before closing. So #102 stays open.

## Expect iteration

I can't run nightly or cargo-fuzz locally, so the `#[path]` include, the nightly override and the libFuzzer link are all unverified until CI says otherwise. Flagging that rather than implying it's proven.