### PR TITLE
Repair a missing header/body separator instead of eating the body (#150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A message whose header block is never terminated by a blank line no longer
+  loses its first MIME part (#150). RFC 5322 ends the header block with an empty
+  line; real mail sometimes omits it, and the stdlib names the defect
+  `MissingHeaderBodySeparatorDefect`. Without that line the underlying
+  `mailparse` keeps consuming the body as headers -- it stops only at a blank line
+  and accepts a colonless line as a field name -- so on the message this was found
+  on it swallowed the first MIME boundary, which left the first part's body before
+  the *next* boundary: multipart preamble, discarded by definition. The
+  `text/html` alternative was delimited normally and survived, so the message came
+  back looking populated with its plain-text body silently gone, its boundary
+  delimiter reported as a header key, and the first part's own headers merged into
+  the message's (two `Content-Type` values).
+  - The payload is now normalised before it reaches `mailparse`, by the stdlib's
+    rule: a non-continuation line in the header block that cannot be a header
+    field ends the header block, and the body starts there. `parse_email`,
+    `parse_many` and `parse_email_tree` all apply it, so the flat and structural
+    views cannot disagree about such a message.
+  - A message that has its separator -- every other fixture in the corpus, and
+    every well-formed message -- is parsed from the original bytes, unchanged.
+  - `tests/data/invalid_message.eml` is consequently no longer excluded from the
+    stdlib-parity, MIME-tree and `parse_many` corpora. The two parsers now agree
+    on its topology, its header set (29 keys, not 31) and both of its bodies; what
+    is left is the CRLF and unfolding divergence that every real message shows.
 - `headers` keys are now in the order the header names first appeared in the
   message, stably across parses. They came from a Rust `HashMap`, whose iteration
   order is randomised per instance, and that order became the Python dict's

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -24,6 +24,12 @@ library reported every MIME node as an attachment and collapsed repeated headers
 to their last value, so the structural dimensions diverged on nearly every
 multipart message.
 
+It also includes `invalid_message`, a real message whose header block is never
+terminated by a blank line. It was excluded from the comparison until this
+library learned the stdlib's recovery for that defect (#150); the two now agree
+on its structure, its header set and its bodies, and the differences left are the
+line-ending and unfolding ones below.
+
 ## Where they differ
 
 ### 1. Raw UTF-8 in headers — this library is more correct
@@ -45,14 +51,16 @@ If you are migrating *to* the stdlib, this one will cost you.
 
 | | |
 | --- | --- |
-| Fixture | `attachment_message` |
+| Fixtures | `attachment_message`, `invalid_message` |
 | Dimension | `headers` |
 | stdlib | `Date: Wed, 24 Apr 2019 10:05:02 +0200` |
 | this library | `Date: Wed, 24 Apr 2019 10:05:02 +0200 (CEST)` |
 
 `headers` gives values as they appeared, unfolded and RFC 2047-decoded, and
 nothing more. The stdlib additionally parses structured headers and re-emits a
-canonical form, dropping the RFC 5322 comment `(CEST)`.
+canonical form, dropping the RFC 5322 comment `(CEST)`. It re-spells them too:
+`invalid_message` sends `Date: Wed,  1 Jul 2020 05:33:42 +0000` and the stdlib
+returns the day zero-padded.
 
 Use `date_parsed` when you want an interpreted value; use `headers` when you want
 what the sender actually wrote.
@@ -78,14 +86,16 @@ and is a candidate to raise upstream.
 
 | | |
 | --- | --- |
-| Fixture | `valid_message` |
+| Fixtures | `valid_message`, `invalid_message` |
 | Dimensions | `text_plain`, `text_html` |
 | stdlib | `"…browser (…)\n\n\n** What's New?\n"` |
 | this library | `"…browser (…)\r\n\r\n\r\n** What's New?\r\n"` |
 
 The stdlib's text content manager normalises line endings to `LF`. This library
 returns the body as it arrived, so a message transmitted with `CRLF` keeps
-`CRLF`.
+`CRLF`. Note that "as it arrived" means after the transfer decoding:
+`invalid_message` is bare-LF on the wire, but its quoted-printable parts spell
+their line endings `=0D=0A`, so its decoded bodies carry `CRLF` all the same.
 
 This is the divergence most likely to surprise you in practice, because it
 affects every multi-line body from a real mail server. If you are comparing
@@ -99,7 +109,7 @@ body = mail.text_plain[0].replace("\r\n", "\n")
 
 | | |
 | --- | --- |
-| Fixture | `valid_message` |
+| Fixtures | `valid_message`, `invalid_message` |
 | Dimension | `headers` |
 | stdlib | `i=1; mx.google.com;       dkim=pass …` |
 | this library | `i=1; mx.google.com; dkim=pass …` |

--- a/src/mail_parser.rs
+++ b/src/mail_parser.rs
@@ -50,6 +50,86 @@ const MAX_MIME_DEPTH: usize = 256;
 pub(crate) const ERR_INPUT_TOO_LARGE: &str = "Input exceeds maximum allowed size";
 pub(crate) const ERR_MIME_DEPTH: &str = "MIME nesting exceeds maximum allowed depth";
 
+/// Restore the header/body separator when a message omits it, or `None` when the
+/// message has one and can be parsed exactly as it stands.
+///
+/// RFC 5322 section 2.1 ends the header block with an empty line. Real mail
+/// sometimes omits it -- `tests/data/invalid_message.eml` is a Mailchimp-delivered
+/// message that does, and the stdlib names the defect
+/// `MissingHeaderBodySeparatorDefect`.
+/// mailparse stops parsing headers only at an empty line, and it accepts a line
+/// with no colon as a field name with an empty value, so with the separator gone
+/// it keeps consuming the body as headers. In that fixture it swallows the first
+/// MIME boundary, which leaves the first part's body sitting before the *next*
+/// boundary -- making it multipart preamble, discarded by definition -- so the
+/// `text/plain` alternative vanished and nothing was raised about it (#150).
+///
+/// The recovery is the stdlib's: a non-continuation line in the header block that
+/// cannot be a header field ends the header block, and the body starts there.
+/// Handing mailparse the separator the sender left out is what makes it reach
+/// the same conclusion, and it needs no change to the header parsing itself,
+/// which mailparse owns.
+///
+/// "Cannot be a header field" is narrowed here to "contains no colon". The
+/// stdlib is stricter -- a field name may hold only printable ASCII other than
+/// colon, so `Subject : x`, or an 8-bit byte in a field name, ends the block for
+/// it too -- but mailparse accepts both of those as headers, and demoting them to
+/// body text would trade one silent loss for another. The colon is the part of
+/// the rule that identifies this defect. Two exemptions are the stdlib's own: a
+/// line starting with space or tab is a folded continuation, and a leading
+/// `From ` line is an mbox envelope header rather than a field.
+///
+/// What gets repaired is a whole message: the payload handed in, and an embedded
+/// `message/rfc822` when the tree parses one. A multipart *part*'s headers are
+/// parsed inside mailparse's boundary split, which is not reachable from here, so
+/// a part that omits its own separator is still read the way mailparse reads it.
+///
+/// Cost on a well-formed message is one pass over the header block, ending at the
+/// empty line it has: O(header bytes), one comparison per line, and no
+/// allocation. Only a defective message allocates, and it allocates once.
+///
+/// `#[inline(never)]` because this runs on every parse while being nothing worth
+/// inlining, and because code size in the parse path is not free in this crate --
+/// see the Performance section of CONTRIBUTING.md.
+#[inline(never)]
+fn repair_missing_separator(payload: &[u8]) -> Option<Vec<u8>> {
+    let mut at = 0;
+
+    while at < payload.len() {
+        let rest = &payload[at..];
+        let newline = rest.iter().position(|&b| b == b'\n');
+        let line = &rest[..newline.unwrap_or(rest.len())];
+
+        // An empty line is the separator, in its place: everything past it is
+        // body, which this scan never reads. A line starting with CR is either
+        // that same separator spelled `\r\n` or a lone CR where a header should
+        // start, which mailparse rejects on its own. Neither is ours to repair.
+        if line.is_empty() || line.starts_with(b"\r") {
+            return None;
+        }
+
+        let folded = matches!(line[0], b' ' | b'\t');
+        if !folded && !line.starts_with(b"From ") && !line.contains(&b':') {
+            // A bare LF, whatever the message's own line endings: mailparse
+            // takes a lone LF as the terminator and reports the body as starting
+            // after it, and its boundary search accepts a delimiter sitting at
+            // the first body byte. The separator is consumed rather than
+            // becoming body, so its spelling is not observable either way.
+            let mut repaired = Vec::with_capacity(payload.len() + 1);
+            repaired.extend_from_slice(&payload[..at]);
+            repaired.push(b'\n');
+            repaired.extend_from_slice(&payload[at..]);
+            return Some(repaired);
+        }
+
+        // No newline after this line means no body follows it, so there is no
+        // separator missing from between the two.
+        at += newline? + 1;
+    }
+
+    None
+}
+
 pub(crate) fn parse_email(payload: &[u8]) -> Result<Mail, MailParseError> {
     Mail::new(payload)
 }
@@ -276,7 +356,8 @@ impl MimePart {
             // forwards cannot recurse further than a multipart tree can.
             let raw = part.get_body_raw()?;
             let inner = {
-                let parsed = parse_mail(&raw)?;
+                let repaired = repair_missing_separator(&raw);
+                let parsed = parse_mail(repaired.as_deref().unwrap_or(raw.as_slice()))?;
                 Self::build(&parsed, depth + 1)?
             };
             (Some(raw), vec![inner])
@@ -306,7 +387,10 @@ pub(crate) fn parse_email_tree(payload: &[u8]) -> Result<MimePart, MailParseErro
         return Err(MailParseError::Generic(ERR_INPUT_TOO_LARGE));
     }
 
-    MimePart::build(&parse_mail(payload)?, 0)
+    // The same repair as the flat path, so the two views cannot disagree about a
+    // message whose header block was never terminated (#150).
+    let repaired = repair_missing_separator(payload);
+    MimePart::build(&parse_mail(repaired.as_deref().unwrap_or(payload))?, 0)
 }
 
 /// Month tokens `mailparse::dateparse` accepts.
@@ -414,12 +498,27 @@ pub(crate) struct Attachment {
     pub(crate) disposition: Option<String>,
 }
 
-impl<'a> Mail {
-    pub(crate) fn new(payload: &'a [u8]) -> Result<Self, MailParseError> {
+impl Mail {
+    /// Parse one message.
+    ///
+    /// Two steps, so that what mailparse sees is normalised first: a message
+    /// missing its header/body separator is parsed from a repaired copy of the
+    /// payload (#150). `from_payload` reads whatever buffer it is handed and
+    /// returns fully owned data, so that copy can be a local here.
+    pub(crate) fn new(payload: &[u8]) -> Result<Self, MailParseError> {
+        // Measured against the payload as received: a repair adds one byte, and
+        // no message should become oversized by being repaired.
         if payload.len() > MAX_INPUT_BYTES {
             return Err(MailParseError::Generic(ERR_INPUT_TOO_LARGE));
         }
 
+        let repaired = repair_missing_separator(payload);
+        Mail::from_payload(repaired.as_deref().unwrap_or(payload))
+    }
+}
+
+impl<'a> Mail {
+    fn from_payload(payload: &'a [u8]) -> Result<Self, MailParseError> {
         let mail = parse_mail(payload)?;
 
         let headers = collect_headers(&mail);

--- a/tests/test_known_issues.py
+++ b/tests/test_known_issues.py
@@ -9,6 +9,10 @@ what it should do. Each one pins an open bug so that:
 
 Every test here names its issue. When that issue is closed, the test should be
 rewritten to assert the corrected behaviour, or deleted.
+
+#150 is the first to have been fixed, so its section below is the exception the
+rule above describes: those tests assert the recovered behaviour and stay here as
+the regression suite for the fix.
 """
 
 import email
@@ -17,7 +21,7 @@ import os
 
 import pytest
 
-from fast_mail_parser import parse_email
+from fast_mail_parser import parse_email, parse_email_tree, walk
 
 FIXTURE = os.path.join(os.path.dirname(__file__), "data", "invalid_message.eml")
 
@@ -31,7 +35,7 @@ def malformed() -> bytes:
         return handle.read()
 
 
-# --- #150: unterminated header block swallows the first part ------------------
+# --- #150: an unterminated header block is repaired ---------------------------
 #
 # `invalid_message.eml` is a real Mailchimp-delivered message, bare-LF
 # throughout, whose header block is never terminated by a blank line. A folded
@@ -39,91 +43,139 @@ def malformed() -> bytes:
 # followed directly by the FIRST MIME boundary. The stdlib has a name for this
 # defect: MissingHeaderBodySeparatorDefect.
 #
-# So a parser scanning for the separator keeps consuming header lines -- 73 of
-# them, up to the first genuinely blank line. Reconstructing that block by hand
-# gives 30 distinct colon-bearing keys plus one colonless line (the boundary,
-# kept as a key with no value) = the 31 keys we report, which is what confirms
-# the mechanism rather than merely fitting it.
+# Left as it arrived, that message cost us the first part. mailparse stops
+# parsing headers only at a blank line and accepts a colonless line as a field
+# name, so it consumed 73 lines as headers -- 31 keys, one of them the boundary,
+# and two Content-Type values, the message's own and the part's. The boundary
+# that opened the text/plain part having been eaten, that part's content ended up
+# before the NEXT boundary, which makes it multipart preamble: discarded by
+# definition. The text/html part was delimited normally and survived, so the
+# message came back looking populated with its plain-text alternative silently
+# gone.
 #
-# Two consequences, both pinned below. The boundary that opened the text/plain
-# part was eaten as a header, so that part's content ends up BEFORE the next
-# boundary -- making it multipart preamble, which is discarded by definition.
-# The second boundary is intact, so the text/html part survives: the loss is
-# partial, which is what makes it easy to miss. And the lines absorbed after the
-# boundary are the first part's OWN headers, so the top-level header map ends up
-# carrying two Content-Type values.
-#
-# Note for anyone reading this looking for a detection signal: "multipart with
-# zero parts" does NOT fire here, because the html part parses fine.
+# `repair_missing_separator` in src/mail_parser.rs now restores the separator the
+# sender omitted, by the stdlib's rule: a non-continuation line in the header
+# block that cannot be a header field ends the header block, and the body starts
+# there. The tests below assert the recovery, the last three against the stdlib
+# rather than against numbers written down here.
 
 
 def test__150_malformed_message_still_parses(malformed: bytes):
-    # It does not raise. That is the whole problem: the failure is silent.
     mail = parse_email(malformed)
 
-    assert mail.subject, "expected the headers before the break to survive"
+    assert mail.subject == "Your June OpenShift Update"
 
 
-def test__150_only_the_first_part_is_lost(malformed: bytes):
+def test__150_the_lost_part_is_recovered(malformed: bytes):
     mail = parse_email(malformed)
 
-    # WRONG, pinned: the message has a text/plain part and we report none,
-    # because the boundary that opened it was eaten as a header.
-    assert mail.text_plain == []
-    # The second boundary survived, so the html part is recovered. The loss is
-    # partial, which is what makes it easy to miss.
+    # Both alternatives, which is what the message actually contains.
+    assert len(mail.text_plain) == 1
     assert len(mail.text_html) == 1
+    assert "OpenShift" in mail.text_plain[0]
 
 
-def test__150_boundary_is_reported_as_a_header_key(malformed: bytes):
+def test__150_boundary_is_not_a_header_key(malformed: bytes):
     mail = parse_email(malformed)
 
-    # WRONG, pinned: a boundary delimiter is not a header field.
-    assert f"--{BOUNDARY}" in mail.headers
+    assert f"--{BOUNDARY}" not in mail.headers
+
+    # The rule rather than the fixture: no key may be `--` + the boundary this
+    # message declares. That signature can only mean unterminated headers.
+    content_type = mail.headers["Content-Type"][0]
+    declared = content_type.split('boundary="')[1].split('"')[0]
+    assert f"--{declared}" not in mail.headers
 
 
-def test__150_part_headers_leak_into_the_top_level_map(malformed: bytes):
+def test__150_part_headers_stay_out_of_the_top_level_map(malformed: bytes):
     mail = parse_email(malformed)
 
-    # WRONG, pinned: the two lines absorbed after the swallowed boundary are the
-    # first part's own headers, so the message appears to declare Content-Type
-    # twice -- the real multipart/alternative one and the part's text/plain.
-    # A well-formed message has exactly one, which makes this a second cheap
-    # detection signal. It only became visible when headers started keeping
-    # every value (#123); before that the part's value silently overwrote the
-    # multipart one.
-    assert len(mail.headers["Content-Type"]) == 2
-    assert any("multipart/alternative" in v for v in mail.headers["Content-Type"])
-    assert any("text/plain" in v for v in mail.headers["Content-Type"])
+    # The two lines after the swallowed boundary are the first part's own
+    # headers. A message declares Content-Type once.
+    assert len(mail.headers["Content-Type"]) == 1
+    assert "multipart/alternative" in mail.headers["Content-Type"][0]
 
 
-def test__150_the_stdlib_recovers_what_we_lose(malformed: bytes):
-    # The contrast is the argument that this is our bug and not merely bad input:
-    # the same bytes give the stdlib the part we drop.
+def test__150_the_second_defect_is_left_as_it_is(malformed: bytes):
+    # The message carries two defects and only one of them loses data. The
+    # injected ` hello` line is a legal fold, so it still folds into the header
+    # above it -- as it does for the stdlib, which reads the same value.
+    mail = parse_email(malformed)
+
+    assert mail.headers["MIME-Version"] == ["1.0 hello"]
+
+
+def test__150_the_header_set_matches_the_stdlib(malformed: bytes):
     message = email.message_from_bytes(malformed, policy=email.policy.default)
 
-    bodies = [
-        part
+    mail = parse_email(malformed)
+
+    assert set(mail.headers) == set(dict(message.items()))
+
+
+def test__150_the_recovered_body_matches_the_stdlib(malformed: bytes):
+    message = email.message_from_bytes(malformed, policy=email.policy.default)
+    theirs = [
+        part.get_content()
         for part in message.walk()
         if part.get_content_type() == "text/plain"
         and part.get_content_disposition() != "attachment"
     ]
 
-    assert len(bodies) == 1
-    assert f"--{BOUNDARY}" not in dict(message.items())
+    ours = parse_email(malformed).text_plain
+
+    # Line endings aside, which differ here for the reason they differ on every
+    # fixture: the stdlib normalises body line endings to LF and this library
+    # returns the wire form. See docs/compatibility.md.
+    assert [text.replace("\r\n", "\n") for text in ours] == theirs
 
 
-def test__150_a_header_key_matches_the_declared_boundary(malformed: bytes):
-    # The signal a fix could detect cheaply and exactly: a header key equal to
-    # `--<the boundary this message declares>` can only mean the header block was
-    # never terminated. Well-formed mail cannot produce it.
-    mail = parse_email(malformed)
+def test__150_the_tree_agrees_with_the_flat_view(malformed: bytes):
+    # Both views parse the same payload through the same repair, so the structure
+    # one reports cannot contradict the bodies the other returns.
+    theirs = email.message_from_bytes(malformed, policy=email.policy.default)
 
-    content_type = mail.headers["Content-Type"][0]
-    assert content_type.startswith("multipart/")
+    ours = [part.content_type for part in walk(parse_email_tree(malformed))]
 
-    declared = content_type.split('boundary="')[1].split('"')[0]
-    assert f"--{declared}" in mail.headers, (
-        "the unterminated-header signature: the declared boundary appears as a "
-        "header key"
+    assert ours == [part.get_content_type() for part in theirs.walk()]
+
+
+# The repair fires only while scanning the header block, which ends at the first
+# blank line -- so a body line without a colon, which is most body lines, can
+# never reach it. These pin that boundary.
+
+
+def test__150_a_terminated_header_block_is_untouched():
+    mail = parse_email(
+        b"Subject: intact\r\n"
+        b"Content-Type: text/plain\r\n"
+        b"\r\n"
+        b"a body line with no colon in it\r\n"
     )
+
+    assert mail.subject == "intact"
+    assert mail.text_plain == ["a body line with no colon in it\r\n"]
+
+
+def test__150_the_rule_is_the_colon_and_not_the_boundary():
+    # Nothing MIME-specific about it: the header block ends at the first line
+    # that cannot be a header field, whatever that line happens to say.
+    mail = parse_email(b"Subject: no separator\nthis line is the body\n")
+
+    assert mail.subject == "no separator"
+    assert mail.text_plain == ["this line is the body\n"]
+
+
+def test__150_a_folded_continuation_does_not_end_the_header_block():
+    # A continuation line carries no colon of its own. Ending the header block at
+    # one would be a new bug in the same place as the old one.
+    mail = parse_email(
+        b"Subject: folded\r\n"
+        b"X-Long: first\r\n"
+        b" second\r\n"
+        b"\r\n"
+        b"body\r\n"
+    )
+
+    assert mail.headers["X-Long"] == ["first second"]
+    assert mail.text_plain == ["body\r\n"]

--- a/tests/test_mime_tree.py
+++ b/tests/test_mime_tree.py
@@ -28,13 +28,12 @@ from fast_mail_parser import (
 
 _DATA = os.path.join(os.path.dirname(__file__), "data")
 
-# Same corpus and same exclusion as test_stdlib_parity.py: invalid_message.eml is
-# a real message malformed such that the two parsers legitimately disagree about
-# its structure, which is documented in #150 rather than compared blindly.
+# The same corpus as test_stdlib_parity.py, and like it, nothing is excluded.
+# invalid_message.eml was, because the two parsers disagreed about its structure
+# while only the stdlib recovered from its unterminated header block; the tree
+# path applies the same repair as the flat one, so the topologies now agree (#150).
 FIXTURES = sorted(glob.glob(os.path.join(_DATA, "rfc", "*.eml"))) + sorted(
-    path
-    for path in glob.glob(os.path.join(_DATA, "*.eml"))
-    if os.path.basename(path) != "invalid_message.eml"
+    glob.glob(os.path.join(_DATA, "*.eml"))
 )
 
 

--- a/tests/test_parse_many.py
+++ b/tests/test_parse_many.py
@@ -65,13 +65,11 @@ def test__accepts_mixed_str_and_bytes():
 
 _DATA = os.path.join(os.path.dirname(__file__), "data")
 
-# Every real fixture. invalid_message.eml is excluded because the two parsers
-# disagree about it -- it is malformed in a way both accept but interpret
-# differently -- not because it fails to parse; it does parse.
+# Every real fixture, invalid_message.eml included: it was excluded while the two
+# parsers still disagreed about it (#150), and the batch path has to reproduce the
+# single-message result on a repaired message as exactly as on any other.
 CORPUS = sorted(glob.glob(os.path.join(_DATA, "rfc", "*.eml"))) + sorted(
-    path
-    for path in glob.glob(os.path.join(_DATA, "*.eml"))
-    if os.path.basename(path) != "invalid_message.eml"
+    glob.glob(os.path.join(_DATA, "*.eml"))
 )
 
 
@@ -135,8 +133,8 @@ def test__chunking_a_batch_changes_nothing():
 
 def test__an_unparseable_payload_lands_in_its_own_slot_amid_real_messages():
     # BROKEN rather than tests/data/invalid_message.eml: despite its name that
-    # fixture parses successfully (see #150), so it cannot
-    # stand in for a parse failure.
+    # fixture parses successfully -- and since #150 it parses correctly -- so it
+    # cannot stand in for a parse failure.
     good = open(CORPUS[0], "rb").read()
     payloads = [good, BROKEN, good]
 

--- a/tests/test_stdlib_parity.py
+++ b/tests/test_stdlib_parity.py
@@ -28,14 +28,14 @@ _DATA = os.path.join(os.path.dirname(__file__), "data")
 
 # The generated RFC corpus plus the hand-written fixtures, which are closer to
 # real-world mail and so likelier to surface a genuine divergence.
-# invalid_message.eml is excluded, but NOT because it fails to parse -- despite
-# the name, both parsers accept it. It is a real-world message malformed such
-# that the two disagree on the body and the header set, which is a documented
-# divergence to classify rather than a fixture to compare blindly.
+#
+# Nothing is excluded. invalid_message.eml used to be: the two parsers disagreed
+# about its body and its header set, because its header block is never terminated
+# and only the stdlib recovered from that (#150). Now that both do, it is compared
+# like every other fixture, and the three divergences it still shows are the
+# line-ending and unfolding ones that every real message shows.
 FIXTURES = sorted(glob.glob(os.path.join(_DATA, "rfc", "*.eml"))) + sorted(
-    path
-    for path in glob.glob(os.path.join(_DATA, "*.eml"))
-    if os.path.basename(path) != "invalid_message.eml"
+    glob.glob(os.path.join(_DATA, "*.eml"))
 )
 
 # (fixture, dimension) -> why the two legitimately differ.
@@ -84,6 +84,26 @@ DIVERGENCES: dict[tuple[str, str], str] = {
     ("valid_message", "headers"): (
         "on unfolding, this library collapses folding whitespace to one space; "
         "the stdlib preserves the original run"
+    ),
+    # invalid_message is bare-LF on the wire, but its parts are
+    # quoted-printable and encode their line endings as CRLF, so the decoded
+    # bodies carry CRLF and the same line-ending divergence as valid_message.
+    # Both parts are compared because both are now recovered (#150).
+    ("invalid_message", "text_plain"): (
+        "stdlib normalises body line endings to LF; this library preserves the "
+        "wire form (CRLF, encoded as =0D=0A by the quoted-printable part)"
+    ),
+    ("invalid_message", "text_html"): (
+        "stdlib normalises body line endings to LF; this library preserves the "
+        "wire form (CRLF, encoded as =0D=0A by the quoted-printable part)"
+    ),
+    # Both of the header divergences already documented for other fixtures, in
+    # one message: its ARC-*/Received/DKIM-Signature headers are folded, and its
+    # Date is 'Wed,  1 Jul 2020 ...' which the stdlib re-emits zero-padded.
+    ("invalid_message", "headers"): (
+        "on unfolding, this library collapses folding whitespace to one space "
+        "while the stdlib preserves the original run; and the stdlib renormalises "
+        "structured headers, zero-padding the day in Date"
     ),
 }
 


### PR DESCRIPTION
Closes #150.

## The defect

RFC 5322 ends the header block with an empty line. `tests/data/invalid_message.eml`
— a real Mailchimp-delivered message, bare-LF throughout — never sends one: a
folded ` hello` line is followed directly by the first MIME boundary.

mailparse stops parsing headers only at an empty line, and `parse_header` accepts
a colonless line as a field name with an empty value, so it kept consuming the
body as headers — 73 lines, 31 keys, one of them `--<the boundary the message
declares>`, plus a second `Content-Type` belonging to the first part rather than
to the message. With the opening delimiter eaten, the first part's body sat
before the *next* boundary, which makes it multipart preamble: discarded by
definition. The `text/html` alternative was delimited normally and survived, so
the message came back looking populated with its plain-text body silently gone.

That silence is the argument for repairing rather than only reporting: a parse
that quietly returns less than the message contains is worse than one that fails.

## The repair

The rule is the stdlib's, which names the defect
`MissingHeaderBodySeparatorDefect`: a non-continuation line in the header block
that cannot be a header field ends the header block, and the body starts there.

mailparse owns the header parsing, so the rule is applied to the payload mailparse
is handed rather than to mailparse: `repair_missing_separator` in
`src/mail_parser.rs` scans the header block and, if it finds such a line, returns
a copy of the payload with a single `\n` inserted in front of it. mailparse then
reaches the stdlib's conclusion on its own, with no change to it and no second
header parser in this crate. Where the payload is already well-formed the function
returns `None` and the original bytes are parsed, untouched.

Applied by `parse_email`, `parse_many` and `parse_email_tree`, and to an embedded
`message/rfc822` that the tree parses, so the flat and structural views cannot
disagree about such a message. **Not** applied to a multipart *part*'s headers:
those are parsed inside mailparse's boundary split, which is not reachable from
here, so a part that omits its own separator is still read the way mailparse reads
it. That case would need upstream work.

### Why "cannot be a header field" is narrowed to "contains no colon"

The stdlib's `headerRE` is stricter: a field name may hold only printable ASCII
other than colon, so `Subject : x`, or an 8-bit byte in a field name, ends the
block for it too. mailparse accepts both of those as headers, and demoting them to
body text would trade one silent loss (a body) for another (the rest of the
headers). The colon is the part of the rule that identifies *this* defect. Two
exemptions are the stdlib's own: a line starting with space or tab is a folded
continuation, and a leading `From ` line is an mbox envelope header.

Nothing else changes behaviour for a message that has its separator, and the
narrower rule can only fire on strictly fewer inputs than the stdlib's.

## The exclusions are gone

`test_stdlib_parity.py`, `test_mime_tree.py` and `test_parse_many.py` each skipped
this fixture because the two parsers disagreed about it. All three now compare it
like any other fixture — which is the real validation of the fix, since it puts
the stdlib in charge of judging the result rather than numbers written into a
test.

What makes that safe to assert without a build: **repaired, `invalid_message.eml`
differs from `valid_message.eml` — the same Mailchimp message with its header
block correctly terminated — by exactly one line**, the injected ` hello` fold,
which both parsers read identically as `MIME-Version: 1.0 hello`. `valid_message`
passes the parity suite today with exactly three declared divergences, so
`invalid_message` inherits that profile, and the three entries added to
`DIVERGENCES` are its existing ones:

- `text_plain` / `text_html` — CRLF in the decoded bodies. The file is bare-LF on
  the wire, but its quoted-printable parts spell their line endings `=0D=0A`, so
  the decoded bodies carry CRLF while the stdlib normalises to LF. Divergence 4 in
  `docs/compatibility.md`.
- `headers` — folding whitespace collapsed to one space (divergence 5), plus the
  stdlib re-spelling `Date: Wed,  1 Jul 2020 …` with the day zero-padded
  (divergence 2).

`docs/compatibility.md` is updated for all three, since the parity test fails on a
divergence that is declared but not documented and on one that is documented but
no longer observed.

## Performance

Cost on a well-formed message is one pass over the header block, which ends at the
empty line it has: one comparison per line, nothing read past the separator, no
allocation. Only a defective message allocates, and it allocates once. The
100 MiB input cap is still checked *before* the scan, so an oversized payload is
still rejected without being read or copied (`test_payload_memory.py` measures
exactly that).

The change lives in `src/mail_parser.rs`, the PyO3-free core; no hot function body
changed apart from the two-line dispatch, and the scan carries `#[inline(never)]`
so it cannot grow the parse path's code size — which has cost this crate 24%
before (see the Performance section of `CONTRIBUTING.md`).

## Tests

- `tests/test_known_issues.py` — the four `#150` pins now assert the recovery
  instead of the loss: both parts present, no boundary as a header key, one
  `Content-Type`, and the header set and the recovered plain body compared
  against the stdlib. Three added tests pin the *rule* rather than the fixture: a
  terminated header block is untouched, a colonless line ends the block whether
  or not it is a MIME boundary, and a folded continuation does not.
- The second defect is pinned as unchanged: ` hello` still folds into
  `MIME-Version`, as it does for the stdlib.
- No warnings channel here — that is #100, being worked on in parallel. Happy to
  rebase.

## What I could not verify locally

There is no Rust toolchain in the environment I worked in, so **CI is the first
compile**. Everything above about mailparse's behaviour is read out of
`mailparse` 0.16.1's source rather than assumed:

- `parse_headers` breaks only on `\n` / `\r\n` and errors on a lone CR at a header
  start (so a line beginning with CR is deliberately left alone).
- `parse_header` keeps a colonless line as a key with an empty value.
- `find_from_u8_line_prefix` accepts a boundary delimiter at `ix == ix_start`,
  which is what makes a body that begins immediately with `--boundary` split
  correctly after the repair — the one thing the whole approach rests on.
- `MailParseError` borrows nothing, so parsing from a local buffer is sound.

The behavioural predictions were checked by applying a line-for-line Python port
of the scan to every fixture (it fires on `invalid_message.eml` and on nothing
else), to every message-shaped literal in the test suite (nothing), and by
parsing the repaired bytes with an older installed build to confirm the recovered
part, the 29-key header set and the byte-diff against `valid_message.eml`.
