### PR TITLE
Add an interleaved A/B harness to measure what abi3 costs

### DIFF
--- a/.github/scripts/ab_median.py
+++ b/.github/scripts/ab_median.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Compare two builds measured in interleaved rounds.
+
+``check_benchmark.py`` compares one measurement per side, which is right for the
+PR gate: there, both sides are built and measured once in the same job, and
+within-job noise is ~0.3%.
+
+That does not hold when the two sides need *separate build-and-measure cycles*.
+Measured on this project, two such cycles read ~16% apart on a no-op change --
+the build cycle itself moves the number, presumably via cache and thermal state.
+A one-shot A/B therefore cannot resolve a threshold anywhere near 5%: it will
+report a confident number that means nothing.
+
+The fix is to stop pairing a build with its measurement. Build both wheels
+first, then alternate measurement rounds between the two installed builds
+(A, B, A, B, ...) and take each side's **median across rounds**. Interleaving
+cancels monotonic drift, and the median discards a single disturbed round.
+
+The pure-Python benchmarks are the noise floor. They cannot be affected by how
+the Rust extension was built, so whatever delta they show is measurement error,
+and a treatment delta is only believable when it clears that floor. This is the
+control that made the toolchain measurement trustworthy (#120): the effect was
++30% while the control moved +2.3%.
+
+Usage:
+    ab_median.py --a-label abi3 --b-label versioned \
+        --a a1.json a2.json a3.json --b b1.json b2.json b3.json
+
+Environment:
+    AB_THRESHOLD_PCT  Delta above which the verdict is "significant" (default: 5).
+"""
+import argparse
+import json
+import os
+import statistics
+import sys
+
+# Benchmarks that cannot be affected by how the extension was built. Their
+# spread is the measurement noise floor for the run.
+CONTROL_PREFIXES = (
+    "test__mail_parser___",
+    "test__mailparser_lib___",
+    "test__stdlib_email___",
+)
+
+
+def read_mins(path):
+    """Return {benchmark name: minimum seconds} from a pytest-benchmark report."""
+    with open(path) as fh:
+        report = json.load(fh)
+    mins = {}
+    for bench in report["benchmarks"]:
+        name = bench["name"]
+        if name in mins:
+            sys.exit(f"::error::benchmark {name!r} appears more than once in {path}")
+        mins[name] = bench["stats"]["min"]
+    if not mins:
+        sys.exit(f"::error::no benchmarks in {path}")
+    return mins
+
+
+def is_control(name):
+    return name.startswith(CONTROL_PREFIXES)
+
+
+def collect(paths):
+    """Return ({name: [per-round seconds]}, round_count)."""
+    rounds = [read_mins(path) for path in paths]
+    names = set(rounds[0])
+    for extra in rounds[1:]:
+        names &= set(extra)
+    dropped = sorted((set().union(*(set(r) for r in rounds))) - names)
+    if dropped:
+        print(f"::warning::benchmarks missing from some rounds, ignored: {dropped}")
+    return {name: [r[name] for r in rounds] for name in sorted(names)}, len(rounds)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--a-label", required=True)
+    parser.add_argument("--b-label", required=True)
+    parser.add_argument("--a", nargs="+", required=True, metavar="JSON")
+    parser.add_argument("--b", nargs="+", required=True, metavar="JSON")
+    args = parser.parse_args()
+
+    threshold = float(os.environ.get("AB_THRESHOLD_PCT", "5"))
+
+    a_rounds, a_count = collect(args.a)
+    b_rounds, b_count = collect(args.b)
+    shared = sorted(set(a_rounds) & set(b_rounds))
+    if not shared:
+        sys.exit("::error::the two sides share no benchmarks")
+
+    lines = [
+        f"### A/B: {args.a_label} vs {args.b_label}\n",
+        f"Median of {a_count} interleaved rounds per side; each value is a "
+        "benchmark's minimum. Positive delta = "
+        f"`{args.a_label}` is slower.\n",
+        f"| Benchmark | {args.b_label} | {args.a_label} | Delta | |",
+        "|---|---|---|---|---|",
+    ]
+
+    deltas = {}
+    for name in shared:
+        a_median = statistics.median(a_rounds[name])
+        b_median = statistics.median(b_rounds[name])
+        delta = (a_median / b_median - 1.0) * 100
+        deltas[name] = delta
+        lines.append(
+            f"| `{name}` | {b_median * 1e3:.3f} ms | {a_median * 1e3:.3f} ms "
+            f"| {delta:+.1f}% | {'control' if is_control(name) else ''} |"
+        )
+
+    controls = {n: d for n, d in deltas.items() if is_control(n)}
+    treatments = {n: d for n, d in deltas.items() if not is_control(n)}
+    if not treatments:
+        sys.exit("::error::no treatment benchmarks found (all matched a control)")
+
+    noise_floor = max((abs(d) for d in controls.values()), default=None)
+    worst_name, worst = max(treatments.items(), key=lambda kv: kv[1])
+
+    lines.append("")
+    if noise_floor is None:
+        lines.append(
+            "_No control benchmark present, so there is no in-run noise "
+            "estimate: treat the deltas as unbounded._\n"
+        )
+    else:
+        lines.append(
+            f"Noise floor from the pure-Python controls: **{noise_floor:.1f}%** "
+            "(they cannot be affected by the build, so this is measurement "
+            "error).\n"
+        )
+
+    lines.append(f"Worst treatment delta: **{worst:+.1f}%** (`{worst_name}`).\n")
+
+    significant = worst > threshold and (noise_floor is None or worst > noise_floor)
+    if significant:
+        lines.append(
+            f"**Verdict: significant.** `{args.a_label}` is {worst:+.1f}% slower "
+            f"than `{args.b_label}`, past the {threshold:.0f}% threshold and "
+            "clear of the noise floor.\n"
+        )
+    elif worst > threshold:
+        lines.append(
+            f"**Verdict: inconclusive.** The {worst:+.1f}% delta exceeds the "
+            f"{threshold:.0f}% threshold but does not clear the "
+            f"{noise_floor:.1f}% noise floor, so this run cannot tell the "
+            "effect from measurement error. Re-run with more rounds.\n"
+        )
+    else:
+        lines.append(
+            f"**Verdict: no significant difference.** Worst delta {worst:+.1f}% "
+            f"is within the {threshold:.0f}% threshold.\n"
+        )
+
+    lines.append("<details><summary>Per-round values (ms)</summary>\n")
+    for label, rounds in ((args.a_label, a_rounds), (args.b_label, b_rounds)):
+        lines.append(f"\n`{label}`:\n")
+        for name in shared:
+            series = " ".join(f"{v * 1e3:.3f}" for v in rounds[name])
+            lines.append(f"- `{name}`: {series}")
+    lines.append("\n</details>\n")
+
+    summary = "\n".join(lines) + "\n"
+    print(summary)
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a") as fh:
+            fh.write(summary)
+
+    # Exit nonzero only when the difference is real: a dispatch-only measurement
+    # workflow going red is the signal that a decision is needed, not a failure.
+    if significant:
+        print(
+            f"::error::{args.a_label} is {worst:+.1f}% slower than "
+            f"{args.b_label} — a decision is required",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/abi3-ab.yml
+++ b/.github/workflows/abi3-ab.yml
@@ -1,0 +1,126 @@
+name: abi3 A/B
+
+# Measures what the stable ABI costs, by building the SAME source twice: once
+# with `pyo3/abi3-py311` (what we ship) and once version-specific for the
+# running interpreter. #101 makes the decision conditional on this number --
+# under 5%, ship abi3 everywhere; over, ship a hybrid.
+#
+# abi3 forbids some PyO3 fast paths, so the cost lands in the Python<->Rust
+# boundary rather than in parsing: string and bytes creation, building the
+# headers dict. Whether that is measurable is exactly the question.
+#
+# The two sides need separate build-and-measure cycles, and on this project two
+# such cycles read ~16% apart on a no-op -- far too noisy for a 5% threshold. So
+# both wheels are built first and the measurements are interleaved afterwards
+# (A, B, A, B, ...), with the median taken per side. The pure-Python benchmarks
+# ride along as a noise floor: they cannot care how the extension was built, so
+# their delta is measurement error, and a result is only believed when it clears
+# them. See .github/scripts/ab_median.py.
+on:
+  workflow_dispatch:
+    inputs:
+      rounds:
+        description: "Interleaved measurement rounds per side"
+        default: "3"
+      threshold:
+        description: "Delta above which a hybrid decision is needed, percent"
+        default: "5"
+      python-version:
+        description: "Interpreter to measure on (the version-specific side targets it)"
+        default: "3.12"
+
+permissions:
+  contents: read
+
+jobs:
+  compare:
+    name: abi3 vs version-specific
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ inputs.python-version }}
+          cache: pip
+
+      - name: Build the abi3 wheel (as shipped)
+        run: |
+          python -m pip install -q --upgrade pip
+          python -m pip wheel . --no-deps -w "$RUNNER_TEMP/w-abi3"
+
+      - name: Build the version-specific wheel
+        run: |
+          # Dropping the feature from Cargo.toml rather than passing a maturin
+          # flag: it is unambiguous and needs no assumption about how the build
+          # backend forwards arguments.
+          sed -i 's|, "pyo3/abi3-py311"||' Cargo.toml
+          # Never trust a sed silently -- if the pattern drifts, the "candidate"
+          # is the same build and the run reports a reassuring 0%.
+          if grep -q 'abi3' Cargo.toml; then
+            echo "::error::abi3 still present in Cargo.toml after the edit"
+            grep -n abi3 Cargo.toml
+            exit 1
+          fi
+          # A separate target dir, for the same reason cargo would otherwise hand
+          # back the previous build's artifacts.
+          CARGO_TARGET_DIR="$RUNNER_TEMP/target-versioned" \
+            python -m pip wheel . --no-deps -w "$RUNNER_TEMP/w-versioned"
+          git checkout Cargo.toml
+
+      - name: Check the two builds actually differ
+        run: |
+          abi3_whl=$(ls "$RUNNER_TEMP/w-abi3"/*.whl)
+          ver_whl=$(ls "$RUNNER_TEMP/w-versioned"/*.whl)
+          echo "abi3:            $(basename "$abi3_whl")"
+          echo "version-specific: $(basename "$ver_whl")"
+          # The wheel tag is the evidence: abi3 builds carry an `abi3` platform
+          # tag, version-specific ones carry `cpXY-cpXY`. Equal tags mean the
+          # A/B compared one build with itself.
+          case "$(basename "$abi3_whl")" in
+            *abi3*) ;;
+            *) echo "::error::the abi3 side is not tagged abi3"; exit 1 ;;
+          esac
+          case "$(basename "$ver_whl")" in
+            *abi3*) echo "::error::the version-specific side is tagged abi3"; exit 1 ;;
+          esac
+          echo "abi3_whl=$abi3_whl" >> "$GITHUB_ENV"
+          echo "ver_whl=$ver_whl" >> "$GITHUB_ENV"
+
+      - name: Install both builds
+        run: |
+          for side in abi3 versioned; do
+            python -m venv "$RUNNER_TEMP/venv-$side"
+            "$RUNNER_TEMP/venv-$side/bin/pip" install -q --upgrade pip
+          done
+          # `[test]` on the wheel path pulls the test extra from the wheel's own
+          # metadata, so the pinned versions come from pyproject.toml and neither
+          # venv rebuilds the extension.
+          "$RUNNER_TEMP/venv-abi3/bin/pip" install -q "${abi3_whl}[test]"
+          "$RUNNER_TEMP/venv-versioned/bin/pip" install -q "${ver_whl}[test]"
+
+      - name: Measure, interleaved
+        run: |
+          for round in $(seq 1 "${{ inputs.rounds }}"); do
+            for side in abi3 versioned; do
+              echo "::group::round $round — $side"
+              "$RUNNER_TEMP/venv-$side/bin/pytest" -q tests/benchmark \
+                --benchmark-min-rounds=25 \
+                --benchmark-json="$side-$round.json"
+              echo "::endgroup::"
+            done
+          done
+
+      - name: Compare
+        env:
+          AB_THRESHOLD_PCT: ${{ inputs.threshold }}
+        run: |
+          python .github/scripts/ab_median.py \
+            --a-label abi3 --b-label version-specific \
+            --a abi3-*.json --b versioned-*.json
+
+      - name: Upload reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: abi3-ab-json
+          path: "*-[0-9].json"

--- a/tests/test_ab_median.py
+++ b/tests/test_ab_median.py
@@ -1,0 +1,121 @@
+"""Tests for the interleaved A/B comparator used to make build decisions.
+
+``.github/scripts/ab_median.py`` decides whether a measured difference between
+two builds is real. Its noise-floor rule is the subtle part, and a comparator
+that silently mis-decides is worse than none: it produces a confident number
+that a decision then rests on. So the rule is pinned here.
+"""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / ".github" / "scripts" / "ab_median.py"
+
+pytestmark = pytest.mark.skipif(
+    not SCRIPT.exists(), reason="CI scripts are not part of the installed package"
+)
+
+
+def _report(path: Path, treatment: float, control: float) -> str:
+    """Write a minimal pytest-benchmark report. Times are in seconds."""
+    path.write_text(
+        json.dumps(
+            {
+                "benchmarks": [
+                    {
+                        "name": "test__fast_mail_parser___parse_message",
+                        "stats": {"min": treatment},
+                    },
+                    {
+                        "name": "test__mail_parser___parse_message",
+                        "stats": {"min": control},
+                    },
+                ]
+            }
+        )
+    )
+    return str(path)
+
+
+def _run(tmp_path: Path, a_rounds, b_rounds, threshold="5"):
+    a = [
+        _report(tmp_path / f"a{i}.json", t, c) for i, (t, c) in enumerate(a_rounds)
+    ]
+    b = [
+        _report(tmp_path / f"b{i}.json", t, c) for i, (t, c) in enumerate(b_rounds)
+    ]
+    env = os.environ.copy()
+    env["AB_THRESHOLD_PCT"] = threshold
+    # Otherwise a test run inside CI would append its synthetic verdicts to the
+    # job summary.
+    env.pop("GITHUB_STEP_SUMMARY", None)
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--a-label", "abi3", "--b-label", "versioned",
+         "--a", *a, "--b", *b],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+# Steady control, sides equal.
+EQUAL = [(1.000, 10.0), (1.010, 10.1), (0.995, 9.90)]
+BASE = [(1.005, 10.0), (0.998, 10.0), (1.002, 10.05)]
+
+
+def test__no_difference_passes(tmp_path: Path):
+    result = _run(tmp_path, EQUAL, BASE)
+
+    assert result.returncode == 0, result.stdout
+    assert "no significant difference" in result.stdout
+
+
+def test__real_effect_over_a_steady_control_is_significant(tmp_path: Path):
+    slower = [(1.120, 10.0), (1.125, 10.1), (1.118, 9.95)]
+
+    result = _run(tmp_path, slower, BASE)
+
+    # Nonzero exit is how a dispatch-only measurement says "decide something".
+    assert result.returncode == 1
+    assert "Verdict: significant" in result.stdout
+    # median(1.120, 1.125, 1.118) / median(1.005, 0.998, 1.002) - 1
+    assert "+11.8%" in result.stdout
+
+
+def test__effect_inside_the_noise_floor_is_inconclusive_not_significant(
+    tmp_path: Path,
+):
+    # 8% apparent cost, but the pure-Python control moved 20% -- which it cannot
+    # do for any reason connected to the build. The run cannot tell the effect
+    # from measurement error, and must not claim it can.
+    noisy = [(1.080, 12.0), (1.085, 12.1), (1.078, 11.9)]
+
+    result = _run(tmp_path, noisy, BASE)
+
+    assert result.returncode == 0
+    assert "Verdict: inconclusive" in result.stdout
+    assert "Verdict: significant" not in result.stdout
+
+
+def test__median_discards_one_disturbed_round(tmp_path: Path):
+    # One round arrives 3x slow (a noisy neighbour on the runner). The median
+    # ignores it; a mean would report a ~65% regression that is not there.
+    disturbed = [(1.000, 10.0), (3.000, 30.0), (1.005, 10.0)]
+
+    result = _run(tmp_path, disturbed, BASE)
+
+    assert result.returncode == 0, result.stdout
+    assert "no significant difference" in result.stdout
+
+
+def test__a_faster_side_is_not_reported_as_a_regression(tmp_path: Path):
+    faster = [(0.800, 10.0), (0.805, 10.1), (0.798, 9.95)]
+
+    result = _run(tmp_path, faster, BASE)
+
+    assert result.returncode == 0
+    assert "no significant difference" in result.stdout


### PR DESCRIPTION
Toward #101. Lands the tooling for the one acceptance criterion still genuinely open there; the number itself follows once this is on master (`workflow_dispatch` needs the workflow file on the default branch).

## Why the obvious measurement doesn't work

#101 says: measure abi3 against a version-specific build, and if the cost exceeds **5%**, ship a hybrid instead of full abi3.

The two sides need separate build-and-measure cycles, and on this project two such cycles read **~16% apart on a no-op change** — the build cycle itself moves the number. A one-shot A/B cannot resolve a 5% threshold. It would produce a confident-looking figure with no information in it, and a packaging decision would then rest on that figure.

## What this does instead

- **Build both wheels first, then interleave the measurements** (A, B, A, B, …), median per side. Interleaving cancels monotonic drift; the median discards one disturbed round.
- **The pure-Python benchmarks are an in-run noise floor.** They cannot be affected by how the Rust extension was built, so whatever delta they show is measurement error. A treatment delta is only called significant once it clears them. This is the control that made the toolchain measurement in #120 trustworthy: +30% effect against a control that moved +2.3%.
- **Two guards against the silent failure mode** — measuring one build against itself, which reports a reassuring 0%:
  - the Cargo feature edit is verified to have taken effect (`grep`, not a trusted `sed`);
  - the two wheel tags are asserted to differ, since an abi3 build carries an `abi3` tag and a version-specific one carries `cpXY-cpXY`. That is direct evidence the A/B compared two different things.

The non-abi3 side drops the feature in `Cargo.toml` rather than passing a build-backend flag — unambiguous, and it needs no assumption about how the backend forwards arguments.

## Verdicts

Three outcomes, and the middle one is the point:

| | meaning | exit |
|---|---|---|
| no significant difference | worst delta within threshold | 0 |
| **inconclusive** | delta over threshold but **under the noise floor** — this run can't tell the effect from error | 0 |
| significant | over threshold *and* clear of the floor — a decision is needed | 1 |

## Tests

`tests/test_ab_median.py` pins the comparator's logic — the CI scripts had no tests before, and this one exists to decide whether a number can be believed:

- steady control, equal sides → no significant difference
- real +11.8% over a steady control → significant, exit 1
- **8% apparent effect while the control moved 20% → inconclusive, not significant**
- one round 3x slow → median absorbs it (a mean would report a ~65% regression that isn't there)
- a *faster* side is not reported as a regression

No library code changes; nothing user-facing, so no CHANGELOG entry.

## Next

Dispatch `abi3 A/B` from master, record the result on #101, and take the full-abi3 vs hybrid decision per the >5% rule. If it lands inconclusive, re-run with more rounds rather than reporting the number.