### PR TITLE
Require a non-empty canary value, not merely a set one

### DIFF
--- a/.github/workflows/deep-fuzz.yml
+++ b/.github/workflows/deep-fuzz.yml
@@ -106,6 +106,11 @@ jobs:
           # libFuzzer learns the operands of comparisons against input, so an
           # input-triggered canary is something it finds -- and finds within
           # seconds, twice.
+          #
+          # This is still *set* on a normal run, to the empty string, because an
+          # `env:` entry cannot be conditionally omitted. The target therefore
+          # requires a non-empty value; treating "present" as armed fired the
+          # canary on every run.
           FMP_FUZZ_CANARY: ${{ inputs.inject_canary && '1' || '' }}
         run: |
           if [ -n "${FMP_FUZZ_CANARY:-}" ]; then

--- a/fuzz/fuzz_targets/parse_email.rs
+++ b/fuzz/fuzz_targets/parse_email.rs
@@ -106,8 +106,13 @@ fn total_output_bytes(mail: &mail_parser::Mail) -> usize {
 ///
 /// An environment variable has neither problem. No input can synthesise it, and
 /// nothing is written where it can persist.
+///
+/// The value must be non-empty, not merely present. A workflow `env:` entry whose
+/// expression evaluates to `''` still *defines* the variable, so `is_some()` was
+/// true on every run and armed the canary unconditionally -- a third false
+/// crasher, from the fix for the second.
 fn canary_armed() -> bool {
-    std::env::var_os("FMP_FUZZ_CANARY").is_some()
+    std::env::var_os("FMP_FUZZ_CANARY").is_some_and(|value| !value.is_empty())
 }
 
 fuzz_target!(|data: &[u8]| {


### PR DESCRIPTION
Third false crasher, and this one came out of the fix for the second — caught by the verification run I promised in #176 rather than by another Monday.

## The bug

`env:` cannot be conditionally omitted in a workflow, so a normal run still sets:

```yaml
FMP_FUZZ_CANARY: ${{ inputs.inject_canary && '1' || '' }}   # -> ""
```

An empty value still **defines** the variable. The target checked `std::env::var_os("FMP_FUZZ_CANARY").is_some()`, which is true for an empty value, so the canary armed on **every run**. The normal run dispatched to verify #176 crashed within forty seconds.

The bash guard in the very same step got this right — `[ -n "${FMP_FUZZ_CANARY:-}" ]` — while the Rust two lines away did not. That is the entire bug.

## The fix

`is_some_and(|value| !value.is_empty())`. Emptiness is what "unset" means for an `env:` entry that has to exist.

## Tally, since it is not flattering

Three false crasher issues from this drill mechanism in one morning: bytes planted in a cached corpus (#171), bytes learned by libFuzzer from a `memcmp` (#175), and now a set-but-empty environment variable. Each was found by running the thing rather than re-reading it, and each fix was correct about the failure it addressed and blind to the next one.

## Verification

Both halves again, in sequence: a drill (green, reports) followed immediately by a normal run (finds nothing, green). The pair is the test — verifying either alone is what let the first two through.