### PR TITLE
Cap generated fuzz input size so the deep run finds more per minute

### DIFF
--- a/.github/workflows/deep-fuzz.yml
+++ b/.github/workflows/deep-fuzz.yml
@@ -13,6 +13,14 @@ name: Deep fuzz
 #     seed deliberately, to stay reproducible; here that would mean repeating one
 #     search every week forever.
 #
+# Input size is capped, because leaving it uncapped made the run slow. libFuzzer
+# takes its default limit from the largest seed, and the seed corpus contains a
+# 0.75 MiB message -- so it generated inputs averaging ~59 KiB and managed only
+# ~158 executions per second, building a 57 MiB corpus in two minutes. Bugs per
+# minute is what matters here, and mail parsers do not need 700 KiB inputs to
+# expose them; behaviour on oversized input is covered directly by
+# tests/test_dos_limits.py instead.
+#
 # A crasher becomes an artifact, a minimized reproducer, and an entry on a single
 # pinned issue rather than a new issue per run.
 on:
@@ -29,6 +37,9 @@ on:
         description: "Plant the canary input to test the crash-reporting path"
         type: boolean
         default: false
+      max_len:
+        description: "Largest input libFuzzer will generate, bytes"
+        default: "65536"
 
 permissions:
   contents: read
@@ -49,6 +60,7 @@ jobs:
       # Keep in step with the short pass in test.yml.
       CARGO_FUZZ_VERSION: "0.13.2"
       FUZZ_SECONDS: ${{ inputs.seconds || 1800 }}
+      FUZZ_MAX_LEN: ${{ inputs.max_len || 65536 }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
@@ -74,8 +86,8 @@ jobs:
           path: fuzz/corpus/parse_email
           # A cache entry is immutable, so each run writes a new key and inherits
           # the newest previous one by prefix.
-          key: fuzz-corpus-parse_email-${{ github.run_id }}
-          restore-keys: fuzz-corpus-parse_email-
+          key: fuzz-corpus-v2-parse_email-${{ github.run_id }}
+          restore-keys: fuzz-corpus-v2-parse_email-
 
       - name: Evict any canary left in the corpus
         run: |
@@ -127,6 +139,7 @@ jobs:
           set -o pipefail
           if cargo fuzz run parse_email -- \
                -max_total_time="$FUZZ_SECONDS" \
+               -max_len="$FUZZ_MAX_LEN" \
                -print_final_stats=1 2>&1 | tee fuzz-output.log; then
             echo "crashed=false" >> "$GITHUB_OUTPUT"
           else
@@ -143,7 +156,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: fuzz/corpus/parse_email
-          key: fuzz-corpus-parse_email-${{ github.run_id }}
+          key: fuzz-corpus-v2-parse_email-${{ github.run_id }}
 
       - name: Minimize the crasher
         if: steps.fuzz.outputs.crashed == 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,6 +206,12 @@ minutes with no fixed seed and, importantly, **caches the corpus between runs**,
 so coverage compounds instead of restarting from the fixtures every week — that
 accumulation is most of what makes a scheduled run worth more than the PR pass.
 
+Generated inputs are capped at 64 KiB (`-max_len`). Uncapped, libFuzzer takes its
+limit from the largest seed — and the seed corpus contains a 0.75 MiB message — so
+it spent its time on ~59 KiB inputs at ~158 executions per second. Bugs per minute
+is the thing being bought here, and oversized-input behaviour is covered directly
+by `tests/test_dos_limits.py` rather than by hoping the fuzzer stumbles into it.
+
 A crasher there is minimised, uploaded, and reported onto a single pinned issue
 labelled `fuzz-crash`: one issue that gets comments, not a new issue per week,
 because a crasher stays in the corpus and keeps being found until it is fixed.


### PR DESCRIPTION
Toward #102. Found by reading the first real deep run's output rather than assuming it was working well.

## What the log showed

```
DONE   cov: 2858 ft: 9841 corp: 971/57Mb lim: 785774 exec/s: 157
```

**157 executions per second**, and a **57 MiB** corpus built in two minutes. Both come from `lim: 785774` — libFuzzer takes its default input-size limit from the largest seed, and the seed corpus contains a 0.75 MiB message. So it spent its time mutating inputs averaging ~59 KiB.

For comparison, the interesting structure in email — headers, boundaries, encodings, charsets — fits in kilobytes. A fuzzer's value is bugs found per minute, and this configuration was buying very few of either.

## The change

Inputs capped at **64 KiB**, adjustable per dispatch. Oversized-input behaviour is not lost from coverage: `tests/test_dos_limits.py` asserts directly that a payload past `MAX_INPUT_BYTES` is rejected before any parsing, which is a stronger statement than hoping the fuzzer wanders there.

The corpus cache lineage is bumped to `v2` in the same change, because the current cache holds those 971 large inputs and inheriting them would keep every run slow no matter what the limit says. That costs one run's accumulation and buys the throughput the cap exists for.

## Verification

I'll dispatch a run after merge and compare `exec/s` against the 157 above. If it doesn't improve materially, the diagnosis is wrong and this should come back out — I'll report the number either way.