### PR TITLE
Report a crasher through a file, and bound every field that has no bound

### DIFF
--- a/.github/scripts/report_fuzz_crash.sh
+++ b/.github/scripts/report_fuzz_crash.sh
@@ -18,21 +18,44 @@ TITLE="Deep fuzz: crasher in parse_email"
 mkdir -p fuzz/artifacts
 
 count=$(find fuzz/artifacts -type f | wc -l | tr -d ' ')
-files=$(find fuzz/artifacts -type f | sort | sed 's|^|- `|; s|$|`|')
+# Also capped: 45 crashers is a plausible haul, and an unbounded list is how a
+# report grows past what GitHub will accept.
+MAX_LISTED=20
+files=$(find fuzz/artifacts -type f | sort | head -n "$MAX_LISTED" \
+  | sed 's|^|- `|; s|$|`|')
 [ -n "$files" ] || files="- (none on disk; see the log)"
+if [ "$count" -gt "$MAX_LISTED" ]; then
+  files="${files}
+- ... and $((count - MAX_LISTED)) more, in the artifact"
+fi
 
 # The tail carries libFuzzer's dedup token and where it wrote the reproducer.
-excerpt=$(tail -n 40 fuzz-output.log 2>/dev/null || echo "(no log captured)")
+#
+# Capped by BYTES as well as lines, because a line has no bound: an assertion
+# message can be as large as the values it prints, and this harness compares whole
+# header maps. Forty such lines came to hundreds of kilobytes, the body went to
+# `gh` as a command-line argument, and the report died with "Argument list too
+# long" -- on the first real finding, so 45 crashers went unreported.
+EXCERPT_BYTES=3000
+excerpt=$(tail -n 40 fuzz-output.log 2>/dev/null | tail -c "$EXCERPT_BYTES" \
+  || echo "(no log captured)")
+[ -n "$excerpt" ] || excerpt="(no log captured)"
 
 # ...but not reliably the panic message. A Rust panic prints the location and
 # then the message on the following line, and 40 lines of stack frames can push
 # both out of the tail -- which is exactly what happened on the first drill. So
 # pull it out explicitly: it is the single most useful line in the log.
-panic=$(grep -m1 -A2 "panicked at" fuzz-output.log 2>/dev/null || true)
+# Capped for the same reason as the excerpt: a panic message is as large as the
+# values it prints, and this harness prints whole header maps. Uncapped, this
+# single field reached 40 KB on the first real finding.
+PANIC_BYTES=1500
+panic=$(grep -m1 -A2 "panicked at" fuzz-output.log 2>/dev/null \
+  | head -c "$PANIC_BYTES" || true)
 if [ -z "$panic" ]; then
   # No Rust panic: a timeout, an OOM, or a signal. libFuzzer's own summary says
   # which.
-  panic=$(grep -m1 -E "^(SUMMARY|==[0-9]+==ERROR)" fuzz-output.log 2>/dev/null || true)
+  panic=$(grep -m1 -E "^(SUMMARY|==[0-9]+==ERROR)" fuzz-output.log 2>/dev/null \
+    | head -c "$PANIC_BYTES" || true)
 fi
 [ -n "$panic" ] || panic="(the log records no panic or summary line)"
 
@@ -90,10 +113,27 @@ gh label create "$LABEL" \
 existing=$(gh issue list --label "$LABEL" --state open --limit 1 \
   --json number --jq '.[0].number // empty')
 
+# Written to a file rather than passed as an argument: a single argv string is
+# capped by the kernel (MAX_ARG_STRLEN, 128 KiB), and this body is assembled from
+# fuzzer output whose size is not ours to choose. GitHub also rejects a body over
+# 65536 characters, so it is trimmed to fit with a line saying so.
+body_file=$(mktemp)
+trap 'rm -f "$body_file"' EXIT
+printf '%s\n' "$body" > "$body_file"
+
+MAX_BODY=60000
+if [ "$(wc -c < "$body_file")" -gt "$MAX_BODY" ]; then
+  head -c "$MAX_BODY" "$body_file" > "${body_file}.trimmed"
+  printf '\n\n_Report trimmed to %s bytes; the full log is in the artifact._\n' \
+    "$MAX_BODY" >> "${body_file}.trimmed"
+  mv "${body_file}.trimmed" "$body_file"
+  echo "report trimmed to $MAX_BODY bytes"
+fi
+
 if [ -n "$existing" ]; then
   echo "commenting on existing #${existing}"
-  gh issue comment "$existing" --body "$body"
+  gh issue comment "$existing" --body-file "$body_file"
 else
   echo "opening a new issue"
-  gh issue create --title "$TITLE" --label "$LABEL" --body "$body"
+  gh issue create --title "$TITLE" --label "$LABEL" --body-file "$body_file"
 fi

--- a/.github/workflows/deep-fuzz.yml
+++ b/.github/workflows/deep-fuzz.yml
@@ -197,6 +197,11 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Verdict
+        # Always, even when reporting failed. Reporting is how a finding reaches a
+        # human, but the verdict is how it reaches CI, and one must not be able to
+        # swallow the other -- on the first real finding the reporter died and took
+        # the verdict's step with it.
+        if: always()
         # The drill and a real finding both crash, so "did it crash" is not the
         # verdict on its own. Before this, a working drill went red and a drill
         # whose canary went UNDETECTED went green -- the signal was inverted, and


### PR DESCRIPTION
**The alarm failed on its first real finding.** Toward #102.

`parse_agreement` found 45 crashers in the deep run ([33066089356](https://github.com/namecheap/fast_mail_parser/actions/runs/33066089356)) and the report died:

```
report_fuzz_crash.sh: line 98: /usr/bin/gh: Argument list too long
```

The body was passed as a command-line argument, which the kernel caps at 128 KiB per argument (`MAX_ARG_STRLEN`). Three of the body's fields have **no bound**: a panic message is as large as the values it prints, and this harness prints whole header maps — one line reached 40 KB, and forty of them came to 1.6 MB.

## Why this was worse than a failed step

No issue was filed. And because the verdict step lacked `if: always()`, it was **skipped** when reporting failed — so the run's own conclusion never printed either. The finding survived only because I was reading the run by hand.

The drills passed repeatedly because a drill produces one small crasher and a short log. They verified the path works, not that it works on the input it exists for. That distinction cost nothing here and would have cost the next real finding.

## Four fixes

- body written to a file and passed with `--body-file`, so the kernel's argument limit does not apply
- panic field capped at 1.5 KB, log excerpt at 3 KB — neither has a natural size
- reproducer list capped at twenty, with a count of the remainder
- **verdict always runs**, so reporting can no longer swallow it

Also trims the whole body to 60 KB with a note, since GitHub rejects a body over 65536 characters — a limit this would have hit next.

## Verified by reproducing it

45 crashers and a 1.6 MB log whose lines are 40 KB each: **6,977-byte report, exit 0**, where before it was fatal. The drill case still produces 893 bytes. Both run against a stubbed `gh` that fails the test if `--body` is used instead of `--body-file`.