### PR TITLE
Arm the fuzz canary from the environment, not from input bytes

### DIFF
--- a/.github/workflows/deep-fuzz.yml
+++ b/.github/workflows/deep-fuzz.yml
@@ -89,27 +89,6 @@ jobs:
           key: fuzz-corpus-v2-parse_email-${{ github.run_id }}
           restore-keys: fuzz-corpus-v2-parse_email-
 
-      - name: Evict any canary left in the corpus
-        run: |
-          # The canary is planted INTO the corpus, and the corpus is cached, so a
-          # drill used to leave it there for every later run to trip over -- each
-          # one crashing within seconds and filing a crasher issue for a crash
-          # that was staged on purpose. Exactly what happened on the first real
-          # run after the drills.
-          #
-          # Matched by content rather than by the filename the drill uses, so a
-          # copy under any other name goes too.
-          mkdir -p fuzz/corpus/parse_email
-          found=$(grep -rlF 'FMP_FUZZ_CANARY_DO_NOT_REPORT_42' \
-            fuzz/corpus/parse_email 2>/dev/null || true)
-          if [ -n "$found" ]; then
-            echo "::warning::evicting canary inputs left in the restored corpus"
-            echo "$found" | while read -r stale; do
-              echo "  removing $stale"
-              rm -f "$stale"
-            done
-          fi
-
       - name: Seed the corpus from the test fixtures
         run: |
           mkdir -p fuzz/corpus/parse_email
@@ -119,18 +98,19 @@ jobs:
                "$(find fuzz/corpus/parse_email -type f | wc -l) after seeding"
           echo "corpus_inherited=$inherited" >> "$GITHUB_ENV"
 
-      - name: Plant the canary
-        if: inputs.inject_canary
-        run: |
-          # Exercises the crash path on demand. The target panics on exactly
-          # these bytes; see CANARY in fuzz/fuzz_targets/parse_email.rs.
-          printf '%s' 'FMP_FUZZ_CANARY_DO_NOT_REPORT_42' \
-            > fuzz/corpus/parse_email/zz-canary
-          echo "::warning::canary planted -- this run is expected to crash"
-
       - name: Fuzz parse_email
         id: fuzz
+        env:
+          # Arms the deliberate panic in the target, for a drill of the reporting
+          # path. Passed through the environment rather than as a magic input:
+          # libFuzzer learns the operands of comparisons against input, so an
+          # input-triggered canary is something it finds -- and finds within
+          # seconds, twice.
+          FMP_FUZZ_CANARY: ${{ inputs.inject_canary && '1' || '' }}
         run: |
+          if [ -n "${FMP_FUZZ_CANARY:-}" ]; then
+            echo "::warning::canary armed -- this run is expected to crash"
+          fi
           # No -seed: each run should explore somewhere new.
           #
           # The crash is recorded as an output instead of failing the step here,
@@ -149,9 +129,8 @@ jobs:
       - name: Save the accumulated corpus
         # Also on failure: the inputs found before the crash are worth keeping.
         #
-        # Never from a drill, though. A drill crashes within seconds, so its
-        # corpus has nothing in it worth keeping, and saving one is how the canary
-        # got into the cache in the first place.
+        # Never from a drill, though: it crashes on its first input, so its
+        # corpus holds nothing worth keeping.
         if: always() && inputs.inject_canary != true
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,9 +219,17 @@ Anything found should be minimised and committed as a regression fixture under
 `tests/`, so the finding stays found.
 
 To rehearse that reporting path without waiting for a real crash, dispatch the
-workflow with `inject_canary`. It plants an input the target panics on by design
-(`CANARY` in `fuzz/fuzz_targets/parse_email.rs`) and the resulting issue says so
-— close it afterwards.
+workflow with `inject_canary`. That sets `FMP_FUZZ_CANARY` in the environment,
+which arms a deliberate panic in the target, and the resulting issue says so —
+close it afterwards.
+
+The canary is armed through the environment rather than by a magic input, and the
+first attempt got that wrong in two ways worth knowing before changing it.
+libFuzzer intercepts `memcmp` and **learns** the operands input is compared
+against, so a literal comparison is an instruction to the fuzzer rather than a
+secret from it — it found a 32-byte magic string within seconds. And the bytes had
+to be planted in the corpus, which is cached, so every drill left its staged crash
+behind for later runs to trip over. Both produced false crasher issues.
 
 A drill **passes green**: with `inject_canary` set, the job succeeds when the
 canary crashed and was reported, and fails when it did not, because a canary that

