### PR TITLE
Correct the claim that a part cannot decode larger than it was encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Attachments come back as `PyAttachmentMetadata` with `encoded_size` -- the
     bytes the part occupies in the message, before decoding. Named for what it is:
     the decoded size cannot be known without the decode this mode exists to skip.
+    It is **not** an upper bound on the decoded size -- quoted-printable emits a
+    line break as CRLF, so a body of bare LFs decodes larger than it was encoded.
+    Decoding cannot more than double a part.
   - No `text_plain`/`text_html`, and absent rather than empty: an empty list
     cannot be told apart from "no text part", so a sweep counting bodyless
     messages would count all of them.

--- a/Readme.md
+++ b/Readme.md
@@ -310,6 +310,10 @@ transfer-decoding — named for what it is, because metadata mode cannot know th
 decoded size without doing the decode it exists to skip (base64 inflates by about
 a third). In full mode the decoded size is `len(content)`.
 
+It is **not an upper bound** on the decoded size, which is easy to assume and
+wrong: quoted-printable emits a line break as CRLF, so a body of bare LFs decodes
+*larger* than it was encoded. Decoding cannot more than double a part.
+
 Two things metadata mode deliberately does not give you:
 
 **No bodies.** There is no `text_plain`/`text_html` — not empty lists, absent. An

--- a/fast_mail_parser/__init__.pyi
+++ b/fast_mail_parser/__init__.pyi
@@ -72,6 +72,11 @@ class PyAttachmentMetadata:
     decoded size without doing the decode it exists to skip, and base64 inflates
     by about a third. In full mode the decoded size is ``len(content)``.
 
+    It is **not** an upper bound on the decoded size. Base64 decodes smaller, but
+    quoted-printable emits a line break as CRLF, so a body of bare LFs decodes
+    *larger* than it was encoded. Decoding cannot more than double a part, which
+    is the bound the test suite and the fuzz harness assert.
+
     A separate type rather than a ``PyAttachment`` whose ``content`` is ``None``,
     so that ``PyAttachment.content`` stays ``bytes`` for every caller who never
     asked for this mode.

--- a/fuzz/fuzz_targets/parse_agreement.rs
+++ b/fuzz/fuzz_targets/parse_agreement.rs
@@ -20,8 +20,9 @@
 //! 4. **The attachment inventory agrees** -- count, and per attachment the
 //!    mimetype, filename, content id and disposition. Only the content and the
 //!    size differ by design.
-//! 5. **`encoded_size` is never smaller than the decoded size.** No transfer
-//!    encoding shrinks its input.
+//! 5. **Decoding does not amplify a part beyond doubling it.** Not "decoded is
+//!    never larger than encoded", which is false: quoted-printable emits a line
+//!    break as CRLF, so a body of bare LFs grows by a byte per line.
 //! 6. **The tree is bounded and deterministic**, every attachment the flat parse
 //!    reports appears as some leaf's content, and the tree root's headers are the
 //!    flat parse's headers -- the root is the same message, so they cannot differ
@@ -102,13 +103,25 @@ fuzz_target!(|data: &[u8]| {
                 "disposition disagrees"
             );
 
-            // No transfer encoding shrinks its input: base64 inflates,
-            // quoted-printable inflates, 7bit and 8bit are the identity.
+            // Decoding cannot amplify a part beyond doubling it.
+            //
+            // The obvious invariant -- decoded is never larger than encoded --
+            // is false, and this target found it in fifteen minutes with 45
+            // crashers, every one quoted-printable. The `quoted_printable`
+            // crate emits a line break as `\r\n` (`decoded.push(b'\r');
+            // decoded.push(b'\n')`), so in robust mode a body of bare LFs comes
+            // back one byte longer per line: the minimised case was a body of a
+            // single `\n` decoding to two bytes.
+            //
+            // Doubling is the true bound. Every `\r\n` pair costs at least one
+            // input byte, `=XX` shrinks three to one, a literal byte is one to
+            // one, and base64 shrinks by a quarter. Past 2x, something is
+            // amplifying.
             assert!(
-                described.encoded_size >= decoded.content.len(),
-                "encoded size {} is below the decoded size {}",
-                described.encoded_size,
-                decoded.content.len()
+                decoded.content.len() <= described.encoded_size * 2,
+                "decoded size {} is more than double the encoded size {}",
+                decoded.content.len(),
+                described.encoded_size
             );
         }
     }

