### PR TITLE
Correct what the malformed fixture actually does, and drop the dead copy

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,29 +39,6 @@ def valid_message(read_mail: Callable) -> str:
     return read_mail('tests/data/valid_message.eml')
 
 
-@pytest.fixture
-def invalid_message(read_mail: Callable) -> str:
-    """A malformed real-world message that nonetheless PARSES.
-
-    The name is misleading and has cost real time: `parse_email` does not raise
-    on this file. It is malformed in that its header block is never terminated --
-    a folded continuation line (` hello`) is followed directly by the MIME
-    boundary with no blank line between them.
-
-    The consequence is silent: the boundary is consumed as a header field, so the
-    `multipart/alternative` declared in Content-Type finds zero parts and the body
-    disappears. `text_plain` comes back empty and `headers` contains one entry
-    whose key is the boundary delimiter. The stdlib recovers the body; we do not.
-    Tracked in #150.
-
-    So this is not a substitute for a parse failure. Use an inline payload with a
-    broken transfer encoding for that -- see `tests/test_error_taxonomy.py`.
-    The stdlib-parity suite excludes this fixture for the same reason: the two
-    parsers disagree about it rather than either rejecting it.
-    """
-    return read_mail('tests/data/invalid_message.eml')
-
-
 @pytest.fixture(scope='module')
 def large_message(read_mail: Callable) -> str:
     return read_mail('tests/data/large_message.eml')

--- a/tests/test_known_issues.py
+++ b/tests/test_known_issues.py
@@ -31,13 +31,30 @@ def malformed() -> bytes:
         return handle.read()
 
 
-# --- #150: unterminated header block swallows the body -----------------------
+# --- #150: unterminated header block swallows the first part ------------------
 #
-# The fixture's header block is never terminated: a folded continuation line
-# (` hello`) is followed directly by the FIRST MIME boundary with no blank line.
-# That boundary is consumed as a header field, so the part it opened -- the
-# text/plain body -- is lost. The second boundary is intact, so the text/html
-# part survives. No error is raised, so the loss is silent and partial.
+# `invalid_message.eml` is a real Mailchimp-delivered message, bare-LF
+# throughout, whose header block is never terminated by a blank line. A folded
+# continuation line (` hello`, which makes MIME-Version read `1.0 hello`) is
+# followed directly by the FIRST MIME boundary. The stdlib has a name for this
+# defect: MissingHeaderBodySeparatorDefect.
+#
+# So a parser scanning for the separator keeps consuming header lines -- 73 of
+# them, up to the first genuinely blank line. Reconstructing that block by hand
+# gives 30 distinct colon-bearing keys plus one colonless line (the boundary,
+# kept as a key with no value) = the 31 keys we report, which is what confirms
+# the mechanism rather than merely fitting it.
+#
+# Two consequences, both pinned below. The boundary that opened the text/plain
+# part was eaten as a header, so that part's content ends up BEFORE the next
+# boundary -- making it multipart preamble, which is discarded by definition.
+# The second boundary is intact, so the text/html part survives: the loss is
+# partial, which is what makes it easy to miss. And the lines absorbed after the
+# boundary are the first part's OWN headers, so the top-level header map ends up
+# carrying two Content-Type values.
+#
+# Note for anyone reading this looking for a detection signal: "multipart with
+# zero parts" does NOT fire here, because the html part parses fine.
 
 
 def test__150_malformed_message_still_parses(malformed: bytes):
@@ -63,6 +80,21 @@ def test__150_boundary_is_reported_as_a_header_key(malformed: bytes):
 
     # WRONG, pinned: a boundary delimiter is not a header field.
     assert f"--{BOUNDARY}" in mail.headers
+
+
+def test__150_part_headers_leak_into_the_top_level_map(malformed: bytes):
+    mail = parse_email(malformed)
+
+    # WRONG, pinned: the two lines absorbed after the swallowed boundary are the
+    # first part's own headers, so the message appears to declare Content-Type
+    # twice -- the real multipart/alternative one and the part's text/plain.
+    # A well-formed message has exactly one, which makes this a second cheap
+    # detection signal. It only became visible when headers started keeping
+    # every value (#123); before that the part's value silently overwrote the
+    # multipart one.
+    assert len(mail.headers["Content-Type"]) == 2
+    assert any("multipart/alternative" in v for v in mail.headers["Content-Type"])
+    assert any("text/plain" in v for v in mail.headers["Content-Type"])
 
 
 def test__150_the_stdlib_recovers_what_we_lose(malformed: bytes):


### PR DESCRIPTION
Documentation and one characterization test. **Does not fix #150** — the body is still lost.

## The contradiction

Two descriptions of `tests/data/invalid_message.eml` disagreed, and the wrong one was the one a reader meets first:

- `conftest.py`: the declared `multipart/alternative` *"finds zero parts and the body disappears"*
- `test_known_issues.py`: only the **first** part is lost; the `text/html` part survives — asserted, and green in CI

The tests are right. The stale claim wasn't harmless: "multipart with zero parts" reads like a cheap way to detect this class of message, and it does not fire here at all, because the html part parses fine. I proposed exactly that signal on #150 before checking.

That `conftest.py` fixture was also **consumed by no test** — every reference in the suite is to the file path, not the fixture — so it was dead code whose docstring served only to mislead. Removed, with the accurate description consolidated where the file is actually used.

## What the description now records

Verified rather than inferred:

- The message is bare-LF throughout (0 CRLF in 103,648 bytes) and its header block is never terminated by a blank line. The stdlib has a name for the defect: `MissingHeaderBodySeparatorDefect`.
- Reconstructing the absorbed block by hand gives 73 lines up to the first genuinely blank one: **30 distinct colon-bearing keys plus one colonless line** (the boundary, kept as a key with no value) = the **31** keys we report. The prediction matching the observation is what confirms the mechanism rather than merely fitting it.
- The folded ` hello` line makes `MIME-Version` read `1.0 hello` (stdlib's reading; noted as such, not asserted).
- Why the loss is partial: the boundary that opened the text/plain part was eaten as a header, so that part's content sits *before* the next boundary — making it multipart **preamble**, discarded by definition. The second boundary is intact, so html survives.

## New pin

The lines absorbed after the swallowed boundary are the first part's **own** headers, so the top-level map carries **two** `Content-Type` values — the real `multipart/alternative` and the part's `text/plain`. No test covered that.

It is a second cheap detection signal, and it only became visible once headers kept every value (#123): before that, the part's value silently overwrote the multipart one.

Full analysis on #150.