### PR TITLE
Add a weekly deep fuzz run with an accumulating corpus

### DIFF
--- a/.github/scripts/report_fuzz_crash.sh
+++ b/.github/scripts/report_fuzz_crash.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Report a deep-fuzz crasher onto ONE pinned issue.
+#
+# A new issue per weekly run would bury the first finding under duplicates of
+# itself, since a crasher stays in the corpus and keeps being found until it is
+# fixed. So the first crash opens an issue and later ones comment on it -- the
+# drift-alarm pattern #102 asks for.
+#
+# Called only from .github/workflows/deep-fuzz.yml, on failure of the fuzz step.
+set -euo pipefail
+
+LABEL="fuzz-crash"
+TITLE="Deep fuzz: crasher in parse_email"
+
+# `find` on a missing directory exits 1, and under `pipefail` that ends the
+# script before it can report anything -- the one case where reporting matters
+# most is a crash whose artifact directory never got created.
+mkdir -p fuzz/artifacts
+
+count=$(find fuzz/artifacts -type f | wc -l | tr -d ' ')
+files=$(find fuzz/artifacts -type f | sort | sed 's|^|- `|; s|$|`|')
+[ -n "$files" ] || files="- (none on disk; see the log)"
+
+# The tail carries libFuzzer's own diagnosis: the panic message, the dedup
+# token, and where it wrote the reproducer.
+excerpt=$(tail -n 40 fuzz-output.log 2>/dev/null || echo "(no log captured)")
+
+# The smallest crasher inline, if small enough to be useful. Saves whoever picks
+# this up from downloading an artifact to see what the input was.
+smallest=$(find fuzz/artifacts -type f -exec ls -S {} + | tail -n 1)
+if [ -n "$smallest" ] && [ "$(wc -c < "$smallest")" -le 2048 ]; then
+  reproducer=$(printf 'Smallest crasher, base64 (`%s`, %s bytes):\n\n```\n%s\n```' \
+    "$(basename "$smallest")" "$(wc -c < "$smallest" | tr -d ' ')" \
+    "$(base64 < "$smallest")")
+else
+  reproducer="The crashers are in the run artifact; none was small enough to inline."
+fi
+
+body=$(cat <<EOF
+The scheduled deep fuzz run found **${count}** crasher(s).
+
+Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+Artifact: \`deep-fuzz-${GITHUB_RUN_ID}\` (crashers plus the full log)
+
+Files:
+
+${files}
+
+${reproducer}
+
+<details><summary>Last 40 lines of the fuzzer output</summary>
+
+\`\`\`
+${excerpt}
+\`\`\`
+
+</details>
+
+---
+
+If this says \`fuzz canary\`, it is the reporting path being tested on purpose
+and nothing is wrong -- close it.
+
+Otherwise: minimize (\`cargo fuzz tmin parse_email <crasher>\`), commit the
+minimized input as a regression fixture so the finding stays found, then fix it.
+EOF
+)
+
+# --label fails on a label that does not exist yet, and the first crash is
+# exactly when it will not.
+gh label create "$LABEL" \
+  --color B60205 \
+  --description "Found by the scheduled deep fuzz run" >/dev/null 2>&1 || true
+
+existing=$(gh issue list --label "$LABEL" --state open --limit 1 \
+  --json number --jq '.[0].number // empty')
+
+if [ -n "$existing" ]; then
+  echo "commenting on existing #${existing}"
+  gh issue comment "$existing" --body "$body"
+else
+  echo "opening a new issue"
+  gh issue create --title "$TITLE" --label "$LABEL" --body "$body"
+fi

--- a/.github/workflows/deep-fuzz.yml
+++ b/.github/workflows/deep-fuzz.yml
@@ -1,0 +1,153 @@
+name: Deep fuzz
+
+# The PR job fuzzes for 60 seconds with a fixed seed: enough to catch a gross
+# regression, not enough to explore. Real fuzzing needs time and a corpus that
+# grows, which is what this is for (#102).
+#
+# Two things make a weekly run worth more than 30x the PR job:
+#
+#   - The corpus is cached and restored, so coverage compounds week over week
+#     instead of restarting from the fixtures every time. This is most of the
+#     value: a fuzzer's reach is mostly a function of the corpus it inherits.
+#   - No fixed seed, so each run explores a different path. The PR job pins the
+#     seed deliberately, to stay reproducible; here that would mean repeating one
+#     search every week forever.
+#
+# A crasher becomes an artifact, a minimized reproducer, and an entry on a single
+# pinned issue rather than a new issue per run.
+on:
+  schedule:
+    # Mondays, 03:17 UTC. Off the hour: scheduled jobs cluster there and get
+    # queued behind everyone else's.
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
+    inputs:
+      seconds:
+        description: "Fuzzing time per target, seconds"
+        default: "1800"
+      inject_canary:
+        description: "Plant the canary input to test the crash-reporting path"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  # Never two deep runs at once: they would race on the corpus cache and the
+  # slower one's save would clobber the faster one's findings.
+  group: deep-fuzz
+  cancel-in-progress: false
+
+jobs:
+  deep-fuzz:
+    name: parse_email (${{ inputs.seconds || 1800 }}s)
+    runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: nightly
+      # Keep in step with the short pass in test.yml.
+      CARGO_FUZZ_VERSION: "0.13.2"
+      FUZZ_SECONDS: ${{ inputs.seconds || 1800 }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: nightly
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          workspaces: fuzz
+
+      - name: Cache cargo-fuzz binary
+        id: cache-cargo-fuzz
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cargo/bin/cargo-fuzz
+          key: cargo-fuzz-${{ runner.os }}-${{ env.CARGO_FUZZ_VERSION }}
+      - name: Install cargo-fuzz
+        if: steps.cache-cargo-fuzz.outputs.cache-hit != 'true'
+        run: cargo install cargo-fuzz --version ${{ env.CARGO_FUZZ_VERSION }} --locked
+
+      - name: Restore the accumulated corpus
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: fuzz/corpus/parse_email
+          # A cache entry is immutable, so each run writes a new key and inherits
+          # the newest previous one by prefix.
+          key: fuzz-corpus-parse_email-${{ github.run_id }}
+          restore-keys: fuzz-corpus-parse_email-
+
+      - name: Seed the corpus from the test fixtures
+        run: |
+          mkdir -p fuzz/corpus/parse_email
+          inherited=$(find fuzz/corpus/parse_email -type f | wc -l)
+          cp tests/data/*.eml tests/data/rfc/*.eml fuzz/corpus/parse_email/
+          echo "inherited $inherited inputs from the cache, "\
+               "$(find fuzz/corpus/parse_email -type f | wc -l) after seeding"
+          echo "corpus_inherited=$inherited" >> "$GITHUB_ENV"
+
+      - name: Plant the canary
+        if: inputs.inject_canary
+        run: |
+          # Exercises the crash path on demand. The target panics on exactly
+          # these bytes; see CANARY in fuzz/fuzz_targets/parse_email.rs.
+          printf '%s' 'FMP_FUZZ_CANARY_DO_NOT_REPORT_42' \
+            > fuzz/corpus/parse_email/zz-canary
+          echo "::warning::canary planted -- this run is expected to crash"
+
+      - name: Fuzz parse_email
+        id: fuzz
+        run: |
+          # No -seed: each run should explore somewhere new.
+          set -o pipefail
+          cargo fuzz run parse_email -- \
+            -max_total_time="$FUZZ_SECONDS" \
+            -print_final_stats=1 2>&1 | tee fuzz-output.log
+
+      - name: Save the accumulated corpus
+        # Also on failure: the inputs found before the crash are worth keeping.
+        if: always()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: fuzz/corpus/parse_email
+          key: fuzz-corpus-parse_email-${{ github.run_id }}
+
+      - name: Minimize the crasher
+        if: failure() && steps.fuzz.conclusion == 'failure'
+        run: |
+          # A raw crasher is whatever the mutator happened to be holding; the
+          # minimized one is what a regression fixture should be made from.
+          for crasher in fuzz/artifacts/parse_email/*; do
+            [ -f "$crasher" ] || continue
+            echo "::group::tmin $(basename "$crasher")"
+            cargo fuzz tmin parse_email "$crasher" || \
+              echo "minimization failed; the raw crasher is still in the artifact"
+            echo "::endgroup::"
+          done
+
+      - name: Upload crashers and log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: deep-fuzz-${{ github.run_id }}
+          path: |
+            fuzz/artifacts
+            fuzz-output.log
+          if-no-files-found: ignore
+
+      - name: Report a crasher
+        if: failure() && steps.fuzz.conclusion == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: .github/scripts/report_fuzz_crash.sh
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### Deep fuzz"
+            echo
+            echo "- ran for ${FUZZ_SECONDS}s"
+            echo "- corpus: ${corpus_inherited} inherited, $(find fuzz/corpus/parse_email -type f | wc -l) now"
+            echo "- crashers: $(find fuzz/artifacts -type f 2>/dev/null | wc -l)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,12 +172,18 @@ RUSTUP_TOOLCHAIN=nightly cargo fuzz run parse_email
 `RUSTUP_TOOLCHAIN` is needed because `rust-toolchain.toml` pins a stable version;
 the env var is the only thing that overrides a toolchain file.
 
-Three invariants are asserted on arbitrary input: **no panic** (the one that
-matters most, since a panic crossing the FFI boundary takes down the host
-process), **determinism** (the same bytes parse the same twice, compared over the
-whole `Debug` output rather than a chosen subset), and **bounded output** (decoded
-size stays within a generous multiple of the input, so nothing can amplify its
-way through memory).
+Three invariants are asserted on arbitrary input:
+
+- **No panic** — still the one that matters most, though not because a panic
+  takes down the host process: it never did. PyO3 catches panics at the boundary,
+  and since #162 the binding converts them to `ParseError`. What a panic costs is
+  a message reported as unparseable instead of parsed, so finding one here is
+  finding it before a mail pipeline does.
+- **Determinism** — the same bytes parse the same twice, compared over every
+  field, headers **in order**. The harness's first run failed here and it was a
+  real bug (#157), not a flawed check.
+- **Bounded output** — decoded size stays within a generous multiple of the
+  input, so nothing can amplify its way through memory.
 
 Two things about the harness are deliberate and worth knowing before changing it:
 
@@ -192,9 +198,24 @@ Two things about the harness are deliberate and worth knowing before changing it
 `fuzz/Cargo.toml` duplicates the `charset` and `mailparse` versions from the root
 manifest. They must stay in step, or the harness stops testing what ships.
 
-CI runs a 60-second deterministic pass on every PR; a crasher is uploaded as an
-artifact. Anything found should be minimised and committed as a regression
-fixture under `tests/`.
+CI runs a 60-second deterministic pass on every PR, seeded so it stays
+reproducible; a crasher is uploaded as an artifact.
+
+A **weekly deep run** (`.github/workflows/deep-fuzz.yml`, Mondays) fuzzes for 30
+minutes with no fixed seed and, importantly, **caches the corpus between runs**,
+so coverage compounds instead of restarting from the fixtures every week — that
+accumulation is most of what makes a scheduled run worth more than the PR pass.
+
+A crasher there is minimised, uploaded, and reported onto a single pinned issue
+labelled `fuzz-crash`: one issue that gets comments, not a new issue per week,
+because a crasher stays in the corpus and keeps being found until it is fixed.
+Anything found should be minimised and committed as a regression fixture under
+`tests/`, so the finding stays found.
+
+To rehearse that reporting path without waiting for a real crash, dispatch the
+workflow with `inject_canary`. It plants an input the target panics on by design
+(`CANARY` in `fuzz/fuzz_targets/parse_email.rs`) and the resulting issue says so
+— close it afterwards.
 
 ## Linting
 

--- a/fuzz/fuzz_targets/parse_email.rs
+++ b/fuzz/fuzz_targets/parse_email.rs
@@ -2,12 +2,17 @@
 //!
 //! Invariants asserted on arbitrary input:
 //!
-//! 1. **No panic.** A panic reaching the FFI boundary is a crash in the host
-//!    process, so for a library that parses attacker-controlled mail this is the
-//!    invariant that matters most. libFuzzer treats any panic as a finding.
+//! 1. **No panic.** Still the invariant that matters most, though not for the
+//!    reason first written here: a panic never crashed the host process -- PyO3
+//!    catches it -- and since #162 the binding converts it to a `ParseError`.
+//!    What a panic costs is a message parsed as garbage instead of parsed, so
+//!    finding one here is finding it before a mail pipeline does. libFuzzer
+//!    treats any panic as a finding.
 //! 2. **Determinism.** The same bytes parse to the same result twice, compared
-//!    over every field via `canonical` -- which sorts the header map, because its
-//!    iteration order is randomised and is not part of the parse result.
+//!    over every field via `canonical`, headers **in order**. This target's first
+//!    run failed here, on a header map whose iteration order was randomised per
+//!    instance -- a real bug (#157), not a flawed check. Now that the core keeps
+//!    wire order, an ordering regression is a finding rather than noise.
 //! 3. **Bounded output.** Decoded output stays within a generous multiple of the
 //!    input, so no input can make the parser amplify its way through memory.
 
@@ -83,7 +88,24 @@ fn total_output_bytes(mail: &mail_parser::Mail) -> usize {
     bodies + attachments + headers + mail.subject.len() + mail.date.len()
 }
 
+/// Input that makes this target panic on purpose.
+///
+/// The scheduled deep run is supposed to turn a crasher into an artifact and a
+/// filed issue, and #102 asks for that path to be verified rather than trusted.
+/// Verifying it needs a crash on demand, and the whole point of the harness is
+/// that no known input produces one -- so this provides it.
+///
+/// Dispatching the deep-fuzz workflow with `inject_canary` writes these bytes
+/// into the corpus, and libFuzzer runs corpus inputs first. Nothing else reaches
+/// it: a 32-byte magic string is far outside what random mutation finds, and
+/// nothing in the seed corpus resembles it.
+const CANARY: &[u8] = b"FMP_FUZZ_CANARY_DO_NOT_REPORT_42";
+
 fuzz_target!(|data: &[u8]| {
+    if data == CANARY {
+        panic!("fuzz canary: this crash is a deliberate test of the reporting path");
+    }
+
     let first = mail_parser::parse_email(data);
     let second = mail_parser::parse_email(data);
 


### PR DESCRIPTION
Second slice of #102 (CI integration, AC 2). **Does not close it** — the 24 CPU-hours of initial fuzzing and the triage of whatever it finds remain.

## Why weekly beats 30x the PR job

The PR pass fuzzes 60 seconds with a fixed seed — enough to catch a gross regression, not enough to explore. Two changes make the scheduled run qualitatively different:

- **The corpus is cached and restored between runs**, so coverage compounds instead of restarting from the fixtures every week. This is most of the value: a fuzzer's reach is largely a function of the corpus it inherits, and a scheduled job that starts from zero every time just re-explores the same shallow space.
- **No fixed seed.** The PR job pins its seed deliberately, to stay reproducible. Weekly, that would mean repeating one identical search forever.

Cache save uses the explicit `cache/save` with `if: always()`, so inputs discovered *before* a crash are kept rather than lost with the failed job.

## One pinned issue, not one per week

A crasher is minimized (`cargo fuzz tmin`), uploaded with the full log, and reported onto a single issue labelled `fuzz-crash` — comments thereafter. A new issue per run would bury the first finding under duplicates of itself, since a crasher stays in the corpus and keeps being found until it's fixed.

The smallest crasher is inlined as base64 when it's under 2 KB, so whoever picks it up doesn't need to download an artifact to see what the input was.

## Verifying the alarm instead of trusting it

#102 asks for the reporting path to be verified by a deliberately-injected panic. That can't be done on a branch — `workflow_dispatch` requires the workflow on the default branch — and the harness's whole point is that no known input panics.

So there's a canary: 32 magic bytes the target panics on by design. Dispatch with `inject_canary` and the full path runs — crash, minimize, artifact, issue — with the filed issue stating it was a drill. Nothing else reaches it; random mutation does not produce a 32-byte magic string, and no seed resembles it.

## Corrections carried along

The claim that **a panic crossing the FFI boundary takes down the host process** appeared in the harness's module doc and in CONTRIBUTING (and in #102 itself). It's wrong: PyO3 catches panics, and since #162 the binding converts them to `ParseError`. Both now state what a panic actually costs — a message reported unparseable instead of parsed.

The module doc also still described `canonical` as sorting the header map. That stopped being true in #158, when the key order became deterministic and the sort was removed precisely so the fuzzer would catch a regression to nondeterminism.

## Testing

The reporter is a script rather than inline YAML so it could be tested before dispatch, against a stubbed `gh`:

- 2 crashers, one small → count correct, smallest (not first) inlined as base64
- only a large crasher → no inline, says so
- no artifacts at all → still reports
- existing open `fuzz-crash` issue → comments instead of creating

That caught a real bug: `find` on a missing artifacts directory exits 1, and under `pipefail` the script died before reporting anything — in exactly the case where reporting matters most. Every `run:` block in the workflow is also bash-syntax-checked.