### PR TITLE
Check the feature line, not the whole file, in the abi3 A/B guard

### DIFF
--- a/.github/workflows/abi3-ab.yml
+++ b/.github/workflows/abi3-ab.yml
@@ -56,11 +56,21 @@ jobs:
           sed -i 's|, "pyo3/abi3-py311"||' Cargo.toml
           # Never trust a sed silently -- if the pattern drifts, the "candidate"
           # is the same build and the run reports a reassuring 0%.
-          if grep -q 'abi3' Cargo.toml; then
-            echo "::error::abi3 still present in Cargo.toml after the edit"
-            grep -n abi3 Cargo.toml
-            exit 1
-          fi
+          #
+          # Inspect the feature line, not the whole file: the comment above it
+          # explains abi3, so a file-wide grep always matched and failed the run
+          # while in fact proving the edit had worked.
+          features=$(grep -E '^default *=' Cargo.toml)
+          echo "default features now: $features"
+          case "$features" in
+            *abi3*)
+              echo "::error::the feature edit did not take: $features"
+              exit 1 ;;
+            *extension-module*) ;;
+            *)
+              echo "::error::unrecognised default features after the edit: $features"
+              exit 1 ;;
+          esac
           # A separate target dir, for the same reason cargo would otherwise hand
           # back the previous build's artifacts.
           CARGO_TARGET_DIR="$RUNNER_TEMP/target-versioned" \


### PR DESCRIPTION
Fixes the harness added in #159 before it has produced a number. Toward #101.

## What went wrong

The guard exists to catch the failure mode where the A/B silently compares one build with itself and reports a reassuring 0%. It checked `grep -q abi3 Cargo.toml` — which also matches the **comment** three lines above the feature, explaining what abi3 is.

So the version-specific build never ran, and the error it printed was:

```
##[error]abi3 still present in Cargo.toml after the edit
46:# abi3-py311 targets the CPython stable ABI with a 3.11 baseline (matching
```

Line 46 is the comment — which is itself proof the `sed` had worked correctly. Too strict rather than too lax is the right direction for a guard to fail in, but it still cost a run.

It now inspects the `default =` line and echoes what that line says, so the log records which features were actually measured rather than only that a check passed.

## Also verified

The next step rests on pip accepting extras on an absolute wheel path (`<wheel>[test]`, so the pinned test dependencies come from the wheel's own metadata and neither venv rebuilds the extension). Checked against pip directly rather than assumed — it resolves the extra.

Every `run:` script in the workflow is now also syntax-checked as bash locally, which is what would have caught this class of thing before dispatching.