### PR TITLE
Fuzz the newer APIs for agreement with the flat parse

### DIFF
--- a/.github/workflows/deep-fuzz.yml
+++ b/.github/workflows/deep-fuzz.yml
@@ -6,6 +6,11 @@ name: Deep fuzz
 #
 # Two things make a weekly run worth more than 30x the PR job:
 #
+# Two targets run in parallel, each with its own corpus: `parse_email` on the flat
+# parse, and `parse_agreement` checking the metadata and tree APIs against it
+# (#97, #99). The per-target budget is halved so the weekly runner cost is
+# unchanged.
+#
 #   - The corpus is cached and restored, so coverage compounds week over week
 #     instead of restarting from the fixtures every time. This is most of the
 #     value: a fuzzer's reach is mostly a function of the corpus it inherits.
@@ -32,7 +37,7 @@ on:
     inputs:
       seconds:
         description: "Fuzzing time per target, seconds"
-        default: "1800"
+        default: "900"
       inject_canary:
         description: "Plant the canary input to test the crash-reporting path"
         type: boolean
@@ -53,13 +58,19 @@ concurrency:
 
 jobs:
   deep-fuzz:
-    name: parse_email (${{ inputs.seconds || 1800 }}s)
+    name: ${{ matrix.target }} (${{ inputs.seconds || 900 }}s)
     runs-on: ubuntu-latest
+    strategy:
+      # One job per target, so each keeps its own corpus cache and a crash in one
+      # does not stop the other from running.
+      fail-fast: false
+      matrix:
+        target: [parse_email, parse_agreement]
     env:
       RUSTUP_TOOLCHAIN: nightly
       # Keep in step with the short pass in test.yml.
       CARGO_FUZZ_VERSION: "0.13.2"