--- a/tests/test_metadata_mode.py
+++ b/tests/test_metadata_mode.py
@@ -83,14 +83,47 @@ def test__the_attachment_inventory_is_identical_to_full_mode(path: str):
 
 
 @pytest.mark.parametrize("path", FIXTURES, ids=IDS)
-def test__encoded_size_is_at_least_the_decoded_size(path: str):
-    # A transfer encoding never shrinks its input: base64 inflates by a third,
-    # quoted-printable by however many bytes needed escaping, 7bit/8bit not at
-    # all. So this holds for every encoding without knowing which was used.
+def test__decoding_does_not_amplify_a_part(path: str):
+    # NOT "encoded is at least decoded", which this asserted until a fuzz run
+    # produced 45 counterexamples: quoted-printable emits a line break as CRLF,
+    # so a body of bare LFs decodes larger than it was encoded. Doubling is the
+    # true bound -- see test__quoted_printable_can_decode_larger_than_its_encoded_size.
     full, meta = _both(path)
 
     for described, decoded in zip(meta.attachments, full.attachments, strict=True):
-        assert described.encoded_size >= len(decoded.content), described.filename
+        assert len(decoded.content) <= described.encoded_size * 2, described.filename
+
+
+def test__quoted_printable_can_decode_larger_than_its_encoded_size():
+    # `encoded_size` is the bytes on the wire, and it is NOT an upper bound on the
+    # decoded size. The `quoted_printable` crate emits a line break as CRLF, so a
+    # body of bare LFs gains a byte per line.
+    #
+    # Found by the `parse_agreement` fuzz target, which produced 45 crashers in
+    # fifteen minutes -- every one quoted-printable -- against an invariant that
+    # said this could not happen. Pinned here so the surprise is documented where
+    # someone reading the attribute will meet it.
+    message = (
+        b"Subject: qp\r\n"
+        b'Content-Type: application/octet-stream; name="x"\r\n'
+        b"Content-Disposition: attachment\r\n"
+        b"Content-Transfer-Encoding: quoted-printable\r\n"
+        b"\r\n"
+        b"a\nb\nc\n"
+    )
+
+    full = parse_email(message)
+    meta = parse_email(message, mode="metadata")
+
+    described = meta.attachments[0]
+    decoded = full.attachments[0].content
+
+    assert described.encoded_size < len(decoded), (
+        f"expected quoted-printable to grow: encoded {described.encoded_size}, "
+        f"decoded {len(decoded)}"
+    )
+    # Doubling is the real bound, and what the fuzz target now asserts.
+    assert len(decoded) <= described.encoded_size * 2
 
 
 def test__encoded_size_is_larger_for_base64(attachment_message: str):


### PR DESCRIPTION
The `parse_agreement` target from #187 produced **45 crashers in fifteen minutes**, every one quoted-printable, against an invariant asserting this could not happen ([run 33066089356](https://github.com/namecheap/fast_mail_parser/actions/runs/33066089356)).

**The invariant was wrong, not the library.**

## The mechanism, from the source rather than the crash

`quoted_printable` emits a line break as CRLF:

```rust
if add_line_break == Some(true) {
    decoded.push(b'\r');
    decoded.push(b'\n');
```

So in robust mode a body of bare LFs comes back one byte longer per line. The minimised crasher is 76 bytes whose body is a single `\n`, decoding to two.

I checked the crate rather than stopping at a plausible story — 45/45 being quoted-printable made the explanation likely, but likely is how the last three wrong diagnoses started.

## The bound that is actually true

**Doubling.** Each `\r\n` pair costs at least one input byte; `=XX` shrinks three bytes to one; a literal byte is one to one; base64 shrinks by a quarter. Past 2x something genuinely is amplifying, which is the DoS-relevant property and the one worth asserting.

That replaces the assertion in the fuzz target and in the corpus test.

## The same mistake was in the documentation

`encoded_size` read as an upper bound on the decoded size — precisely the assumption I made while writing it. A user sizing a buffer from it would have been wrong on quoted-printable mail, which is not rare. Corrected in the type stub, the README and the changelog.

And pinned by a test that decodes a bare-LF quoted-printable body and asserts it **grows**, so the surprise sits where someone reading the attribute will meet it rather than in a fuzz log.

## No regression fixture

#102's policy is that a crasher becomes a committed regression fixture. Not here: there is no bug to regress against. The artifact of this finding is a corrected bound and a test that documents the real behaviour.