### PR TITLE
Make a fuzz drill pass green, and surface the panic message

### DIFF
--- a/.github/scripts/report_fuzz_crash.sh
+++ b/.github/scripts/report_fuzz_crash.sh
@@ -21,9 +21,20 @@ count=$(find fuzz/artifacts -type f | wc -l | tr -d ' ')
 files=$(find fuzz/artifacts -type f | sort | sed 's|^|- `|; s|$|`|')
 [ -n "$files" ] || files="- (none on disk; see the log)"
 
-# The tail carries libFuzzer's own diagnosis: the panic message, the dedup
-# token, and where it wrote the reproducer.
+# The tail carries libFuzzer's dedup token and where it wrote the reproducer.
 excerpt=$(tail -n 40 fuzz-output.log 2>/dev/null || echo "(no log captured)")
+
+# ...but not reliably the panic message. A Rust panic prints the location and
+# then the message on the following line, and 40 lines of stack frames can push
+# both out of the tail -- which is exactly what happened on the first drill. So
+# pull it out explicitly: it is the single most useful line in the log.
+panic=$(grep -m1 -A2 "panicked at" fuzz-output.log 2>/dev/null || true)
+if [ -z "$panic" ]; then
+  # No Rust panic: a timeout, an OOM, or a signal. libFuzzer's own summary says
+  # which.
+  panic=$(grep -m1 -E "^(SUMMARY|==[0-9]+==ERROR)" fuzz-output.log 2>/dev/null || true)
+fi
+[ -n "$panic" ] || panic="(the log records no panic or summary line)"
 
 # The smallest crasher inline, if small enough to be useful. Saves whoever picks
 # this up from downloading an artifact to see what the input was.
@@ -41,6 +52,10 @@ The scheduled deep fuzz run found **${count}** crasher(s).
 
 Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
 Artifact: \`deep-fuzz-${GITHUB_RUN_ID}\` (crashers plus the full log)
+
+\`\`\`
+${panic}
+\`\`\`
 
 Files:
 

--- a/.github/workflows/deep-fuzz.yml
+++ b/.github/workflows/deep-fuzz.yml
@@ -99,10 +99,18 @@ jobs:
         id: fuzz
         run: |
           # No -seed: each run should explore somewhere new.
+          #
+          # The crash is recorded as an output instead of failing the step here,
+          # so the verdict can be decided further down. A canary drill and a real
+          # finding both crash, and they mean opposite things.
           set -o pipefail
-          cargo fuzz run parse_email -- \
-            -max_total_time="$FUZZ_SECONDS" \
-            -print_final_stats=1 2>&1 | tee fuzz-output.log
+          if cargo fuzz run parse_email -- \
+               -max_total_time="$FUZZ_SECONDS" \
+               -print_final_stats=1 2>&1 | tee fuzz-output.log; then
+            echo "crashed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "crashed=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Save the accumulated corpus
         # Also on failure: the inputs found before the crash are worth keeping.
@@ -113,7 +121,7 @@ jobs:
           key: fuzz-corpus-parse_email-${{ github.run_id }}
 
       - name: Minimize the crasher
-        if: failure() && steps.fuzz.conclusion == 'failure'
+        if: steps.fuzz.outputs.crashed == 'true'
         run: |
           # A raw crasher is whatever the mutator happened to be holding; the
           # minimized one is what a regression fixture should be made from.
@@ -136,7 +144,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Report a crasher
-        if: failure() && steps.fuzz.conclusion == 'failure'
+        if: steps.fuzz.outputs.crashed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: .github/scripts/report_fuzz_crash.sh
@@ -151,3 +159,24 @@ jobs:
             echo "- corpus: ${corpus_inherited} inherited, $(find fuzz/corpus/parse_email -type f | wc -l) now"
             echo "- crashers: $(find fuzz/artifacts -type f 2>/dev/null | wc -l)"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verdict
+        # The drill and a real finding both crash, so "did it crash" is not the
+        # verdict on its own. Before this, a working drill went red and a drill
+        # whose canary went UNDETECTED went green -- the signal was inverted, and
+        # a broken alarm was the quiet outcome.
+        run: |
+          crashed='${{ steps.fuzz.outputs.crashed }}'
+          if [ '${{ inputs.inject_canary }}' = 'true' ]; then
+            if [ "$crashed" = 'true' ]; then
+              echo "drill passed: the canary crashed and was reported"
+            else
+              echo "::error::drill failed: the canary did not crash, so the alarm is not working"
+              exit 1
+            fi
+          elif [ "$crashed" = 'true' ]; then
+            echo "::error::fuzzing found a crasher -- see the reported issue"
+            exit 1
+          else
+            echo "no crashers"
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,6 +217,11 @@ workflow with `inject_canary`. It plants an input the target panics on by design
 (`CANARY` in `fuzz/fuzz_targets/parse_email.rs`) and the resulting issue says so
 — close it afterwards.
 
+A drill **passes green**: with `inject_canary` set, the job succeeds when the
+canary crashed and was reported, and fails when it did not, because a canary that
+goes undetected means the alarm is broken. A normal run fails on any crash, as
+you would expect.
+
 ## Linting
 
 The following checks are run in CI. Run them locally before opening a PR:


### PR DESCRIPTION
Both fixes come from running the drill added in #163 rather than reasoning about it. Toward #102.

## The drill's signal was inverted

A crash is what the drill *provokes*, so:

| | before | meaning |
|---|---|---|
| canary crashed and was reported | job **red** | the alarm works |
| canary went undetected | job **green** | the alarm is broken |

The quiet outcome was the broken one, and a red run on master was the healthy one. That is the wrong way round for a check whose entire purpose is to tell you the alarm still works — and it also left a legitimately-red run in master's history for a successful drill ([the first one](https://github.com/namecheap/fast_mail_parser/actions/runs/33050216496)).

"Did it crash" cannot be the verdict on its own, because a drill and a real finding both crash and mean opposite things. The crash is now recorded as a step output and a final step decides:

- **canary planted:** green if it crashed and was reported, red if it did not
- **normal run:** any crash is a finding and fails, as before

## The report lost the most useful line in the log

A Rust panic prints its location and then its message. Forty lines of stack frames pushed both out of the log tail, so the first drill's issue was identifiable only because the canary's own bytes happened to show up in libFuzzer's summary — luck, not design. On a real finding the panic message is the first thing anyone needs.

It is now pulled out explicitly and placed at the top of the report, with libFuzzer's summary as the fallback for a crash that isn't a Rust panic (timeout, OOM, signal).

Verified against three logs: a panic sitting fifty lines above the tail (extracted correctly, with its message), an out-of-memory summary with no panic (falls back), and an empty log (says so rather than rendering an empty block).