### PR TITLE
Give headers a deterministic, wire-order key sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `headers` keys are now in the order the header names first appeared in the
+  message, stably across parses. They came from a Rust `HashMap`, whose iteration
+  order is randomised per instance, and that order became the Python dict's
+  insertion order -- so identical bytes produced a different key order on every
+  parse (forty distinct orders in forty parses) and the message's own header order
+  was unrecoverable. Dict *content* was unaffected, which is why it went unnoticed
+  (#157, found by the fuzz harness on its first run).
 - `parse_many(payloads, threads=0)` now raises `ValueError` instead of silently
   behaving as `threads=None`. Treating 0 as "the machine's default" hid caller
   bugs: `threads=os.cpu_count() - 1` on a one-core machine, or an unset config

--- a/Readme.md
+++ b/Readme.md
@@ -144,7 +144,7 @@ Two things this table deliberately does *not* do:
 | `to` / `cc` / `bcc` / `reply_to` | `list[PyAddress]` | Recipients, groups flattened. |
 | `text_plain` | `list[str]` | All `text/plain` bodies. |
 | `text_html` | `list[str]` | All `text/html` bodies. |
-| `headers` | `dict[str, list[str]]` | All values of every header, in order. |
+| `headers` | `dict[str, list[str]]` | Every header's values, in order; keys in wire order. |
 | `attachments` | `list[PyAttachment]` | Non-body parts (see below). |
 
 Each `PyAttachment` has:
@@ -180,7 +180,9 @@ mail.from_.address        # 'jane@example.com'
 ### Headers
 
 `headers` maps each header name to a **list** of every value it appeared with,
-in message order, so repeated fields survive:
+in message order, so repeated fields survive. The keys are themselves in the
+order the names first appeared in the message, and that order is stable across
+parses:
 
 ```python
 mail.headers["Received"]   # ['from mx1...', 'from mx2...', 'from mx3...']

--- a/fast_mail_parser/__init__.pyi
+++ b/fast_mail_parser/__init__.pyi
@@ -76,7 +76,8 @@ class PyMail:
     ``headers`` maps each header name to **every** value it appeared with, in
     order, so repeated keys such as ``Received`` or ``DKIM-Signature`` are
     preserved. Single-valued headers are one-element lists:
-    ``headers["From"] == ["a@example.com"]``.
+    ``headers["From"] == ["a@example.com"]``. The keys are in the order the names
+    first appeared in the message, stably across parses.
 
     Body parts and attachments are disjoint. A part is body text -- reaching
     ``text_plain`` or ``text_html`` -- when it is ``text/plain`` or ``text/html``

--- a/fuzz/fuzz_targets/parse_email.rs
+++ b/fuzz/fuzz_targets/parse_email.rs
@@ -21,17 +21,14 @@ use libfuzzer_sys::fuzz_target;
 
 /// Render a parse deterministically for comparison.
 ///
-/// `Mail`'s derived `Debug` cannot be compared across parses: `headers` is a
-/// `std::collections::HashMap`, whose iteration order is randomised per instance,
-/// so two parses of the same bytes format their headers in different orders. The
-/// first run of this target found exactly that -- a flaw in the check, not in the
-/// parser, though it did expose a real one: #157.
-///
-/// Sorting the header entries removes that noise while still comparing every
-/// field, so a genuine difference anywhere in the result still fails.
+/// Headers are compared **in order**, deliberately. This target's first run
+/// failed here because `headers` was a `HashMap` whose iteration order is
+/// randomised per instance -- which turned out to be a real bug rather than only
+/// a flawed check (#157), since that order reached callers. Now that the core
+/// keeps wire order, comparing unsorted means this target also guards against a
+/// regression to nondeterministic ordering.
 fn canonical(mail: &mail_parser::Mail) -> String {
-    let mut headers: Vec<_> = mail.headers.iter().collect();
-    headers.sort();
+    let headers = &mail.headers;
 
     let attachments: Vec<_> = mail
         .attachments

--- a/src/fast_mail_parser.rs
+++ b/src/fast_mail_parser.rs
@@ -18,9 +18,8 @@ mod mail_parser;
 
 use mailparse::MailParseError;
 use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyDateTime, PyList, PyString, PyTzInfo};
+use pyo3::types::{PyBytes, PyDateTime, PyDict, PyList, PyString, PyTzInfo};
 use pyo3::{create_exception, exceptions, wrap_pyfunction};
-use std::collections::HashMap;
 use std::num::NonZeroUsize;
 
 create_exception!(fast_mail_parser, ParseError, exceptions::PyException);
@@ -185,8 +184,9 @@ pub struct PyMail {
     /// image referenced only by `Content-ID`.
     #[pyo3(get)]
     pub attachments: Vec<PyAttachment>,
-    #[pyo3(get)]
-    pub headers: HashMap<String, Vec<String>>,
+    /// Stored as ordered pairs, not a map: the key order is the point (#157).
+    /// Exposed through the `headers` getter below.
+    pub headers: Vec<(String, Vec<String>)>,
 }
 
 #[pymethods]
@@ -201,6 +201,22 @@ impl PyMail {
     /// the instant is exact while the original offset is not retained -- read
     /// `date` for that. An unparseable header yields `None`, leaving `date`
     /// intact as the raw string.
+    /// All values of every header, keyed by name, in the order the names first
+    /// appeared in the message.
+    ///
+    /// Built on access rather than stored as a dict. Python dicts preserve
+    /// insertion order, so inserting in wire order is what makes the ordering
+    /// observable -- and the previous `HashMap` field, converted per access,
+    /// produced a different order every time (#157).
+    #[getter]
+    fn headers<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let dict = PyDict::new(py);
+        for (name, values) in &self.headers {
+            dict.set_item(name, values)?;
+        }
+        Ok(dict)
+    }
+
     #[getter]
     fn date_parsed<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyDateTime>>> {
         let Some(epoch) = mail_parser::parse_date_epoch(&self.date) else {

--- a/src/mail_parser.rs
+++ b/src/mail_parser.rs
@@ -281,7 +281,7 @@ pub(crate) struct Mail {
     pub(crate) bcc: Vec<Address>,
     pub(crate) reply_to: Vec<Address>,
     pub(crate) attachments: Vec<Attachment>,
-    pub(crate) headers: HashMap<String, Vec<String>>,
+    pub(crate) headers: Vec<(String, Vec<String>)>,
 }
 
 #[derive(Debug)]
@@ -301,17 +301,32 @@ impl<'a> Mail {
 
         let mail = parse_mail(payload)?;
 
-        // Keep every value for a repeated key, in the order the keys appear.
-        // Collapsing to one value per key kept only the last, discarding all but
-        // the final `Received`, `DKIM-Signature`, `Received-SPF`, ... -- which
-        // made delivery-path tracing and signature verification impossible
-        // (#12, #23).
-        let mut headers: HashMap<String, Vec<String>> = HashMap::new();
+        // Keys in the order they first appear, and every value for a repeated
+        // key in the order it appeared. Collapsing to one value per key kept only
+        // the last, discarding all but the final `Received`, `DKIM-Signature`,
+        // `Received-SPF`, ... -- which made delivery-path tracing and signature
+        // verification impossible (#12, #23).
+        //
+        // A `HashMap` cannot carry the key order: its iteration order is
+        // randomised per instance, and that order became the Python dict's
+        // insertion order, so `mail.headers` came back differently ordered on
+        // every parse of the same bytes (#157).
+        //
+        // `positions` keeps insertion O(1). Scanning `headers` for each field
+        // would be quadratic in the header count, which turns a message carrying
+        // thousands of headers into an amplification vector -- the sort of thing
+        // MAX_INPUT_BYTES and MAX_MIME_DEPTH exist to prevent elsewhere.
+        let mut headers: Vec<(String, Vec<String>)> = Vec::new();
+        let mut positions: HashMap<String, usize> = HashMap::new();
         for header in mail.get_headers() {
-            headers
-                .entry(header.get_key())
-                .or_default()
-                .push(header.get_value());
+            let key = header.get_key();
+            match positions.get(&key).copied() {
+                Some(position) => headers[position].1.push(header.get_value()),
+                None => {
+                    positions.insert(key.clone(), headers.len());
+                    headers.push((key, vec![header.get_value()]));
+                }
+            }
         }
 
         // Read these straight from the parsed headers rather than back out of the

--- a/tests/test_multivalue_headers.py
+++ b/tests/test_multivalue_headers.py
@@ -12,6 +12,8 @@ What is covered elsewhere (NOT re-tested here):
 Contract:
 - Every value is a ``list[str]``, including single-valued headers, which are
   one-element lists.
+- Keys appear in the order the header names first appeared in the message, and
+  that order is stable across parses.
 - Repeated keys keep every value in message order -- nothing is dropped, joined,
   or reordered.
 - A repeated key is still a single dict entry; the multiplicity lives in the list.
@@ -105,3 +107,40 @@ def test__subject_and_date_are_independent_of_the_headers_map():
     assert mail.date == "Mon, 01 Jan 2024 12:00:00 +0000"
     # The map still reports both occurrences.
     assert mail.headers["Subject"] == ["the real one", "a later duplicate"]
+
+
+# --- key ordering (#157) ------------------------------------------------------
+
+
+def test__key_order_is_stable_across_parses():
+    # Was not: the keys came from a Rust HashMap whose iteration order is
+    # randomised per instance, so identical bytes produced a different order on
+    # every parse -- forty distinct orders in forty parses.
+    raw = _build("Subject: s\r\nX-A: 1\r\nX-B: 2\r\nX-C: 3\r\nX-D: 4\r\nX-E: 5")
+
+    orders = {tuple(parse_email(raw).headers) for _ in range(30)}
+
+    assert len(orders) == 1, f"key order varies across parses: {len(orders)} distinct"
+
+
+def test__keys_are_in_the_order_the_names_first_appeared():
+    raw = _build(
+        "Received: hop-1\r\n"
+        "Subject: s\r\n"
+        "Received: hop-2\r\n"
+        "From: a@b.c\r\n"
+    )
+
+    mail = parse_email(raw)
+
+    # `Received` keeps its first position even though it appears again later.
+    assert list(mail.headers) == ["Received", "Subject", "From"]
+    assert mail.headers["Received"] == ["hop-1", "hop-2"]
+
+
+def test__ordering_survives_a_realistic_header_block(valid_mail: PyMail):
+    # The wire order of the first few headers of tests/data/valid_message.eml.
+    keys = list(valid_mail.headers)
+
+    assert keys[:3] == ["Delivered-To", "Received", "X-Google-Smtp-Source"], keys[:3]
+    assert len(keys) == 29


### PR DESCRIPTION
Fixes #157.

## The bug

`headers` keys came from a `std::collections::HashMap`, whose iteration order is randomised per instance. That order became the Python dict's insertion order, so parsing the *same bytes* returned a differently ordered dict every time:

```python
>>> {tuple(parse_email(raw).headers) for _ in range(40)}   # before
# 40 distinct orders
```

Two consequences: nothing about the result was reproducible across parses, and the message's own header order — which matters for reading a delivery path top-down, or for anything that re-serialises — was unrecoverable.

Dict *content* was never affected, which is why the test suite didn't catch it: every existing assertion compares values by key. The fuzz harness added in #156 found it on its first run, initially as a flawed determinism check; it turned out the check was right and the parser was wrong.

## The fix

The core keeps `Vec<(String, Vec<String>)>` in first-appearance key order; the binding builds the dict from it on access, relying on Python dicts preserving insertion order.

A repeated key keeps its **first** position, with values in wire order — so `Received: hop-1 / Subject / Received: hop-2` yields keys `[Received, Subject]` and `headers["Received"] == ["hop-1", "hop-2"]`.

Insertion stays O(1) via a transient index map. Scanning the vector per header would be quadratic in the header count, which would turn a message carrying thousands of headers into an amplification vector — the thing `MAX_INPUT_BYTES` and `MAX_MIME_DEPTH` exist to prevent elsewhere.

## Compatibility

Not a breaking change: a random order cannot be depended on, and lookup, `len()`, and value lists are unchanged. Callers that iterated `headers` get wire order instead of noise.

## Tests

- key order identical across 30 parses of the same bytes
- repeated key keeps its first position; values stay in wire order
- the real fixture's keys start `Delivered-To, Received, X-Google-Smtp-Source` (verified against the raw `.eml`), 29 keys
- the fuzz target now compares headers **unsorted**, so it guards this rather than working around it

Also worth noting the old comment claimed "in the order the keys appear" — true of values, never of keys.