--- a/fuzz/fuzz_targets/parse_email.rs
+++ b/fuzz/fuzz_targets/parse_email.rs
@@ -88,21 +88,30 @@ fn total_output_bytes(mail: &mail_parser::Mail) -> usize {
     bodies + attachments + headers + mail.subject.len() + mail.date.len()
 }
 
-/// Input that makes this target panic on purpose.
+/// Panic on purpose when `FMP_FUZZ_CANARY` is set in the environment.
 ///
-/// The scheduled deep run is supposed to turn a crasher into an artifact and a
-/// filed issue, and #102 asks for that path to be verified rather than trusted.
-/// Verifying it needs a crash on demand, and the whole point of the harness is
-/// that no known input produces one -- so this provides it.
+/// The scheduled deep run turns a crasher into an artifact and a filed issue, and
+/// #102 asks for that path to be verified rather than trusted. Verifying it needs
+/// a crash on demand, and the point of the harness is that no known input
+/// produces one -- so the drill has to stage one.
 ///
-/// Dispatching the deep-fuzz workflow with `inject_canary` writes these bytes
-/// into the corpus, and libFuzzer runs corpus inputs first. Nothing else reaches
-/// it: a 32-byte magic string is far outside what random mutation finds, and
-/// nothing in the seed corpus resembles it.
-const CANARY: &[u8] = b"FMP_FUZZ_CANARY_DO_NOT_REPORT_42";
+/// It is staged through the **environment**, not through input bytes, and the
+/// first version got this wrong twice over. A magic 32-byte input looked
+/// unreachable by chance, and libFuzzer found it within seconds: it intercepts
+/// `memcmp` and learns the operands it is compared against, so a literal
+/// comparison against input is an instruction to the fuzzer, not a secret from
+/// it. (`PersAutoDict` in its own log is that machinery at work.) The bytes also
+/// had to be planted in the corpus, and the corpus is cached, so each drill left
+/// its staged crash behind for later runs to trip over.
+///
+/// An environment variable has neither problem. No input can synthesise it, and
+/// nothing is written where it can persist.
+fn canary_armed() -> bool {
+    std::env::var_os("FMP_FUZZ_CANARY").is_some()
+}
 
 fuzz_target!(|data: &[u8]| {
-    if data == CANARY {
+    if canary_armed() {
         panic!("fuzz canary: this crash is a deliberate test of the reporting path");
     }
 


### PR DESCRIPTION
Second false crasher from the same feature ([#175](https://github.com/namecheap/fast_mail_parser/issues/175)), and this time the cause is more interesting than the first. Toward #102.

## The corpus was clean and it still fired

- `Plant the canary` — **skipped** (no `inject_canary`)
- corpus — **inherited 0 inputs**, freshly seeded with 19 fixtures
- and the run still panicked on the canary, within seconds

So #173's fix was correct and insufficient: nothing planted the bytes. **libFuzzer found the magic string itself.**

It intercepts `memcmp` and *learns* the operands that input is compared against, then feeds them back in — the `PersAutoDict` entries in its own log are exactly that machinery. A literal comparison against input is therefore an instruction to the fuzzer, not a secret from it.

Which makes my claim in #163 plainly wrong:

> Nothing else reaches it: a 32-byte magic string is far outside what random mutation finds

Random mutation would indeed never find it. libFuzzer does not rely on random mutation for this, and that is one of its better features — it just happens to defeat the way I staged the drill.

## The fix

Arm the canary from `FMP_FUZZ_CANARY` in the environment. No input can synthesise an environment variable, so the fuzzer cannot reach it; nothing is written into the corpus, so nothing persists into later runs. Both failure modes go at once, and #173's eviction step becomes unnecessary — removed along with the planting step.

## Why it matters beyond the drill

Two false crasher issues in one morning from the alarm's own test rig. An alarm that cries wolf on itself is worse than no alarm, because the next real crasher arrives in a mailbox that has learned to ignore it.

## Verification

After merge: a drill (must go **green** and report), then a normal run (must find nothing and stay green). Both, this time — the previous round verified the drill in isolation and missed what it did to the run *after* it.