### PR TITLE
Run one benchmark round when there is nothing to compare

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -406,11 +406,17 @@ jobs:
           # must therefore guard itself with a skip.
           compare='${{ steps.base.outputs.compare }}'
           identical='${{ steps.differ.outputs.identical }}'
+          # Interleaving only earns its rounds when there are two sides to
+          # alternate between. With nothing to compare, the absolute floor reads
+          # a single report, so two further rounds would be runner time spent to
+          # produce numbers nothing looks at.
           sides="head"
+          rounds="1"
           if [ "$compare" = "true" ] && [ "$identical" != "true" ]; then
             sides="head base"
+            rounds="1 2 3"
           fi
-          for round in 1 2 3; do
+          for round in $rounds; do
             for side in $sides; do
               echo "::group::round $round — $side"
               "$RUNNER_TEMP/venv-$side/bin/pytest" -q tests/benchmark \


### PR DESCRIPTION
Follow-up to #168.

Interleaving earns its rounds only when there are two sides to alternate between. On a docs- or test-only PR the extension is byte-identical, so the comparison is skipped and the absolute floor reads a single report — but three rounds ran regardless, two of them producing numbers nothing reads.

Verified on #170's own run, which took the skip path and measured `head` three times for no reason.