### PR TITLE
Give every fuzz target its own canary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -253,6 +253,11 @@ canary crashed and was reported, and fails when it did not, because a canary tha
 goes undetected means the alarm is broken. A normal run fails on any crash, as
 you would expect.
 
+The deep run is a matrix and that verdict is decided **per job**, so every target
+needs its own canary. A target without one fails a drill by reporting that the
+alarm is broken — true of that job, misleading about the alarm. Adding a target
+means adding the four-line `canary_armed` check to it.
+
 ## Performance
 
 There is a benchmark gate on every pull request. It builds this revision **and**

--- a/fuzz/fuzz_targets/parse_agreement.rs
+++ b/fuzz/fuzz_targets/parse_agreement.rs
@@ -71,7 +71,27 @@ fn leaf_contents(part: &mail_parser::MimePart, out: &mut Vec<Vec<u8>>) {
     }
 }
 
+/// Panic on purpose when `FMP_FUZZ_CANARY` is set, so this target's own path to
+/// a filed issue can be rehearsed.
+///
+/// Duplicated from `parse_email.rs` on purpose. The canary has to live in every
+/// target, because the deep run is a matrix and its drill verdict is decided per
+/// job: a target without one reports "the canary did not crash, so the alarm is
+/// not working", which is true of that job and misleading about the alarm. That
+/// is exactly what the first drill after the matrix landed did.
+///
+/// Armed through the environment rather than an input: libFuzzer learns the
+/// operands of comparisons against input and would find a magic value, and a
+/// planted input persists in the cached corpus. Both of those happened.
+fn canary_armed() -> bool {
+    std::env::var_os("FMP_FUZZ_CANARY").is_some_and(|value| !value.is_empty())
+}
+
 fuzz_target!(|data: &[u8]| {
+    if canary_armed() {
+        panic!("fuzz canary: this crash is a deliberate test of the reporting path");
+    }
+
     let full = mail_parser::parse_email(data);
     let metadata = mail_parser::parse_email_metadata(data);
 


### PR DESCRIPTION
Found by running a drill after #191, which is the fourth thing the drill mechanism has caught about itself today.

## What happened

The deep run became a matrix in #187, and its drill verdict is decided **per job**. The canary lives in each target's source, and only `parse_email` had one. So a drill produced:

| job | outcome |
|---|---|
| `parse_email (60s)` | green — canary crashed and was reported |
| `parse_agreement (60s)` | **red** — "the canary did not crash, so the alarm is not working" |

Which is true of that job and misleading about the alarm. My matrix change created the gap and my own verdict logic reported it accurately.

## The fix

The four-line `canary_armed` check is duplicated into the second target rather than shared. Both targets already stand alone by design — each `#[path]`-includes the core — and a target that cannot rehearse its own path to a filed issue is a target whose alarm is untested.

Noted in `CONTRIBUTING.md` so adding a third target does not repeat it.

## Tally on this mechanism

Five problems, every one found by running it rather than reading it: bytes planted in a cached corpus (#171), bytes learned by libFuzzer from a `memcmp` (#175), a set-but-empty environment variable (#177), a report too large to pass as an argv string (#191 — which lost 45 real crashers), and now a per-job verdict with a per-target trigger.

Worth stating why that is not simply embarrassing: each fix was correct about the failure it addressed and blind to the next, and none of them was reachable by inspection. The alternative to five iterations was one untested alarm.