### PR TITLE
Benchmark the tree parse against the flat parse

### DIFF
--- a/tests/benchmark/test_read_message.py
+++ b/tests/benchmark/test_read_message.py
@@ -212,3 +212,16 @@ def test__threaded___threadpool_parse_email_small(benchmark: Callable):
 
     with ThreadPoolExecutor(max_workers=os.cpu_count()) as pool:
         benchmark(lambda: list(pool.map(parse_email, batch)))
+
+
+def test__fast_mail_parser___parse_tree(large_message: str, benchmark: Callable):
+    # The structural API against the flat one, on the same message. #99 asks for
+    # the overhead to be measured rather than assumed, and the tree genuinely does
+    # more: it decodes every leaf, including parts the flat projection drops, and
+    # builds a Python object per part. Compare with
+    # `test__fast_mail_parser___parse_message` in the same run.
+    from fast_mail_parser import parse_email_tree
+
+    payload = large_message.encode()
+
+    benchmark(lambda: parse_email_tree(payload))


### PR DESCRIPTION
Closes the last open criterion on #99 — tree-parse overhead, measured rather than assumed.

The tree does strictly **more** work than the flat parse for the same message: it decodes every leaf, including parts the flat projection drops, and builds a Python object per part. So the ≤10% target in #99 is a real question rather than a formality, and I would rather report the number than assert the bound.

Gated rather than informational — no threads involved, so it is as deterministic as the other parse benchmarks, and a regression in it should fail a build like any other.

I'll post the ratio against `test__fast_mail_parser___parse_message` from this PR's own gate run.