### PR TITLE
Interleave the PR benchmark gate so it can see a real regression

### DIFF
--- a/.github/scripts/check_benchmark.py
+++ b/.github/scripts/check_benchmark.py
@@ -30,9 +30,16 @@ therefore sits inside the between-runner noise band: tight enough to catch a
 real regression means flaking on honest changes, and loose enough not to flake
 means missing the ~26% class of regression that motivated this (see issue #120).
 
-Comparing two builds in the same job cancels that, because both measurements see
-the same CPU in the same thermal state. At 0.3% noise a few-percent threshold is
-meaningful.
+Comparing two builds in the same job cancels most of that, because both
+measurements see the same CPU in the same thermal state. It is not sufficient on
+its own: pairing each build with its own measurement leaves a ~16% artifact from
+the build cycle itself, which on 2026-08-27 reported -0.2% on a real +15.7%
+toolchain regression (#120). The regression check therefore moved to
+``ab_median.py``, which builds both sides first and interleaves the measurements;
+at ~0.3% residual noise a few-percent threshold is meaningful there.
+
+What remains here is the absolute floor, which needs no base revision and catches
+drift a base comparison cannot see -- because the base drifted with it.
 
 The comparison uses each benchmark's *minimum* time, not the mean: the min is
 the cleanest observed run and the least noise-prone metric.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -349,45 +349,98 @@ jobs:
           fi
           echo "comparison base: $base"
 
-      - name: Benchmark this revision
+      # Both revisions are BUILT first and measured afterwards, alternating
+      # between them. Pairing each build with its own measurement is what this
+      # gate used to do, and it is not good enough: two build-and-measure cycles
+      # read ~16% apart on a no-op, so the gate could report a few percent on a
+      # real regression. That is not hypothetical -- on 2026-08-27 the toolchain
+      # comparison, built the same way, reported -0.2% on what an interleaved
+      # measurement showed to be +15.7% (#120). Within-job noise is only ~0.3%
+      # once the builds are out of the way.
+      - name: Build this revision
         run: |
           python -m venv "$RUNNER_TEMP/venv-head"
           "$RUNNER_TEMP/venv-head/bin/pip" install -q --upgrade pip
           "$RUNNER_TEMP/venv-head/bin/pip" install -q ".[test]"
-          "$RUNNER_TEMP/venv-head/bin/pytest" -q tests/benchmark \
-            --benchmark-min-rounds=25 --benchmark-json=head.json
 
-      - name: Benchmark the comparison base
+      - name: Build the comparison base
         if: steps.base.outputs.compare == 'true'
         env:
           BASE_SHA: ${{ steps.base.outputs.sha }}
         run: |
-          # Each revision is built and measured in its own tree and venv, so the
-          # base build cannot be shadowed by this revision's sources.
+          # A separate tree and venv, so the base build cannot be shadowed by
+          # this revision's sources.
           git worktree add "$RUNNER_TEMP/base" "$BASE_SHA"
           python -m venv "$RUNNER_TEMP/venv-base"
           "$RUNNER_TEMP/venv-base/bin/pip" install -q --upgrade pip
-          "$RUNNER_TEMP/venv-base/bin/pip" install -q "$RUNNER_TEMP/base[test]"
-          cd "$RUNNER_TEMP/base"
-          "$RUNNER_TEMP/venv-base/bin/pytest" -q tests/benchmark \
-            --benchmark-min-rounds=25 \
-            --benchmark-json="$GITHUB_WORKSPACE/base.json"
+          CARGO_TARGET_DIR="$RUNNER_TEMP/target-base" \
+            "$RUNNER_TEMP/venv-base/bin/pip" install -q "$RUNNER_TEMP/base[test]"
+
+      - name: Decide whether there is anything to compare
+        id: differ
+        if: steps.base.outputs.compare == 'true'
+        run: |
+          # A docs- or test-only change compiles to a byte-identical extension,
+          # and comparing it with itself can only produce noise -- which a 7%
+          # threshold will eventually read as a regression. Skip instead.
+          head_so=$(find "$RUNNER_TEMP/venv-head" -name '*.so' -path '*fast_mail_parser*' | head -1)
+          base_so=$(find "$RUNNER_TEMP/venv-base" -name '*.so' -path '*fast_mail_parser*' | head -1)
+          head_hash=$(sha256sum "$head_so" | cut -d' ' -f1)
+          base_hash=$(sha256sum "$base_so" | cut -d' ' -f1)
+          echo "this revision: $head_hash"
+          echo "base:          $base_hash"
+          if [ "$head_hash" = "$base_hash" ]; then
+            echo "identical=true" >> "$GITHUB_OUTPUT"
+            echo "The extension is byte-identical to the base, so there is nothing to compare." \
+              >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "identical=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Measure, interleaved
+        run: |
+          # This revision's benchmark code measures BOTH builds. Running each
+          # revision's own copy would change the instrument and the subject at
+          # once, so a PR that touched tests/benchmark compared nothing
+          # meaningful. A benchmark added here that needs an API the base lacks
+          # must therefore guard itself with a skip.
+          compare='${{ steps.base.outputs.compare }}'
+          identical='${{ steps.differ.outputs.identical }}'
+          sides="head"
+          if [ "$compare" = "true" ] && [ "$identical" != "true" ]; then
+            sides="head base"
+          fi
+          for round in 1 2 3; do
+            for side in $sides; do
+              echo "::group::round $round — $side"
+              "$RUNNER_TEMP/venv-$side/bin/pytest" -q tests/benchmark \
+                --benchmark-min-rounds=25 \
+                --benchmark-json="$side-$round.json"
+              echo "::endgroup::"
+            done
+          done
+          # The absolute floor reads one report; any round will do.
+          cp head-1.json head.json
 
       - name: Enforce performance gate
         env:
-          # Primary gate: slowdown against the base, measured on this runner.
-          # Within-job noise is ~0.3%, so a few percent is a real signal.
-          BENCH_MAX_REGRESSION_PCT: "7"
+          # Primary gate: slowdown against the base. Interleaved and
+          # noise-floor-checked, so a few percent is a real signal.
+          AB_THRESHOLD_PCT: "7"
           # Secondary: catastrophic-drift net only. Deliberately far below the
           # observed 6.3-7.7x range so it cannot flake; the base comparison is
           # what actually catches regressions.
           BENCH_MIN_SPEEDUP: "5.0"
         run: |
-          if [ "${{ steps.base.outputs.compare }}" = "true" ]; then
-            python .github/scripts/check_benchmark.py head.json base.json
-          else
-            python .github/scripts/check_benchmark.py head.json
+          if [ "${{ steps.base.outputs.compare }}" = "true" ] \
+             && [ "${{ steps.differ.outputs.identical }}" != "true" ]; then
+            python .github/scripts/ab_median.py \
+              --a-label "this revision" --b-label "base" \
+              --a head-*.json --b base-*.json
           fi
+          # Absolute floor, always: it needs no base and catches drift that a
+          # base comparison cannot see, because the base drifted too.
+          python .github/scripts/check_benchmark.py head.json
 
       - name: Render the cross-library comparison table
         if: always()
@@ -410,5 +463,6 @@ jobs:
           name: benchmark-json
           path: |
             head.json
-            base.json
+            head-[0-9].json
+            base-[0-9].json
           if-no-files-found: warn


### PR DESCRIPTION
The gate that guards every PR had the flaw that nearly cost us an unpin today.

## The problem, with evidence

The gate built each revision and measured it in the same step. Two such build-and-measure cycles read **~16% apart on a no-op** — so a gate with a **7%** threshold was reading a number whose error was twice its threshold.

Today the toolchain comparison, built exactly the same way, reported **−0.2% PASS** on what an interleaved measurement then showed to be **+15.7%** ([#120](https://github.com/namecheap/fast_mail_parser/issues/120#issuecomment-5435938523)). And the two runs reconcile: correcting the single-shot run by its own pure-Python control — which cannot depend on what compiled the extension, and had moved 10.5% — recovers **+11.4%**. The regression was in that data all along; a measurement artifact of almost the right size cancelled it.

Nothing about that was specific to toolchains. The same failure was available to this gate on any pull request.

## The change

Both revisions are built first and measured afterwards, alternating, median per side, verdict withheld unless it clears the noise floor the pure-Python benchmarks establish (`ab_median.py`, from #159). In the two measurements run through it so far, residual per-round spread was ~0.2% and the floor 0.5–4.4%.

## Three consequences worth calling out

**This revision's benchmark code now measures both builds.** Previously each revision ran *its own* copy of `tests/benchmark`, so a PR that touched the benchmark changed the instrument and the subject at the same time and compared nothing meaningful. Consequence: a benchmark added in a PR that needs an API the base lacks must guard itself with a skip.

**Byte-identical extensions skip the comparison.** A docs- or test-only change compiles to the same `.so`, and comparing it with itself can only produce noise — which a 7% threshold would eventually call a regression. The hashes are compared and the comparison is skipped when they match, which also saves three rounds of benchmarking on documentation PRs.

**The absolute floor still runs on every PR**, base or not. It catches drift a base comparison cannot see, because the base drifted with it.

## Cost

Three rounds per side instead of one measurement each, so the job grows by roughly a minute. That buys a gate whose reading is smaller than its threshold instead of double it.

`check_benchmark.py`'s docstring described the old method as sufficient; corrected, with the counter-example recorded.