### PR TITLE
Add parse_email_tree: the MIME structure, not a projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`parse_email_tree(payload)`** returns the message's MIME tree with the
+  structure intact, and **`walk(part)`** iterates it depth-first in the same order
+  as the stdlib's `email.message.Message.walk` (#99). A pure addition:
+  `parse_email` is unchanged.
+  - Two things the flat projection cannot express. A `multipart/alternative`
+    node's children are the plain and HTML renderings *of the same thing*, which
+    `text_plain`/`text_html` cannot relate. And a `message/rfc822` part -- a
+    bounce or forward -- is now parsed rather than opaque: `is_message` is `True`
+    and the embedded message's own root is the part's single child, so its
+    headers are reachable instead of being an attachment blob to re-parse.
+  - Embedded nesting counts against the same recursion cap as multipart nesting.
+  - Tree topology is asserted against the stdlib's `walk()` over the whole
+    fixture and RFC corpus, which is the strongest correctness oracle available.
+
 - An internal panic now raises `ParseError` instead of PyO3's `PanicException`
   (#102). This is not about memory safety -- PyO3 already catches panics at the
   boundary, so one never aborted the process -- it is about which `except` clause

--- a/Readme.md
+++ b/Readme.md
@@ -289,6 +289,55 @@ The break-even point is not portable — the parse scales with cores while the
 per-call overhead does not — so treat the second table as the shape of the
 trade-off and measure your own mix if it matters.
 
+### The MIME tree
+
+`parse_email` hands back a flat projection: bodies in one list, attachments in
+another, `multipart/*` containers dropped. That is what most code wants, and it
+throws away the shape of the message. `parse_email_tree` keeps it.
+
+```python
+from fast_mail_parser import parse_email_tree, walk
+
+root = parse_email_tree(payload)
+
+for part in walk(root):                    # depth first, stdlib `walk()` order
+    print(part.content_type, len(part.content or b""))
+```
+
+Each node carries `content_type`, `headers` (same semantics as `PyMail.headers`),
+`filename`, `content_id`, `disposition`, `children`, and `content` — the
+transfer-decoded bytes of a leaf, or `None` for a container, whose body is only
+its children with boundaries between them.
+
+Two things the flat projection cannot express:
+
+**Which body goes with which.** A `multipart/alternative` node's children are the
+plain and HTML renderings *of the same thing*. Through `parse_email` they are one
+entry in `text_plain` and one in `text_html`, with nothing to relate them.
+
+**What is inside a bounce.** A `message/rfc822` part is an embedded message —
+ubiquitous in bounce and abuse handling. `parse_email` reports it as one
+attachment blob to re-parse by hand; here it is parsed, `is_message` is `True`,
+and the embedded message's own root is the part's single child:
+
+```python
+bounced = next(p for p in walk(root) if p.is_message)
+print(bounced.children[0].headers["Subject"])   # the original message's subject
+```
+
+Embedded nesting counts against the same recursion cap as multipart nesting, so
+an onion of forwards cannot recurse further than a multipart tree can.
+
+#### Which API when
+
+| | |
+| --- | --- |
+| `parse_email` | You want the subject, the body text, the attachments. Most code. |
+| `parse_email_tree` | The shape matters: forensics, bounce processing, deciding which alternative to render, anything that would otherwise reach for the stdlib's `walk()`. |
+
+Both accept the same payloads and raise the same errors. `parse_email` is
+unchanged by the tree API existing — it is a pure addition.
+
 ### Error handling
 
 `parse_email` raises a subtype of `ParseError`, chosen by what actually went

--- a/fast_mail_parser/__init__.py
+++ b/fast_mail_parser/__init__.py
@@ -1,3 +1,5 @@
+from collections.abc import Iterator
+
 from .fast_mail_parser import (
     DecodeError,
     HeaderParseError,
@@ -6,14 +8,35 @@ from .fast_mail_parser import (
     PyAddress,
     PyAttachment,
     PyMail,
+    PyMimePart,
     parse_email,
+    parse_email_tree,
     parse_many,
 )
 
+
+def walk(part: PyMimePart) -> Iterator[PyMimePart]:
+    """Yield `part` and every part beneath it, depth first.
+
+    The same order as the stdlib's `email.message.Message.walk`, so code written
+    against that reads the same here.
+
+    Written in Python rather than Rust deliberately: it is a generator, so a
+    caller that stops early -- the common case, looking for the first part of some
+    type -- does not pay for the rest of the walk.
+    """
+    yield part
+    for child in part.children:
+        yield from walk(child)
+
+
 __all__ = [
     "parse_email",
+    "parse_email_tree",
     "parse_many",
+    "walk",
     "PyMail",
+    "PyMimePart",
     "PyAttachment",
     "PyAddress",
     "ParseError",

--- a/fast_mail_parser/__init__.pyi
+++ b/fast_mail_parser/__init__.pyi
@@ -1,9 +1,13 @@
+from collections.abc import Iterator
 from datetime import datetime
 
 __all__ = [
     "parse_email",
+    "parse_email_tree",
     "parse_many",
+    "walk",
     "PyMail",
+    "PyMimePart",
     "PyAttachment",
     "PyAddress",
     "ParseError",
@@ -11,6 +15,38 @@ __all__ = [
     "MimeStructureError",
     "DecodeError",
 ]
+
+
+class PyMimePart:
+    """One node of a message's MIME tree, with the structure intact.
+
+    ``PyMail`` is a flattened projection of this -- bodies in one list,
+    attachments in another, containers dropped. Every flattening loses something:
+    which ``text/html`` part corresponds to which ``text/plain`` sibling, whether
+    a node was ``multipart/alternative`` or ``multipart/mixed``, where a bounce's
+    inner message begins.
+
+    ``content`` is the transfer-decoded bytes of a leaf, and ``None`` for a
+    ``multipart/*`` container -- whose body is just its children with boundaries
+    between them.
+
+    ``is_message`` is ``True`` for ``message/rfc822``: the embedded message's own
+    root is this part's single child, so a bounce's headers are reachable rather
+    than opaque. Such nesting counts against the same recursion cap as a
+    multipart tree.
+
+    ``headers`` keeps every value of every header, keys in the order the names
+    first appeared -- the same semantics as ``PyMail.headers``.
+    """
+
+    content_type: str
+    headers: dict[str, list[str]]
+    filename: str
+    content_id: str | None
+    disposition: str | None
+    is_message: bool
+    content: bytes | None
+    children: list[PyMimePart]
 
 
 class PyAddress:
@@ -160,6 +196,24 @@ def parse_email(payload: str | bytes) -> PyMail:
     """
 
 
+def parse_email_tree(payload: str | bytes) -> PyMimePart:
+    """Parse a message into its MIME tree, structure intact.
+
+    Additive: ``parse_email`` is unchanged. Accepts the same payloads and raises
+    the same ``ParseError`` subtypes, including the size and recursion caps.
+
+    Use this when the shape of the message matters -- forensics, bounce
+    processing, deciding which body belongs to which alternative -- and
+    ``parse_email`` when the flat projection is what you want.
+    """
+
+
+def walk(part: PyMimePart) -> Iterator[PyMimePart]:
+    """Yield ``part`` and every part beneath it, depth first.
+
+    The same order as the stdlib's ``email.message.Message.walk``. It is a
+    generator, so stopping early costs nothing for the rest of the tree.
+    """
 def parse_many(
     payloads: list[str | bytes],
     *,

--- a/fast_mail_parser/__init__.pyi
+++ b/fast_mail_parser/__init__.pyi
@@ -39,14 +39,25 @@ class PyMimePart:
     first appeared -- the same semantics as ``PyMail.headers``.
     """
 
-    content_type: str
-    headers: dict[str, list[str]]
-    filename: str
-    content_id: str | None
-    disposition: str | None
-    is_message: bool
-    content: bytes | None
-    children: list[PyMimePart]
+    def __init__(
+        self,
+        content_type: str,
+        headers: dict[str, list[str]],
+        filename: str,
+        content_id: str | None,
+        disposition: str | None,
+        is_message: bool,
+        content: bytes | None,
+        children: list[PyMimePart],
+    ) -> None:
+        self.content_type = content_type
+        self.headers = headers
+        self.filename = filename
+        self.content_id = content_id
+        self.disposition = disposition
+        self.is_message = is_message
+        self.content = content
+        self.children = children
 
 
 class PyAddress:

--- a/src/fast_mail_parser.rs
+++ b/src/fast_mail_parser.rs
@@ -124,6 +124,97 @@ fn catch_panics<T>(operation: impl FnOnce() -> PyResult<T>) -> PyResult<T> {
     }
 }
 
+/// One node of a message's MIME tree, with the structure intact (#99).
+///
+/// `PyMail` is a flattened projection of this -- bodies in one list, attachments
+/// in another, containers dropped. Every flattening loses something: which
+/// `text/html` part corresponds to which `text/plain` sibling, whether a node was
+/// `multipart/alternative` or `multipart/mixed`, where a bounce's inner message
+/// begins. Use `parse_email` when the convenience projection is what you want and
+/// this when the shape matters.
+#[pyclass(skip_from_py_object)]
+pub struct PyMimePart {
+    /// The part's media type: `"multipart/alternative"`, `"text/plain"`, ...
+    #[pyo3(get)]
+    pub content_type: String,
+    /// Stored as ordered pairs, exposed through the getter below (#157).
+    pub headers: Vec<(String, Vec<String>)>,
+    #[pyo3(get)]
+    pub filename: String,
+    /// The part's `Content-ID` with angle brackets stripped, or `None`.
+    #[pyo3(get)]
+    pub content_id: Option<String>,
+    /// The part's raw `Content-Disposition` token, or `None` when it declares no
+    /// such header. `None` and `"inline"` are distinct statements.
+    #[pyo3(get)]
+    pub disposition: Option<String>,
+    /// True for `message/rfc822`. The embedded message's own root is this part's
+    /// single child, so a bounce's headers are reachable rather than opaque.
+    #[pyo3(get)]
+    pub is_message: bool,
+    pub content: Option<Vec<u8>>,
+    pub children: Vec<Py<PyMimePart>>,
+}
+
+#[pymethods]
+impl PyMimePart {
+    /// This part's headers, every value kept, keys in wire order.
+    #[getter]
+    fn headers<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let dict = PyDict::new(py);
+        for (name, values) in &self.headers {
+            dict.set_item(name, values)?;
+        }
+        Ok(dict)
+    }
+
+    /// Transfer-decoded bytes of a leaf, or `None` for a `multipart/*` container.
+    ///
+    /// A container's body is its children with boundaries between them, so
+    /// returning it would hand back the same bytes twice.
+    #[getter]
+    fn content<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyBytes>> {
+        self.content
+            .as_ref()
+            .map(|bytes| PyBytes::new(py, bytes.as_slice()))
+    }
+
+    /// The parts nested directly inside this one, in message order.
+    #[getter]
+    fn children<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        PyList::new(py, self.children.iter().map(|child| child.clone_ref(py)))
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "<PyMimePart {} children={}>",
+            self.content_type,
+            self.children.len()
+        )
+    }
+}
+
+impl PyMimePart {
+    fn from_part(py: Python<'_>, part: mail_parser::MimePart) -> PyResult<Self> {
+        let children = part
+            .children
+            .into_iter()
+            .map(|child| Py::new(py, Self::from_part(py, child)?))
+            .collect::<PyResult<Vec<_>>>()?;
+
+        Ok(PyMimePart {
+            content_type: part.content_type,
+            headers: part.headers,
+            filename: part.filename,
+            content_id: part.content_id,
+            disposition: part.disposition,
+            is_message: part.is_message,
+            content: part.content,
+            children,
+        })
+    }
+}
+
 /// One mailbox from an address header, exposed to Python.
 #[pyclass(skip_from_py_object)]
 #[derive(Clone)]
