### PR TITLE
Stop the canary from poisoning the fuzz corpus

### DIFF
--- a/.github/workflows/deep-fuzz.yml
+++ b/.github/workflows/deep-fuzz.yml
@@ -77,6 +77,27 @@ jobs:
           key: fuzz-corpus-parse_email-${{ github.run_id }}
           restore-keys: fuzz-corpus-parse_email-
 
+      - name: Evict any canary left in the corpus
+        run: |
+          # The canary is planted INTO the corpus, and the corpus is cached, so a
+          # drill used to leave it there for every later run to trip over -- each
+          # one crashing within seconds and filing a crasher issue for a crash
+          # that was staged on purpose. Exactly what happened on the first real
+          # run after the drills.
+          #
+          # Matched by content rather than by the filename the drill uses, so a
+          # copy under any other name goes too.
+          mkdir -p fuzz/corpus/parse_email
+          found=$(grep -rlF 'FMP_FUZZ_CANARY_DO_NOT_REPORT_42' \
+            fuzz/corpus/parse_email 2>/dev/null || true)
+          if [ -n "$found" ]; then
+            echo "::warning::evicting canary inputs left in the restored corpus"
+            echo "$found" | while read -r stale; do
+              echo "  removing $stale"
+              rm -f "$stale"
+            done
+          fi
+
       - name: Seed the corpus from the test fixtures
         run: |
           mkdir -p fuzz/corpus/parse_email
@@ -114,7 +135,11 @@ jobs:
 
       - name: Save the accumulated corpus
         # Also on failure: the inputs found before the crash are worth keeping.
-        if: always()
+        #
+        # Never from a drill, though. A drill crashes within seconds, so its
+        # corpus has nothing in it worth keeping, and saving one is how the canary
+        # got into the cache in the first place.
+        if: always() && inputs.inject_canary != true
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: fuzz/corpus/parse_email


### PR DESCRIPTION
Fixes a bug in #163/#166 that only running the thing could reveal. Toward #102.

## What happened

The first **real** deep-fuzz run after the two drills reported a crasher within seconds ([#171](https://github.com/namecheap/fast_mail_parser/issues/171), [run 33053513959](https://github.com/namecheap/fast_mail_parser/actions/runs/33053513959)):

```
panicked at fuzz_targets/parse_email.rs:106:9:
fuzz canary: this crash is a deliberate test of the reporting path
```

It was the canary. The drill plants it **into the corpus directory**, the corpus is cached and restored between runs, and the save step ran `if: always()` — so each drill left its staged crash in the cache for every later run to trip over.

The alarm was working exactly as designed, and would have reported a deliberately staged crash every Monday, indefinitely. A self-inflicted false positive is the worst kind for an alarm: it trains you to ignore it.

## Two changes, because either alone leaves a hole

**Don't save a drill's corpus.** A drill crashes within seconds, so its corpus contains nothing worth keeping — and saving it is how the canary reached the cache.

**Evict any canary from a restored corpus.** This heals the cache that is poisoned *right now*, rather than waiting for it to age out. Matching is on content rather than the filename the drill uses, so a copy under any other name goes too.

## Verifying rather than assuming

After merge I'll dispatch a short **non-canary** run. The cached corpus still contains the canary today, so a green result is a direct test of the eviction path — and this bug exists precisely because I trusted a mechanism I had not exercised end to end.