### PR TITLE
Borrow bytes payloads instead of copying them

### DIFF
--- a/src/fast_mail_parser.rs
+++ b/src/fast_mail_parser.rs
@@ -18,6 +18,7 @@ mod mail_parser;
 
 use mailparse::MailParseError;
 use pyo3::prelude::*;
+use pyo3::pybacked::PyBackedBytes;
 use pyo3::types::{PyBytes, PyDateTime, PyDict, PyList, PyString, PyTzInfo};
 use pyo3::{create_exception, exceptions, wrap_pyfunction};
 use std::num::NonZeroUsize;
@@ -304,16 +305,47 @@ impl PyMail {
 /// unchanged because ASCII == its own UTF-8, and non-ASCII code points round-trip
 /// correctly instead of being truncated to their low byte). Any other type raises
 /// Python `TypeError`.
-fn payload_to_bytes(payload: &Py<PyAny>, py: Python<'_>) -> PyResult<Vec<u8>> {
+/// A caller's payload, ready to be read with the GIL released.
+///
+/// `bytes` is borrowed rather than copied (#96). Holding a `PyBackedBytes` keeps
+/// the Python object alive and hands out its buffer directly, and reading it
+/// detached is sound because `bytes` is immutable -- nothing can change or free
+/// it underneath us while we hold the reference.
+///
+/// The copy this avoids was not a rounding error at batch sizes. `parse_many`
+/// duplicated every payload before parsing any of them, so a batch of ten
+/// thousand one-megabyte messages needed ten gigabytes of copies *in addition to*
+/// the originals the caller still held.
+///
+/// `str` is a different case and still gets copied. Under the limited API,
+/// obtaining UTF-8 from a `str` means asking CPython to encode it, which
+/// allocates -- there is no buffer to borrow. Callers who care about throughput
+/// should pass `bytes`, which is also what reading a mail file or socket gives
+/// them.
+enum Payload {
+    Borrowed(PyBackedBytes),
+    Owned(Vec<u8>),
+}
+
+impl AsRef<[u8]> for Payload {
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            Payload::Borrowed(bytes) => bytes.as_ref(),
+            Payload::Owned(bytes) => bytes.as_slice(),
+        }
+    }
+}
+
+fn payload_to_bytes(payload: &Py<PyAny>, py: Python<'_>) -> PyResult<Payload> {
     let obj = payload.bind(py);
 
     if let Ok(bytes) = obj.cast::<PyBytes>() {
-        return Ok(bytes.as_bytes().to_vec());
+        return Ok(Payload::Borrowed(PyBackedBytes::from(bytes.clone())));
     }
 
     if let Ok(text) = obj.cast::<PyString>() {
         if let Ok(text) = text.to_str() {
-            return Ok(text.as_bytes().to_vec());
+            return Ok(Payload::Owned(text.as_bytes().to_vec()));
         }
     }
 
@@ -342,7 +374,7 @@ fn parse_email_inner(py: Python<'_>, payload: Py<PyAny>) -> PyResult<PyMail> {
     // borrows from a Python object while the GIL is released. Errors and the
     // `PyMail` are produced after re-attaching, where the interpreter is needed.
     let mail = py
-        .detach(|| mail_parser::parse_email(message.as_slice()))
+        .detach(|| mail_parser::parse_email(message.as_ref()))
         .map_err(to_py_err)?;
 
     Ok(PyMail::from_mail(mail))
@@ -383,9 +415,11 @@ fn parse_many_inner(
     threads: Option<usize>,
     raise_on_error: bool,
 ) -> PyResult<Py<PyList>> {
-    // Convert every payload to owned bytes *before* releasing the GIL: this
-    // touches Python objects, and nothing may borrow from one while detached.
-    let messages: Vec<Vec<u8>> = payloads
+    // Resolve every payload *before* releasing the GIL: this touches Python
+    // objects, which requires the interpreter. What is held afterwards is a
+    // reference to each `bytes` object plus its buffer pointer, not a copy of
+    // its contents, so the batch is no longer duplicated in full (#96).
+    let messages: Vec<Payload> = payloads
         .iter()
         .map(|payload| payload_to_bytes(payload, py))
         .collect::<PyResult<_>>()?;

--- a/src/mail_parser.rs
+++ b/src/mail_parser.rs
@@ -68,8 +68,8 @@ pub(crate) fn parse_email(payload: &[u8]) -> Result<Mail, MailParseError> {
 ///
 /// `threads` caps the worker count; `None` uses the machine's parallelism.
 /// Callers with a batch smaller than the thread count do not spawn idle workers.
-pub(crate) fn parse_many(
-    payloads: &[Vec<u8>],
+pub(crate) fn parse_many<P: AsRef<[u8]> + Sync>(
+    payloads: &[P],
     threads: Option<NonZeroUsize>,
 ) -> Vec<Result<Mail, MailParseError>> {
     if payloads.is_empty() {
@@ -83,7 +83,10 @@ pub(crate) fn parse_many(
     let workers = available.min(payloads.len()).max(1);
 
     if workers == 1 {
-        return payloads.iter().map(|payload| Mail::new(payload)).collect();
+        return payloads
+            .iter()
+            .map(|payload| Mail::new(payload.as_ref()))
+            .collect();
     }
 
     let cursor = AtomicUsize::new(0);
@@ -100,7 +103,7 @@ pub(crate) fn parse_many(
                         if index >= payloads.len() {
                             break;
                         }
-                        mine.push((index, Mail::new(&payloads[index])));
+                        mine.push((index, Mail::new(payloads[index].as_ref())));
                     }
                     mine
                 })

--- a/tests/benchmark/test_read_message.py
+++ b/tests/benchmark/test_read_message.py
@@ -19,8 +19,11 @@ with their payloads decoded. That is the comparison worth publishing, and it is
 what `make bench-table` renders.
 
 Names matter here: `.github/scripts/check_benchmark.py` selects the gate pair by
-substring, so the table pair must not contain `fast_mail_parser` or
-`mail_parser` (note `mailparser_lib` has no underscore).
+**exact** name -- substring matching was ambiguous, since any benchmark
+mentioning a library name made the selection two-valued and failed the gate
+rather than being ignored. New benchmarks are therefore free to be named after
+what they measure; they ride along in the interleaved comparison without
+disturbing the gate pair.
 """
 
 import email
@@ -119,3 +122,14 @@ def test__stdlib_email___full_read(large_message: str, benchmark: Callable):
     assert _stdlib_full(raw)[0], "expected a subject"
 
     benchmark(_stdlib_full, raw)
+
+
+def test__fast_mail_parser___parse_many(large_message: str, benchmark: Callable):
+    from fast_mail_parser import parse_many
+
+    # Single-threaded on purpose: this measures per-payload overhead -- the
+    # handling of the caller's bytes -- and thread scheduling would only add
+    # noise to that. Parallel throughput is a separate question.
+    batch = [large_message.encode()] * 8
+
+    benchmark(lambda: parse_many(batch, threads=1))

--- a/tests/test_payload_memory.py
+++ b/tests/test_payload_memory.py
@@ -1,0 +1,84 @@
+"""Peak memory of a payload handed to the parser (#96).
+
+Every payload used to be copied into Rust-owned memory before any parsing began,
+so a batch cost its own size again in duplicates while the caller still held the
+originals. Payloads that are `bytes` are now borrowed.
+
+Two things make this measurable at all:
+
+**An oversized payload.** A payload just over MAX_INPUT_BYTES is rejected before
+any parsing work (see `test_dos_limits.py`), so nothing else allocates and the
+copy is essentially the only memory movement left. For a payload that parses
+normally, the decoded result would dominate and hide it.
+
+**A subprocess.** `ru_maxrss` is a high-water mark that never falls, so any
+earlier test in this process that allocated more would leave `before` already
+above what the call reaches — and the assertion would pass without measuring
+anything.
+"""
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="ru_maxrss is kilobytes on Linux and bytes on macOS; keep the units unambiguous",
+)
+
+# Copying the payload would cost this much; the allowance is a fifth of it.
+PAYLOAD_MIB = 100
+ALLOWED_GROWTH_MIB = PAYLOAD_MIB / 5
+
+PROBE = textwrap.dedent(
+    """
+    import resource
+    import sys
+
+    from fast_mail_parser import MimeStructureError, parse_email
+
+    limit = 100 * 1024 * 1024
+    payload = b"Subject: big\\r\\n\\r\\n" + b"x" * (limit + 1)
+
+    # After building the payload: its own cost is part of the baseline, so what
+    # is measured is only what the parser adds on top.
+    before = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    try:
+        parse_email(payload)
+    except MimeStructureError:
+        pass
+    else:
+        sys.exit("the oversized payload was not rejected")
+    after = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+
+    print((after - before) / 1024)
+    """
+)
+
+
+def test__an_oversized_payload_is_not_copied_before_being_rejected():
+    probe = subprocess.run(
+        [sys.executable, "-c", PROBE], capture_output=True, text=True
+    )
+
+    assert probe.returncode == 0, probe.stderr
+    growth = float(probe.stdout.strip())
+
+    assert growth < ALLOWED_GROWTH_MIB, (
+        f"peak memory grew {growth:.1f} MiB while rejecting a {PAYLOAD_MIB} MiB "
+        f"payload that is discarded before parsing; more than "
+        f"{ALLOWED_GROWTH_MIB:.0f} MiB suggests it is being copied first"
+    )
+
+
+def test__bytes_and_str_payloads_agree(valid_message: str):
+    # `str` still gets copied -- the limited API has no UTF-8 buffer to borrow --
+    # so the two paths differ internally and must not differ in result.
+    from fast_mail_parser import parse_many
+
+    from_str, from_bytes = parse_many([valid_message, valid_message.encode()])
+
+    assert from_str.subject == from_bytes.subject
+    assert from_str.text_plain == from_bytes.text_plain
+    assert list(from_str.headers) == list(from_bytes.headers)

--- a/tests/test_payload_memory.py
+++ b/tests/test_payload_memory.py
@@ -14,7 +14,8 @@ normally, the decoded result would dominate and hide it.
 **A subprocess.** `ru_maxrss` is a high-water mark that never falls, so any
 earlier test in this process that allocated more would leave `before` already
 above what the call reaches — and the assertion would pass without measuring
-anything.
+anything. It runs outside the repository root, so that the source package there
+does not shadow the installed extension.
 """
 import subprocess
 import sys
@@ -57,9 +58,16 @@ PROBE = textwrap.dedent(
 )
 
 
-def test__an_oversized_payload_is_not_copied_before_being_rejected():
+def test__an_oversized_payload_is_not_copied_before_being_rejected(tmp_path):
+    # Run it from somewhere other than the repository root. `python -c` puts the
+    # working directory first on sys.path, so from the root the source
+    # `fast_mail_parser/` package shadows the installed wheel and the probe
+    # imports a package with no compiled extension in it.
     probe = subprocess.run(
-        [sys.executable, "-c", PROBE], capture_output=True, text=True
+        [sys.executable, "-c", PROBE],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
     )
 
     assert probe.returncode == 0, probe.stderr


### PR DESCRIPTION
Addresses the remaining piece of #96. **Does not close it** — the issue also covers the rayon pool and API shape, which `parse_many` already landed; whether anything else there is still wanted is worth a separate read.

## The copy

Every payload was copied into Rust-owned memory before parsing began. For `parse_many` that means the whole batch was duplicated *before any of it was parsed*, while the caller still held the originals — ten gigabytes of copies for ten thousand one-megabyte messages. The function's own docstring warned about batch memory without mentioning that half of it was avoidable.

`bytes` payloads are now borrowed via `PyBackedBytes`, which keeps the Python object alive and hands out its buffer. Reading that buffer with the GIL released is sound because `bytes` is immutable — nothing can change or free it while the reference is held.

**`str` still gets copied and cannot not be.** Under the limited API, getting UTF-8 out of a `str` means asking CPython to encode it, which allocates; there is no buffer to borrow. So `bytes` is the fast path, which is also what reading a file or socket hands you. A test asserts both paths give identical results.

## Measuring it honestly took two tricks

I first wrote this test with a batch of garbage payloads and an assertion that they all fail to parse — behaviour I had not verified and cannot run locally, since there's no Rust toolchain in my environment. Replaced with something already proven in `test_dos_limits.py`:

**An oversized payload.** One just past `MAX_INPUT_BYTES` is rejected *before any parsing work*, so the copy is essentially the only memory movement left. For a payload that parses normally, the decoded result dominates and hides the thing under test.

**A subprocess.** `ru_maxrss` is a high-water mark that never falls. `test_dos_limits.py` already allocates ~100 MiB in this process, so `before` would have been sitting above anything the call reaches — and the assertion would have passed while measuring nothing. This is the kind of test that silently succeeds forever, so it's worth being explicit about.

The probe asserts peak growth stays under 20 MiB while rejecting a 100 MiB payload. Reintroducing the copy breaches that by 5x.

## Also

- A single-threaded `parse_many` benchmark: measures per-payload overhead without thread-scheduling noise. Parallel throughput is a separate question.
- Corrects the benchmark file's claim that the gate selects its pair *by substring*. It matches exact names now — which is precisely why a new benchmark can be added there without breaking the gate.

## Note on the gate

This is the first Rust-touching PR since #168, so it's the first to exercise the **interleaved** comparison path rather than the byte-identical skip. I'll check the gate's own output on this PR before merging — the throughput effect may well sit under the noise floor, since the win here is memory rather than time, and I'd rather report that than claim a speedup.