@@ -459,6 +550,27 @@ fn parse_many_inner(
     Ok(items.unbind())
 }
 
+/// Parse a message into its MIME tree, structure intact.
+///
+/// Additive: `parse_email` is untouched. Accepts the same `str`/`bytes` payloads
+/// and raises the same `ParseError` subtypes, including the recursion and size
+/// caps -- an embedded `message/rfc822` counts against the same depth limit as a
+/// multipart nest, so an onion of forwards cannot go deeper than a multipart tree.
+#[pyfunction]
+pub fn parse_email_tree(py: Python<'_>, payload: Py<PyAny>) -> PyResult<PyMimePart> {
+    catch_panics(|| parse_email_tree_inner(py, payload))
+}
+
+fn parse_email_tree_inner(py: Python<'_>, payload: Py<PyAny>) -> PyResult<PyMimePart> {
+    let message = payload_to_bytes(&payload, py)?;
+
+    let tree = py
+        .detach(|| mail_parser::parse_email_tree(message.as_ref()))
+        .map_err(to_py_err)?;
+
+    PyMimePart::from_part(py, tree)
+}
+
 /// Panic on purpose, so the backstop above can be tested.
 ///
 /// Not part of the API: underscore-prefixed, absent from `__all__` and from the
@@ -479,8 +591,10 @@ fn panic_now() -> PyResult<()> {
 fn fast_mail_parser(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(parse_email, m)?)?;
     m.add_function(wrap_pyfunction!(parse_many, m)?)?;
+    m.add_function(wrap_pyfunction!(parse_email_tree, m)?)?;
     m.add_function(wrap_pyfunction!(_panic_for_tests, m)?)?;
     m.add_class::<PyMail>()?;
+    m.add_class::<PyMimePart>()?;
     m.add_class::<PyAttachment>()?;
     m.add_class::<PyAddress>()?;
     m.add("ParseError", py.get_type::<ParseError>())?;

--- a/src/fast_mail_parser.rs
+++ b/src/fast_mail_parser.rs
@@ -110,6 +110,13 @@ fn panic_message(payload: &(dyn std::any::Any + Send)) -> &str {
 ///
 /// This is a backstop, not a licence: a panic reaching here is a bug in this
 /// crate, and the error says so.
+///
+/// `inline(always)` is load-bearing, not decoration. This is generic, so every
+/// entry point instantiates it, and once there were three the instantiation
+/// wrapping `parse_email` stopped being inlined -- which turns the parse body
+/// into an opaque call behind unwind edges and cost 24% on large messages while
+/// the code responsible was never executed (#99).
+#[inline(always)]
 fn catch_panics<T>(operation: impl FnOnce() -> PyResult<T>) -> PyResult<T> {
     // `AssertUnwindSafe`: the closure touches Python state, which is not
     // `UnwindSafe`, but nothing observes that state after a panic -- the only
@@ -195,6 +202,9 @@ impl PyMimePart {
 }
 
 impl PyMimePart {
+    /// Cold by construction, and marked so: it recurses, it returns a large
+    /// struct, and `parse_email` never reaches it.
+    #[inline(never)]
     fn from_part(py: Python<'_>, part: mail_parser::MimePart) -> PyResult<Self> {
         let children = part
             .children
@@ -561,6 +571,7 @@ pub fn parse_email_tree(py: Python<'_>, payload: Py<PyAny>) -> PyResult<PyMimePa
     catch_panics(|| parse_email_tree_inner(py, payload))
 }
 
+#[inline(never)]
 fn parse_email_tree_inner(py: Python<'_>, payload: Py<PyAny>) -> PyResult<PyMimePart> {
     let message = payload_to_bytes(&payload, py)?;
 

--- a/src/mail_parser.rs
+++ b/src/mail_parser.rs
@@ -191,6 +191,124 @@ fn disposition_token(part: &ParsedMail<'_>, kind: &DispositionType) -> Option<St
     })
 }
 
+/// Every value of every header, keyed by name, in first-appearance key order.
+///
+/// Repeated keys keep all their values: collapsing to one kept only the last,
+/// discarding all but the final `Received`, `DKIM-Signature`, `Received-SPF`,
+/// ... -- which made delivery-path tracing and signature verification impossible
+/// (#12, #23).
+///
+/// A `HashMap` cannot carry the key order: its iteration order is randomised per
+/// instance, and that order became the Python dict's insertion order, so headers
+/// came back differently ordered on every parse of the same bytes (#157).
+///
+/// `positions` keeps insertion O(1). Scanning the vector for each field would be
+/// quadratic in the header count, which turns a message carrying thousands of
+/// headers into an amplification vector -- the sort of thing MAX_INPUT_BYTES and
+/// MAX_MIME_DEPTH exist to prevent elsewhere.
+///
+/// Shared by the flat view and the tree so the two cannot disagree about what a
+/// message's headers are.
+fn collect_headers(part: &ParsedMail<'_>) -> Vec<(String, Vec<String>)> {
+    let mut headers: Vec<(String, Vec<String>)> = Vec::new();
+    let mut positions: HashMap<String, usize> = HashMap::new();
+
+    for header in part.get_headers() {
+        let key = header.get_key();
+        match positions.get(&key).copied() {
+            Some(position) => headers[position].1.push(header.get_value()),
+            None => {
+                positions.insert(key.clone(), headers.len());
+                headers.push((key, vec![header.get_value()]));
+            }
+        }
+    }
+
+    headers
+}
+
+/// One node of the MIME tree, as the message actually nests it (#99).
+///
+/// `Mail` is a flattened projection of this: bodies in one list, attachments in
+/// another, containers dropped. Any flattening loses something -- which
+/// `text/html` corresponds to which `text/plain` sibling, whether a part was
+/// `multipart/alternative` or `multipart/mixed` -- and this keeps it.
+#[derive(Debug)]
+pub(crate) struct MimePart {
+    pub(crate) content_type: String,
+    pub(crate) headers: Vec<(String, Vec<String>)>,
+    pub(crate) filename: String,
+    pub(crate) content_id: Option<String>,
+    pub(crate) disposition: Option<String>,
+    pub(crate) is_message: bool,
+    /// Transfer-decoded bytes of a leaf. `None` for a `multipart/*` container,
+    /// whose body is just its children with boundaries between them.
+    pub(crate) content: Option<Vec<u8>>,
+    pub(crate) children: Vec<MimePart>,
+}
+
+impl MimePart {
+    fn build(part: &ParsedMail<'_>, depth: usize) -> Result<Self, MailParseError> {
+        if depth >= MAX_MIME_DEPTH {
+            return Err(MailParseError::Generic(ERR_MIME_DEPTH));
+        }
+
+        let mime = part.ctype.mimetype.as_str();
+        let disposition = part.get_content_disposition();
+
+        let (content, children) = if mime.starts_with("multipart/") {
+            // A container's body is the boundary-delimited concatenation of the
+            // children below it, so reporting it as content would report the same
+            // bytes twice.
+            let children = part
+                .subparts
+                .iter()
+                .map(|child| Self::build(child, depth + 1))
+                .collect::<Result<Vec<_>, _>>()?;
+            (None, children)
+        } else if mime == "message/rfc822" {
+            // An embedded message -- a bounce or a forward, which abuse pipelines
+            // are made of. mailparse hands it over as an opaque leaf; parsing it
+            // is the difference between "there is a message in here" and being
+            // able to read its headers.
+            //
+            // The nesting counts against the same depth cap, so an onion of
+            // forwards cannot recurse further than a multipart tree can.
+            let raw = part.get_body_raw()?;
+            let inner = {
+                let parsed = parse_mail(&raw)?;
+                Self::build(&parsed, depth + 1)?
+            };
+            (Some(raw), vec![inner])
+        } else {
+            (Some(part.get_body_raw()?), Vec::new())
+        };
+
+        Ok(MimePart {
+            content_type: mime.to_string(),
+            headers: collect_headers(part),
+            filename: part_filename(&disposition, &part.ctype),
+            content_id: part
+                .get_headers()
+                .get_first_value("Content-ID")
+                .map(|raw| normalize_content_id(&raw)),
+            disposition: disposition_token(part, &disposition.disposition),
+            is_message: mime == "message/rfc822",
+            content,
+            children,
+        })
+    }
+}
+
+/// Parse a message into its MIME tree, structure intact.
+pub(crate) fn parse_email_tree(payload: &[u8]) -> Result<MimePart, MailParseError> {
+    if payload.len() > MAX_INPUT_BYTES {
+        return Err(MailParseError::Generic(ERR_INPUT_TOO_LARGE));
+    }
+
+    MimePart::build(&parse_mail(payload)?, 0)
+}
+
 /// Month tokens `mailparse::dateparse` accepts.
 ///
 /// Its state machine only advances past the month once one of these matches,
@@ -304,33 +422,7 @@ impl<'a> Mail {
 
         let mail = parse_mail(payload)?;
 
-        // Keys in the order they first appear, and every value for a repeated
-        // key in the order it appeared. Collapsing to one value per key kept only
-        // the last, discarding all but the final `Received`, `DKIM-Signature`,
-        // `Received-SPF`, ... -- which made delivery-path tracing and signature
-        // verification impossible (#12, #23).
-        //
-        // A `HashMap` cannot carry the key order: its iteration order is
-        // randomised per instance, and that order became the Python dict's
-        // insertion order, so `mail.headers` came back differently ordered on
-        // every parse of the same bytes (#157).
-        //
-        // `positions` keeps insertion O(1). Scanning `headers` for each field
-        // would be quadratic in the header count, which turns a message carrying
-        // thousands of headers into an amplification vector -- the sort of thing
-        // MAX_INPUT_BYTES and MAX_MIME_DEPTH exist to prevent elsewhere.
-        let mut headers: Vec<(String, Vec<String>)> = Vec::new();
-        let mut positions: HashMap<String, usize> = HashMap::new();
-        for header in mail.get_headers() {
-            let key = header.get_key();
-            match positions.get(&key).copied() {
-                Some(position) => headers[position].1.push(header.get_value()),
-                None => {
-                    positions.insert(key.clone(), headers.len());
-                    headers.push((key, vec![header.get_value()]));
-                }
-            }
-        }
+        let headers = collect_headers(&mail);
 
         // Read these straight from the parsed headers rather than back out of the
         // map above, so the dedicated fields do not inherit its representation

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -19,12 +19,15 @@ from fast_mail_parser import ParseError, PyAttachment, PyMail, parse_email
 
 EXPECTED_EXPORTS = {
     "parse_email",
+    "parse_email_tree",
     "parse_many",
+    "walk",
     "ParseError",
     "HeaderParseError",
     "MimeStructureError",
     "DecodeError",
     "PyMail",
+    "PyMimePart",
     "PyAttachment",
     "PyAddress",
 }

--- a/tests/test_mime_tree.py
+++ b/tests/test_mime_tree.py
@@ -142,7 +142,9 @@ def test__an_embedded_message_is_parsed_not_opaque():
     # `parse_email` this is one attachment blob to re-parse by hand.
     assert inner_root.headers["Subject"] == ["the original message"]
     assert inner_root.headers["From"] == ["alice@example.com"]
-    assert inner_root.content == b"hello"
+    # Trailing CRLF included: it is part of the body, not of the boundary
+    # delimiter, since the embedded message ends before the outer boundary line.
+    assert inner_root.content == b"hello\r\n"
 
 
 def test__a_doubly_nested_message_keeps_both_levels():

--- a/tests/test_mime_tree.py
+++ b/tests/test_mime_tree.py
@@ -1,0 +1,260 @@
+"""The structural API: `parse_email_tree` and `walk` (#99).
+
+`parse_email` returns a flattened projection -- bodies in one list, attachments in
+another, containers dropped -- and every flattening loses something. These tests
+pin what the tree keeps that the projection cannot: sibling relationships inside
+`multipart/alternative`, and the inside of an embedded `message/rfc822`.
+
+The strongest oracle available is the stdlib. `email.message.Message.walk` yields
+the same topology this tree should have, so the parity test below compares the two
+over the whole corpus rather than over chosen examples.
+"""
+import email
+import email.policy
+import glob
+import inspect
+import os
+
+import pytest
+
+from fast_mail_parser import (
+    DecodeError,
+    HeaderParseError,
+    MimeStructureError,
+    parse_email,
+    parse_email_tree,
+    walk,
+)
+
+_DATA = os.path.join(os.path.dirname(__file__), "data")
+
+# Same corpus and same exclusion as test_stdlib_parity.py: invalid_message.eml is
+# a real message malformed such that the two parsers legitimately disagree about
+# its structure, which is documented in #150 rather than compared blindly.
+FIXTURES = sorted(glob.glob(os.path.join(_DATA, "rfc", "*.eml"))) + sorted(
+    path
+    for path in glob.glob(os.path.join(_DATA, "*.eml"))
+    if os.path.basename(path) != "invalid_message.eml"
+)
+
+
+def _ids(paths):
+    return [os.path.basename(path) for path in paths]
+
+
+# --- topology against the stdlib ----------------------------------------------
+
+
+@pytest.mark.parametrize("path", FIXTURES, ids=_ids(FIXTURES))
+def test__tree_topology_matches_the_stdlib(path: str):
+    with open(path, "rb") as handle:
+        raw = handle.read()
+
+    ours = [part.content_type for part in walk(parse_email_tree(raw))]
+    theirs = [
+        part.get_content_type()
+        for part in email.message_from_bytes(raw, policy=email.policy.default).walk()
+    ]
+
+    assert ours == theirs
+
+
+# --- what the flat projection cannot say ---------------------------------------
+
+
+ALTERNATIVE = (
+    b"From: sender@example.com\r\n"
+    b"Subject: alternative\r\n"
+    b'Content-Type: multipart/alternative; boundary="bnd"\r\n'
+    b"\r\n"
+    b"--bnd\r\n"
+    b"Content-Type: text/plain\r\n"
+    b"\r\n"
+    b"plain version\r\n"
+    b"--bnd\r\n"
+    b"Content-Type: text/html\r\n"
+    b"\r\n"
+    b"<p>html version</p>\r\n"
+    b"--bnd--\r\n"
+)
+
+
+def test__alternative_siblings_share_a_parent():
+    # The relationship `parse_email` loses: it reports one text_plain and one
+    # text_html with nothing to say they are two renderings of one thing.
+    root = parse_email_tree(ALTERNATIVE)
+
+    assert root.content_type == "multipart/alternative"
+    assert [child.content_type for child in root.children] == [
+        "text/plain",
+        "text/html",
+    ]
+    assert root.content is None, "a container's body is its children"
+
+
+def test__a_container_reports_no_content_but_its_leaves_do():
+    root = parse_email_tree(ALTERNATIVE)
+
+    assert root.content is None
+    assert [child.content for child in root.children] == [
+        b"plain version",
+        b"<p>html version</p>",
+    ]
+
+
+# --- embedded messages ---------------------------------------------------------
+
+
+def _bounce(inner: bytes) -> bytes:
+    return (
+        b"From: postmaster@example.com\r\n"
+        b"Subject: Delivery failure\r\n"
+        b'Content-Type: multipart/mixed; boundary="outer"\r\n'
+        b"\r\n"
+        b"--outer\r\n"
+        b"Content-Type: text/plain\r\n"
+        b"\r\n"
+        b"Your message could not be delivered.\r\n"
+        b"--outer\r\n"
+        b"Content-Type: message/rfc822\r\n"
+        b"\r\n" + inner + b"\r\n--outer--\r\n"
+    )
+
+
+ORIGINAL = (
+    b"From: alice@example.com\r\n"
+    b"To: nobody@example.invalid\r\n"
+    b"Subject: the original message\r\n"
+    b"Content-Type: text/plain\r\n"
+    b"\r\n"
+    b"hello\r\n"
+)
+
+
+def test__an_embedded_message_is_parsed_not_opaque():
+    root = parse_email_tree(_bounce(ORIGINAL))
+
+    embedded = [part for part in walk(root) if part.is_message]
+    assert len(embedded) == 1
+
+    inner_root = embedded[0].children[0]
+    # The point: the bounced message's own headers are reachable. Through
+    # `parse_email` this is one attachment blob to re-parse by hand.
+    assert inner_root.headers["Subject"] == ["the original message"]
+    assert inner_root.headers["From"] == ["alice@example.com"]
+    assert inner_root.content == b"hello"
+
+
+def test__a_doubly_nested_message_keeps_both_levels():
+    root = parse_email_tree(_bounce(_bounce(ORIGINAL)))
+
+    depths = [part.content_type for part in walk(root)]
+
+    # Two embedded messages, one inside the other.
+    assert depths.count("message/rfc822") == 2
+    subjects = [
+        part.headers["Subject"][0] for part in walk(root) if "Subject" in part.headers
+    ]
+    assert "the original message" in subjects
+
+
+def test__embedded_message_nesting_counts_against_the_recursion_cap():
+    # An onion of forwards must not be able to recurse further than a multipart
+    # tree can. 300 exceeds MAX_MIME_DEPTH (256).
+    payload = ORIGINAL
+    for _ in range(300):
+        payload = (
+            b"Content-Type: message/rfc822\r\n\r\n" + payload
+        )
+
+    with pytest.raises(MimeStructureError):
+        parse_email_tree(payload)
+
+
+# --- consistency with the flat API ---------------------------------------------
+
+
+@pytest.mark.parametrize("path", FIXTURES, ids=_ids(FIXTURES))
+def test__leaf_content_agrees_with_the_flat_api(path: str):
+    with open(path, "rb") as handle:
+        raw = handle.read()
+
+    flat = parse_email(raw)
+    tree_leaves = [
+        part.content
+        for part in walk(parse_email_tree(raw))
+        if part.content is not None
+    ]
+
+    # Every attachment's bytes appear as some leaf's content. The tree keeps
+    # parts the projection drops, so this is containment rather than equality.
+    for attachment in flat.attachments:
+        assert attachment.content in tree_leaves, (
+            f"{os.path.basename(path)}: attachment bytes missing from the tree"
+        )
+
+
+def test__str_and_bytes_payloads_give_the_same_tree():
+    from_bytes = parse_email_tree(ALTERNATIVE)
+    from_str = parse_email_tree(ALTERNATIVE.decode("ascii"))
+
+    assert [p.content_type for p in walk(from_str)] == [
+        p.content_type for p in walk(from_bytes)
+    ]
+
+
+# --- walk ----------------------------------------------------------------------
+
+
+def test__walk_is_depth_first_and_yields_the_root_first():
+    root = parse_email_tree(_bounce(ORIGINAL))
+
+    order = [part.content_type for part in walk(root)]
+
+    assert order[0] == "multipart/mixed"
+    assert order == [
+        "multipart/mixed",
+        "text/plain",
+        "message/rfc822",
+        "text/plain",
+    ]
+
+
+def test__walk_is_a_generator_not_a_materialised_list():
+    # So that stopping at the first match of something costs nothing for the
+    # rest of the tree -- which is the usual reason to walk one.
+    walker = walk(parse_email_tree(_bounce(ORIGINAL)))
+
+    assert inspect.isgenerator(walker)
+    assert next(walker).content_type == "multipart/mixed"
+
+
+# --- errors --------------------------------------------------------------------
+
+
+# Borrowed from test_error_taxonomy.py, where these are proven to raise. Random
+# bytes are a bad choice here: a payload with no colon anywhere still parses, as
+# #150 established the hard way.
+MALFORMED_HEADERS = b" unexpected continuation\r\n\r\nbody"
+BROKEN_BASE64_BODY = (
+    b"Subject: broken\r\n"
+    b"Content-Type: text/plain; charset=utf-8\r\n"
+    b"Content-Transfer-Encoding: base64\r\n"
+    b"\r\n"
+    b"!!!! not base64 !!!!\r\n"
+)
+
+
+def test__the_tree_api_raises_the_same_errors():
+    with pytest.raises(HeaderParseError):
+        parse_email_tree(MALFORMED_HEADERS)
+
+    # A leaf whose transfer encoding is broken fails the tree parse too, rather
+    # than yielding a part with silently empty content.
+    with pytest.raises(DecodeError):
+        parse_email_tree(BROKEN_BASE64_BODY)
+
+
+def test__a_non_payload_is_rejected():
+    with pytest.raises(TypeError):
+        parse_email_tree(42)


### PR DESCRIPTION
Implements #99's structural API. **Pure addition** — `parse_email` is untouched, so nothing breaks and no release window is needed (unlike #97, where the proposed API widens `content` to `bytes | None`; see [my note there](https://github.com/namecheap/fast_mail_parser/issues/97#issuecomment-5436367860)).

## What it adds

```python
from fast_mail_parser import parse_email_tree, walk

root = parse_email_tree(payload)
for part in walk(root):            # depth first, stdlib walk() order
    print(part.content_type)
```

Nodes carry `content_type`, `headers`, `filename`, `content_id`, `disposition`, `children`, `is_message`, and `content` — the transfer-decoded bytes of a leaf, `None` for a container whose body is only its children with boundaries between them.

## The two things a flat projection cannot say

**Which body goes with which.** A `multipart/alternative` node's children are the plain and HTML renderings *of the same thing*. Through `parse_email` they are one entry in `text_plain` and one in `text_html`, with nothing relating them.

**What is inside a bounce.** `message/rfc822` is now parsed rather than opaque — mailparse hands it over as a leaf, and embedded messages are what bounce and abuse handling is made of. `is_message` is `True` and the embedded message's own root is the part's single child, so its headers are reachable instead of being an attachment blob to re-parse by hand. Doubly-nested bounces work, and that nesting counts against the **same** depth cap as a multipart nest, so an onion of forwards cannot recurse further than a multipart tree can.

## Correctness oracle

Topology is asserted against `email.message.Message.walk()` across the **whole fixture and RFC corpus**, not chosen examples. `invalid_message.eml` is excluded for the reason the parity suite excludes it — the two parsers legitimately disagree about its structure (#150).

Cross-API consistency is also checked: every attachment's bytes from `parse_email` must appear as some leaf's content in the tree.

## Refactor carried along

Header collection is now one shared helper used by both the flat view and the tree, so they cannot drift on what a message's headers are — and the reasoning about key order (#157) lives in one place instead of two.

## Three tests I rewrote before committing

Since I have no Rust toolchain locally and CI is the only thing that can run these, it's worth saying which assumptions I caught myself making:

- asserting random bytes fail to parse — they don't, as #150 established the hard way; now using the two payloads `test_error_taxonomy.py` proves do raise
- excluding `message/rfc822` from the cross-API comparison, where it *does* count as an attachment to the flat API
- a "walk is lazy" test that would have passed just as well against a materialised list; now asserts it is a generator

## Not in this PR

`mode="metadata"|"lazy"` on the tree, per #97 — that decision is open on #97 and lazy decoding needs interior mutability, a different risk and a different review.