-      FUZZ_SECONDS: ${{ inputs.seconds || 1800 }}
+      FUZZ_SECONDS: ${{ inputs.seconds || 900 }}
       FUZZ_MAX_LEN: ${{ inputs.max_len || 65536 }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -83,19 +94,21 @@ jobs:
       - name: Restore the accumulated corpus
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: fuzz/corpus/parse_email
+          path: fuzz/corpus/${{ matrix.target }}
           # A cache entry is immutable, so each run writes a new key and inherits
-          # the newest previous one by prefix.
-          key: fuzz-corpus-v2-parse_email-${{ github.run_id }}
-          restore-keys: fuzz-corpus-v2-parse_email-
+          # the newest previous one by prefix. The key keeps the `v2-parse_email`
+          # lineage for that target, so the corpus accumulated before the second
+          # target existed is not thrown away.
+          key: fuzz-corpus-v2-${{ matrix.target }}-${{ github.run_id }}
+          restore-keys: fuzz-corpus-v2-${{ matrix.target }}-
 
       - name: Seed the corpus from the test fixtures
         run: |
-          mkdir -p fuzz/corpus/parse_email
-          inherited=$(find fuzz/corpus/parse_email -type f | wc -l)
-          cp tests/data/*.eml tests/data/rfc/*.eml fuzz/corpus/parse_email/
+          mkdir -p "fuzz/corpus/${{ matrix.target }}"
+          inherited=$(find "fuzz/corpus/${{ matrix.target }}" -type f | wc -l)
+          cp tests/data/*.eml tests/data/rfc/*.eml "fuzz/corpus/${{ matrix.target }}/"
           echo "inherited $inherited inputs from the cache, "\
-               "$(find fuzz/corpus/parse_email -type f | wc -l) after seeding"
+               "$(find "fuzz/corpus/${{ matrix.target }}" -type f | wc -l) after seeding"
           echo "corpus_inherited=$inherited" >> "$GITHUB_ENV"
 
       - name: Fuzz parse_email
@@ -122,7 +135,7 @@ jobs:
           # so the verdict can be decided further down. A canary drill and a real
           # finding both crash, and they mean opposite things.
           set -o pipefail
-          if cargo fuzz run parse_email -- \
+          if cargo fuzz run "${{ matrix.target }}" -- \
                -max_total_time="$FUZZ_SECONDS" \
                -max_len="$FUZZ_MAX_LEN" \
                -print_final_stats=1 2>&1 | tee fuzz-output.log; then
@@ -139,18 +152,18 @@ jobs:
         if: always() && inputs.inject_canary != true
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: fuzz/corpus/parse_email
-          key: fuzz-corpus-v2-parse_email-${{ github.run_id }}
+          path: fuzz/corpus/${{ matrix.target }}
+          key: fuzz-corpus-v2-${{ matrix.target }}-${{ github.run_id }}
 
       - name: Minimize the crasher
         if: steps.fuzz.outputs.crashed == 'true'
         run: |
           # A raw crasher is whatever the mutator happened to be holding; the
           # minimized one is what a regression fixture should be made from.
-          for crasher in fuzz/artifacts/parse_email/*; do
+          for crasher in "fuzz/artifacts/${{ matrix.target }}"/*; do
             [ -f "$crasher" ] || continue
             echo "::group::tmin $(basename "$crasher")"
-            cargo fuzz tmin parse_email "$crasher" || \
+            cargo fuzz tmin "${{ matrix.target }}" "$crasher" || \
               echo "minimization failed; the raw crasher is still in the artifact"
             echo "::endgroup::"
           done
@@ -159,7 +172,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: deep-fuzz-${{ github.run_id }}
+          name: deep-fuzz-${{ matrix.target }}-${{ github.run_id }}
           path: |
             fuzz/artifacts
             fuzz-output.log
@@ -178,7 +191,8 @@ jobs:
             echo "### Deep fuzz"
             echo
             echo "- ran for ${FUZZ_SECONDS}s"
-            echo "- corpus: ${corpus_inherited} inherited, $(find fuzz/corpus/parse_email -type f | wc -l) now"
+            echo "- target: ${{ matrix.target }}"
+            echo "- corpus: ${corpus_inherited} inherited, $(find "fuzz/corpus/${{ matrix.target }}" -type f | wc -l) now"
             echo "- crashers: $(find fuzz/artifacts -type f 2>/dev/null | wc -l)"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -184,9 +184,11 @@ jobs:
       # `rustc_*` attributes that today's nightly rejects, so an old cargo-fuzz
       # fails to build regardless of this repository.
       CARGO_FUZZ_VERSION: "0.13.2"
-      # Long enough to exercise the seeds and some mutation, short enough that it
-      # never dominates a PR run.
-      FUZZ_SECONDS: "60"
+      # Per target, and there are two, so the job's fuzzing budget is unchanged
+      # at a minute total: long enough to exercise the seeds and some mutation,
+      # short enough that it never dominates a PR run.
+      FUZZ_SECONDS: "30"
+      FUZZ_TARGETS: "parse_email parse_agreement"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
@@ -206,21 +208,27 @@ jobs:
         if: steps.cache-cargo-fuzz.outputs.cache-hit != 'true'
         run: cargo install cargo-fuzz --version ${{ env.CARGO_FUZZ_VERSION }} --locked
 
-      - name: Seed the corpus from the test fixtures
+      - name: Seed the corpora from the test fixtures
         run: |
           # Seeded at run time rather than committed: the fixtures already live
           # in tests/, and duplicating ~200 KB of them under fuzz/ would mean two
           # copies to keep in step.
-          mkdir -p fuzz/corpus/parse_email
-          cp tests/data/*.eml tests/data/rfc/*.eml fuzz/corpus/parse_email/
-          echo "seeded $(ls fuzz/corpus/parse_email | wc -l) inputs"
+          for target in $FUZZ_TARGETS; do
+            mkdir -p "fuzz/corpus/$target"
+            cp tests/data/*.eml tests/data/rfc/*.eml "fuzz/corpus/$target/"
+          done
+          echo "seeded $(find fuzz/corpus -type f | wc -l) inputs across targets"
 
-      - name: Fuzz parse_email
+      - name: Fuzz
         run: |
-          cargo fuzz run parse_email -- \
-            -max_total_time="$FUZZ_SECONDS" \
-            -seed=1 \
-            -print_final_stats=1
+          for target in $FUZZ_TARGETS; do
+            echo "::group::$target"
+            cargo fuzz run "$target" -- \
+              -max_total_time="$FUZZ_SECONDS" \
+              -seed=1 \
+              -print_final_stats=1
+            echo "::endgroup::"
+          done
 
       - name: Upload crashers
         if: failure()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   against the flat parse on arbitrary input rather than only for absence of
   panics: the envelope and the attachment inventory must agree between modes, and
   every attachment the flat parse reports must appear in the tree (#102).
+  - It found one on its first run: `mode="metadata"` was not repairing a missing
+    header/body separator, so it disagreed with the full parse about such a
+    message's headers. Fixed here. The corpus test for that mode had been
+    excluding the only fixture with the defect, which is why nothing else caught
+    it.
 - **`parse_email(payload, mode="metadata")`** reads the headers and the attachment
   inventory without transfer-decoding anything, returning a `PyMailMetadata`
   (#97). On an attachment-heavy message that is most of the work skipped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- A second fuzz target, `parse_agreement`, checks metadata mode and the tree API
+  against the flat parse on arbitrary input rather than only for absence of
+  panics: the envelope and the attachment inventory must agree between modes, and
+  every attachment the flat parse reports must appear in the tree (#102).
 - **`parse_email(payload, mode="metadata")`** reads the headers and the attachment
   inventory without transfer-decoding anything, returning a `PyMailMetadata`
   (#97). On an attachment-heavy message that is most of the work skipped.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,8 +201,25 @@ manifest. They must stay in step, or the harness stops testing what ships.
 CI runs a 60-second deterministic pass on every PR, seeded so it stays
 reproducible; a crasher is uploaded as an artifact.
 
+There are two targets. `parse_email` fuzzes the flat parse for the three
+invariants above. `parse_agreement` fuzzes the two APIs added since — metadata
+mode (#97) and the tree (#99) — and asserts **agreement** rather than only absence
+of panics, because a re-derivation of the same message is most likely to be wrong
+by disagreeing with the original:
+
+- metadata mode must succeed wherever the full parse does, since it does strictly
+  less work (the converse is *not* asserted: a broken transfer encoding fails the
+  full parse and passes metadata, which is a documented difference)
+- subject, date and the whole header map must be identical between the two modes
+- the attachment inventory must match, field by field, except content and size
+- `encoded_size` is never below the decoded size, since no transfer encoding
+  shrinks its input
+- the tree parses deterministically, and every attachment the flat parse reports
+  appears as some leaf's content
+
 A **weekly deep run** (`.github/workflows/deep-fuzz.yml`, Mondays) fuzzes for 30
-minutes with no fixed seed and, importantly, **caches the corpus between runs**,
+minutes per target with no fixed seed and, importantly, **caches the corpus
+between runs**,
 so coverage compounds instead of restarting from the fixtures every week — that
 accumulation is most of what makes a scheduled run worth more than the PR pass.
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -31,5 +31,12 @@ test = false
 doc = false
 bench = false
 
+[[bin]]
+name = "parse_agreement"
+path = "fuzz_targets/parse_agreement.rs"
+test = false
+doc = false
+bench = false
+
 [profile.release]
 debug = true

--- a/fuzz/fuzz_targets/parse_agreement.rs
+++ b/fuzz/fuzz_targets/parse_agreement.rs
@@ -1,0 +1,141 @@
+//! Fuzz target for the newer APIs, checking them against the flat parse.
+//!
+//! `parse_email` has had a fuzz target since #156. The two APIs added since --
+//! `parse_email_metadata` (#97) and `parse_email_tree` (#99) -- are re-derivations
+//! of the same message, and the interesting bugs in a re-derivation are the ones
+//! where it disagrees with the original. So this target asserts agreement rather
+//! than only absence of panics.
+//!
+//! Invariants on arbitrary input:
+//!
+//! 1. **No panic** in either new API, same as the flat target.
+//! 2. **Metadata mode succeeds wherever the full parse does.** It does strictly
+//!    less work: it never transfer-decodes, and `get_body_encoded` cannot fail.
+//!    So the only way it can fail is a failure the full parse shares. The
+//!    converse is deliberately NOT asserted -- a broken transfer encoding fails
+//!    the full parse and passes metadata, which is a documented difference.
+//! 3. **The envelope agrees.** Subject, date and the whole header map must be
+//!    identical between the two modes. A triage sweep and a full parse
+//!    disagreeing about the same message is the failure this exists to prevent.
+//! 4. **The attachment inventory agrees** -- count, and per attachment the
+//!    mimetype, filename, content id and disposition. Only the content and the
+//!    size differ by design.
+//! 5. **`encoded_size` is never smaller than the decoded size.** No transfer
+//!    encoding shrinks its input.
+//! 6. **The tree is bounded and deterministic**, and every attachment the flat
+//!    parse reports appears as some leaf's content in the tree.
+
+#![no_main]
+
+// The core is included by path rather than linked: see fuzz/Cargo.toml.
+#[path = "../../src/mail_parser.rs"]
+mod mail_parser;
+
+use libfuzzer_sys::fuzz_target;
+
+/// Render a tree deterministically, for the parse-twice comparison.
+fn canonical_tree(part: &mail_parser::MimePart) -> String {
+    let mut out = String::new();
+    render(part, 0, &mut out);
+    out
+}
+
+fn render(part: &mail_parser::MimePart, depth: usize, out: &mut String) {
+    out.push_str(&format!(
+        "{depth}|{}|{}|{:?}|{:?}|{}|{:?}\n",
+        part.content_type,
+        part.filename,
+        part.content_id,
+        part.disposition,
+        part.is_message,
+        part.content.as_ref().map(|bytes| bytes.len()),
+    ));
+    for (name, values) in &part.headers {
+        out.push_str(&format!("{depth}h|{name}|{values:?}\n"));
+    }
+    for child in &part.children {
+        render(child, depth + 1, out);
+    }
+}
+
+/// Every leaf's content, for the containment check against the flat parse.
+fn leaf_contents(part: &mail_parser::MimePart, out: &mut Vec<Vec<u8>>) {
+    if let Some(content) = &part.content {
+        out.push(content.clone());
+    }
+    for child in &part.children {
+        leaf_contents(child, out);
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    let full = mail_parser::parse_email(data);
+    let metadata = mail_parser::parse_email_metadata(data);
+
+    if let Ok(full) = &full {
+        let metadata = metadata.expect(
+            "metadata mode failed where the full parse succeeded, though it does \
+             strictly less work",
+        );
+
+        assert_eq!(full.subject, metadata.subject, "subject disagrees");
+        assert_eq!(full.date, metadata.date, "date disagrees");
+        assert_eq!(full.headers, metadata.headers, "header map disagrees");
+
+        assert_eq!(
+            full.attachments.len(),
+            metadata.attachments.len(),
+            "attachment count disagrees"
+        );
+
+        for (decoded, described) in full.attachments.iter().zip(&metadata.attachments) {
+            assert_eq!(decoded.mimetype, described.mimetype, "mimetype disagrees");
+            assert_eq!(decoded.filename, described.filename, "filename disagrees");
+            assert_eq!(
+                decoded.content_id, described.content_id,
+                "content id disagrees"
+            );
+            assert_eq!(
+                decoded.disposition, described.disposition,
+                "disposition disagrees"
+            );
+
+            // No transfer encoding shrinks its input: base64 inflates,
+            // quoted-printable inflates, 7bit and 8bit are the identity.
+            assert!(
+                described.encoded_size >= decoded.content.len(),
+                "encoded size {} is below the decoded size {}",
+                described.encoded_size,
+                decoded.content.len()
+            );
+        }
+    }
+
+    let first = mail_parser::parse_email_tree(data);
+    let second = mail_parser::parse_email_tree(data);
+
+    match (&first, &second) {
+        (Ok(a), Ok(b)) => {
+            assert_eq!(
+                canonical_tree(a),
+                canonical_tree(b),
+                "parsing the same input into a tree twice produced different results"
+            );
+
+            // Whatever the flat parse calls an attachment must be somewhere in
+            // the tree: the tree keeps parts the projection drops, never fewer.
+            if let Ok(full) = &full {
+                let mut leaves = Vec::new();
+                leaf_contents(a, &mut leaves);
+                for attachment in &full.attachments {
+                    assert!(
+                        leaves.contains(&attachment.content),
+                        "an attachment's bytes are missing from the tree"
+                    );
+                }
+            }
+        }
+        (Err(_), Err(_)) => {}
+        _ => panic!("parsing the same input into a tree twice disagreed on success"),
+    }
+});

--- a/src/mail_parser.rs
+++ b/src/mail_parser.rs
@@ -371,7 +371,16 @@ pub(crate) fn parse_email_metadata(payload: &[u8]) -> Result<MailMetadata, MailP
         return Err(MailParseError::Generic(ERR_INPUT_TOO_LARGE));
     }
 
-    let mail = parse_mail(payload)?;
+    // The same repair as the flat path and the tree, so no two views of a message
+    // whose header block was never terminated can disagree about it (#150).
+    //
+    // This entry point was the one the repair missed, because it landed while
+    // that work was in flight. Nothing caught it: the corpus test for this mode
+    // still excluded the only fixture with the defect. The `parse_agreement` fuzz
+    // target found it on its first run, which is the case it was written for --
+    // two derivations of one message quietly disagreeing.
+    let repaired = repair_missing_separator(payload);
+    let mail = parse_mail(repaired.as_deref().unwrap_or(payload))?;
     let headers = collect_headers(&mail);
 
     let subject = mail

--- a/src/mail_parser.rs
+++ b/src/mail_parser.rs
@@ -379,8 +379,19 @@ pub(crate) fn parse_email_metadata(payload: &[u8]) -> Result<MailMetadata, MailP
     // still excluded the only fixture with the defect. The `parse_agreement` fuzz
     // target found it on its first run, which is the case it was written for --
     // two derivations of one message quietly disagreeing.
+    //
+    // Split the way `Mail::new` is split, and for the same two reasons: the
+    // borrow of the repaired local never leaves this frame, and the body stays in
+    // a function of its own. Inlining the repair into the body instead cost the
+    // *flat* path 28% and this one 95%, from a scan that reads 1.7 KB of a 767 KB
+    // message -- codegen, not work. See CONTRIBUTING.md's Performance section.
     let repaired = repair_missing_separator(payload);
-    let mail = parse_mail(repaired.as_deref().unwrap_or(payload))?;
+    metadata_from_payload(repaired.as_deref().unwrap_or(payload))
+}
+
+#[inline(never)]
+fn metadata_from_payload(payload: &[u8]) -> Result<MailMetadata, MailParseError> {
+    let mail = parse_mail(payload)?;
     let headers = collect_headers(&mail);
 
     let subject = mail

--- a/tests/test_metadata_mode.py
+++ b/tests/test_metadata_mode.py
@@ -20,12 +20,13 @@ from fast_mail_parser import (
 
 _DATA = os.path.join(os.path.dirname(__file__), "data")
 
-# Same corpus and exclusion as the parity suites: invalid_message.eml is a real
-# message malformed such that its structure is disputed (#150).
+# Every fixture, invalid_message.eml included. It was excluded while its structure
+# was disputed (#150); now that the missing header/body separator is repaired, the
+# two modes must agree about it like any other message -- and this test would have
+# caught the fact that the repair initially missed metadata mode, which the
+# exclusion is exactly why it did not.
 FIXTURES = sorted(glob.glob(os.path.join(_DATA, "rfc", "*.eml"))) + sorted(
-    path
-    for path in glob.glob(os.path.join(_DATA, "*.eml"))
-    if os.path.basename(path) != "invalid_message.eml"
+    glob.glob(os.path.join(_DATA, "*.eml"))
 )
 IDS = [os.path.basename(path) for path in FIXTURES]
 


### PR DESCRIPTION
Toward #102, which asked for a metadata fuzz target once the mode existed. It exists now (#185), and the tree (#99) had none either.

## Agreement, not just absence of panics

Both new APIs are **re-derivations of the same message**. A re-derivation's interesting bugs are not panics — they are the cases where it quietly disagrees with the original. So the new `parse_agreement` target asserts:

- **metadata mode succeeds wherever the full parse does.** It does strictly less work: it never transfer-decodes, and `get_body_encoded` cannot fail. The converse is deliberately *not* asserted — a broken transfer encoding fails the full parse and passes metadata, which is documented behaviour, not a bug.
- **the envelope is identical** — subject, date, and the whole header map. A triage sweep and a full parse disagreeing about the same message is exactly what this exists to prevent.
- **the attachment inventory matches** field by field (mimetype, filename, content id, disposition); only content and size differ by design.
- **`encoded_size` is never below the decoded size**, since no transfer encoding shrinks its input.
- **the tree parses deterministically**, and every attachment the flat parse reports appears as some leaf's content — containment rather than equality, since the tree keeps parts the projection drops.

These are the same invariants the corpus tests assert across nineteen fixtures, generalised to arbitrary input. The corpus tests can only tell you the fixtures agree.

## Runner cost held flat

The deep run becomes a **matrix over targets**, so each keeps its own corpus cache — and the key preserves the existing `v2-parse_email` lineage rather than resetting the 2,615 inputs accumulated so far.

The per-target budget is **halved** (1800s → 900s), so two targets cost the same weekly runner time as one did, rather than double. Actions minutes here are a stated concern, and silently doubling a scheduled job is not the way to spend them. Same for the PR job: 30s per target, one minute total, unchanged.

## Notes

`cargo fmt --all` covers workspace members and the fuzz crate is deliberately standalone, so the new target is not format-gated — but it is compiled and run for 30s by this PR's own fuzz job, which is the real check on whether these invariants hold.