### PR TITLE
Turn an internal panic into a ParseError at the FFI boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- An internal panic now raises `ParseError` instead of PyO3's `PanicException`
+  (#102). This is not about memory safety -- PyO3 already catches panics at the
+  boundary, so one never aborted the process -- it is about which `except` clause
+  a panic lands in. `PanicException` derives from `BaseException`, so the
+  `except Exception` wrapped around a pipeline's parse call did not catch it and a
+  single crafted message could take a worker down. The panic payload is kept in
+  the error message, so the bug stays diagnosable. A panic still means a bug in
+  this crate, and the message says so.
+
 ### Fixed
 
 - `headers` keys are now in the order the header names first appeared in the

--- a/Readme.md
+++ b/Readme.md
@@ -282,6 +282,12 @@ wrong:
 | `MimeStructureError` | Malformed MIME structure, or a resource cap tripped: over 100 MiB of input, or nesting deeper than 256 levels. |
 | `DecodeError` | A part's `Content-Transfer-Encoding` did not decode (bad base64, bad quoted-printable). |
 
+A bug in the parser itself — an internal panic — raises the base `ParseError`
+rather than PyO3's `PanicException`. That matters because `PanicException`
+derives from `BaseException`, so it would slip past the `except Exception` around
+a worker's parse call and take the process down; the message carries the panic
+text so the bug can still be reported. No input is known to cause one.
+
 All three inherit from `ParseError`, so existing code keeps working:
 
 ```python

--- a/src/fast_mail_parser.rs
+++ b/src/fast_mail_parser.rs
@@ -78,6 +78,51 @@ fn to_py_err(error: MailParseError) -> PyErr {
     }
 }
 
+/// Extract a readable message from a panic payload.
+///
+/// `panic!` with a literal yields a `&str`; with a format string, a `String`.
+/// Anything else is a `panic_any` of some other type, which this crate never
+/// does but a dependency could.
+fn panic_message(payload: &(dyn std::any::Any + Send)) -> &str {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        message
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.as_str()
+    } else {
+        "unknown panic payload"
+    }
+}
+
+/// Run a parse and convert a panic into a `ParseError` (#102).
+///
+/// PyO3 already catches panics at the boundary, so one does not abort the
+/// process the way #102 assumed -- it raises `pyo3_runtime.PanicException`. The
+/// operational risk is real anyway, for a different reason: `PanicException`
+/// derives from `BaseException`, so the `except Exception` in a mail pipeline
+/// does not catch it, and a single crafted message takes the worker down.
+///
+/// A parser fed attacker-controlled bytes should fail like a parser. Raising
+/// `ParseError` puts a panic in the same `except` clause as every other
+/// unparseable message, and keeping the payload in the message means the bug
+/// stays diagnosable rather than swallowed -- the default panic hook has also
+/// already written the panic and its location to stderr by this point.
+///
+/// This is a backstop, not a licence: a panic reaching here is a bug in this
+/// crate, and the error says so.
+fn catch_panics<T>(operation: impl FnOnce() -> PyResult<T>) -> PyResult<T> {
+    // `AssertUnwindSafe`: the closure touches Python state, which is not
+    // `UnwindSafe`, but nothing observes that state after a panic -- the only
+    // thing built here is an error value.
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(operation)) {
+        Ok(result) => result,
+        Err(payload) => Err(ParseError::new_err(format!(
+            "internal parser panic: {} (this is a bug in fast_mail_parser; \
+             please report it with the input that triggered it)",
+            panic_message(payload.as_ref())
+        ))),
+    }
+}
+
 /// One mailbox from an address header, exposed to Python.
 #[pyclass(skip_from_py_object)]
 #[derive(Clone)]
@@ -283,6 +328,10 @@ fn payload_to_bytes(payload: &Py<PyAny>, py: Python<'_>) -> PyResult<Vec<u8>> {
 /// `HeaderParseError`, `MimeStructureError` or `DecodeError`.
 #[pyfunction]
 pub fn parse_email(py: Python<'_>, payload: Py<PyAny>) -> PyResult<PyMail> {
+    catch_panics(|| parse_email_inner(py, payload))
+}
+
+fn parse_email_inner(py: Python<'_>, payload: Py<PyAny>) -> PyResult<PyMail> {
     let message = payload_to_bytes(&payload, py)?;
 
     // The actual parse is pure Rust and never touches the Python interpreter, so
@@ -316,6 +365,19 @@ pub fn parse_email(py: Python<'_>, payload: Py<PyAny>) -> PyResult<PyMail> {
 #[pyfunction]
 #[pyo3(signature = (payloads, *, threads = None, raise_on_error = false))]
 pub fn parse_many(
+    py: Python<'_>,
+    payloads: Vec<Py<PyAny>>,
+    threads: Option<usize>,
+    raise_on_error: bool,
+) -> PyResult<Py<PyList>> {
+    // A panic fails the whole batch rather than one slot, unlike a parse error.
+    // Per-item isolation would need the panic to ride in the core's error type,
+    // and `MailParseError::Generic` holds a `&'static str`, so a payload cannot
+    // travel that way -- worth revisiting only if a panic is ever actually seen.
+    catch_panics(|| parse_many_inner(py, payloads, threads, raise_on_error))
+}
+
+fn parse_many_inner(
     py: Python<'_>,
     payloads: Vec<Py<PyAny>>,
     threads: Option<usize>,
@@ -363,10 +425,27 @@ pub fn parse_many(
     Ok(items.unbind())
 }
 
+/// Panic on purpose, so the backstop above can be tested.
+///
+/// Not part of the API: underscore-prefixed, absent from `__all__` and from the
+/// type stub, and not re-exported by the package. It exists because an untested
+/// backstop is indistinguishable from a missing one, and #102 asks for exactly
+/// this kind of trigger. There is no other way to obtain a panic on demand --
+/// the parser is not known to panic on any input, which is the whole point.
+#[pyfunction]
+fn _panic_for_tests() -> PyResult<()> {
+    catch_panics(panic_now)
+}
+
+fn panic_now() -> PyResult<()> {
+    panic!("deliberate panic from _panic_for_tests")
+}
+
 #[pymodule]
 fn fast_mail_parser(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(parse_email, m)?)?;
     m.add_function(wrap_pyfunction!(parse_many, m)?)?;
+    m.add_function(wrap_pyfunction!(_panic_for_tests, m)?)?;
     m.add_class::<PyMail>()?;
     m.add_class::<PyAttachment>()?;
     m.add_class::<PyAddress>()?;

--- a/tests/test_panic_backstop.py
+++ b/tests/test_panic_backstop.py
@@ -1,0 +1,63 @@
+"""The panic backstop at the FFI boundary (#102).
+
+A Rust panic does not abort the process -- PyO3 catches it and raises
+`pyo3_runtime.PanicException`. But that derives from `BaseException`, so the
+`except Exception` around a mail pipeline's parse call does not catch it, and one
+crafted message takes the worker down with it.
+
+So the backstop is not about memory safety, it is about which `except` clause a
+panic lands in. These tests exist because an untested backstop is
+indistinguishable from a missing one, and the parser is not known to panic on any
+input -- hence the deliberate trigger.
+"""
+import pytest
+from fast_mail_parser.fast_mail_parser import _panic_for_tests
+
+import fast_mail_parser
+from fast_mail_parser import ParseError, parse_email
+
+
+def test__a_panic_surfaces_as_parse_error():
+    with pytest.raises(ParseError) as excinfo:
+        _panic_for_tests()
+
+    # The payload survives, so the bug stays diagnosable.
+    assert "deliberate panic from _panic_for_tests" in str(excinfo.value)
+    assert "bug in fast_mail_parser" in str(excinfo.value)
+
+
+def test__a_panic_is_caught_by_except_exception():
+    # The whole point. `PanicException` derives from `BaseException` and would
+    # sail straight through this, killing the worker.
+    try:
+        _panic_for_tests()
+    except Exception as error:
+        assert isinstance(error, ParseError)
+    else:
+        pytest.fail("the panic did not raise at all")
+
+
+def test__the_raised_error_is_not_a_bare_base_exception():
+    with pytest.raises(ParseError) as excinfo:
+        _panic_for_tests()
+
+    assert isinstance(excinfo.value, Exception)
+    assert type(excinfo.value).__name__ != "PanicException"
+
+
+def test__the_module_still_works_after_a_panic(valid_message: str):
+    # Unwinding out of the parser must leave nothing broken behind: a caught
+    # panic that poisons the extension would only move the outage later.
+    with pytest.raises(ParseError):
+        _panic_for_tests()
+
+    mail = parse_email(valid_message)
+
+    assert mail.subject
+
+
+def test__the_trigger_is_not_part_of_the_public_surface():
+    # It ships in the extension because there is no other way to obtain a panic
+    # on demand, but it must not look like API.
+    assert "_panic_for_tests" not in fast_mail_parser.__all__
+    assert not hasattr(fast_mail_parser, "_panic_for_tests")


### PR DESCRIPTION
One slice of #102 (the panic policy, AC 3). **Does not close it** — the fuzz targets, scheduled deep run, and 24 CPU-hours remain.

## A correction to the premise

#102 says *"a panic across the PyO3 boundary aborts the host process"*. It does not. PyO3 catches panics at the boundary and raises `pyo3_runtime.PanicException` — verified against PyO3's own documentation rather than assumed.

The operational risk it describes is nonetheless real, for a different reason:

> `PanicException` … like `SystemExit`, derives from `BaseException`

So the `except Exception` wrapped around a worker's parse call **does not catch it**, and one crafted message still takes the worker down. The problem was never memory safety — it is which `except` clause a panic lands in.

## The change

Both entry points run inside `catch_unwind` and convert a surviving panic into `ParseError`, the same clause as every other unparseable message. The payload is kept in the error text, and the default panic hook has already written the panic and its location to stderr, so the bug stays diagnosable rather than swallowed. A panic reaching there is still a bug in this crate, and the message says so.

`parse_many` fails the **whole batch** on a panic rather than one slot, unlike a parse error. Per-item isolation would need the panic to ride in the core's error type, and `MailParseError::Generic` carries a `&'static str` — a payload cannot travel that way. Noted in the code; worth revisiting only if a panic is ever actually observed.

## On formatting

The bodies moved into inner functions rather than being wrapped in place, so they stay byte-identical and rustfmt has nothing to reindent. There is no Rust toolchain in my environment, so CI is the only compiler and formatter available — restructuring to avoid guessing rustfmt's indentation is cheaper than a round trip to find out.

## Testing a backstop that nothing triggers

The parser is not known to panic on any input — which is the point — so there is no way to obtain one on demand. A hidden `_panic_for_tests` provides it; #102 anticipates exactly this. An untested backstop is indistinguishable from a missing one.

It stays out of `__all__`, the type stub, and the package's re-exports (it lives on the extension module only), and a test pins that.

Tests:

- a panic surfaces as `ParseError`, with the payload preserved
- **it is caught by `except Exception`** — the actual point; `PanicException` would sail through
- the raised type is not `PanicException`
- the module still parses normally *after* a caught panic — a backstop that poisons the extension would only move the outage later
- the trigger is absent from the public surface