### PR TITLE
Report a quoted-printable escape that decoding passed through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     classifying a message on content that was silently mended. Asserted over the
     whole fixture and RFC corpus, so good mail cannot start warning by accident.
   - Kinds emitted today: `charset-fallback`, `address-unparseable`,
-    `date-unparseable`, and `unterminated-header-block` — the last of which is
+    `date-unparseable`, `transfer-decode-lossy`, and `unterminated-header-block`
+    — the last of which is
     #150's repair becoming observable. That message's header block is never
     closed, so the payload is resynced before `mailparse` reads it; the repair is
     what saved the body, and this is what says the repair happened.

--- a/Readme.md
+++ b/Readme.md
@@ -470,6 +470,14 @@ The kinds emitted today:
 | `address-unparseable` | An address header did not parse (mailparse rejects an address with no `@`), so no mailboxes were reported for it. | `to`/`cc`/… empty, or `from_` as `None`, with the raw value still in `headers`. |
 | `date-unparseable` | The `Date` header is not a date any parser here recognises. | `date` as the raw header string; `date_parsed` is `None`. |
 | `unterminated-header-block` | The header block was not closed by an empty line (RFC 5322 2.1), so the separator was restored before parsing — the stdlib calls this `MissingHeaderBodySeparatorDefect`. | The whole message, parts included. Left unrepaired this used to lose a body part silently ([#150](https://github.com/namecheap/fast_mail_parser/issues/150)). |
+| `transfer-decode-lossy` | A quoted-printable part contained an escape that is neither `=` plus two hex digits nor a soft line break, and robust decoding passed it through as literal text instead of failing. | The decoded text with the escape still in it, undecoded — `=ZZ` stays three characters where the sender meant one byte. |
+
+`transfer-decode-lossy` deliberately does **not** report line-ending
+canonicalisation. Robust decoding also turns a bare LF into CRLF, which a strict
+decoder rejects too — but then most mail written with bare LFs would warn, and a
+channel whose empty list means something cannot afford to cry wolf. The case worth
+reporting is the one where the sender's intent is lost, not the one where the
+bytes are merely normalised.
 
 `part_path` is a locator into the returned `PyMail`, not MIME tree coordinates.
 That is deliberate: `parse_email` hands back a flat projection, so a coordinate
@@ -511,6 +519,7 @@ except DecodeError:
 | --- | --- |
 | `charset-fallback` | `DecodeError` |
 | `date-unparseable` | `DecodeError` |
+| `transfer-decode-lossy` | `DecodeError` |
 | `address-unparseable` | `HeaderParseError` |
 | `unterminated-header-block` | `MimeStructureError` |
 

--- a/src/fast_mail_parser.rs
+++ b/src/fast_mail_parser.rs
@@ -123,9 +123,9 @@ fn strict_rejection(warnings: &[ParseWarning]) -> PyErr {
         // as "usually the input is not an email at all", would say the wrong
         // thing about it.
         mail_parser::KIND_UNTERMINATED_HEADERS => MimeStructureError::new_err(message),
-        mail_parser::KIND_CHARSET_FALLBACK | mail_parser::KIND_DATE_UNPARSEABLE => {
-            DecodeError::new_err(message)
-        }
+        mail_parser::KIND_CHARSET_FALLBACK
+        | mail_parser::KIND_DATE_UNPARSEABLE
+        | mail_parser::KIND_TRANSFER_DECODE_LOSSY => DecodeError::new_err(message),
         // A kind added to the core without a row above still fails strict mode,
         // just at the base of the hierarchy. Failing open would break the only
         // promise strict mode makes, which is that nothing lossy gets through.

--- a/src/mail_parser.rs
+++ b/src/mail_parser.rs
@@ -65,6 +65,7 @@ pub(crate) const KIND_CHARSET_FALLBACK: &str = "charset-fallback";
 pub(crate) const KIND_ADDRESS_UNPARSEABLE: &str = "address-unparseable";
 pub(crate) const KIND_DATE_UNPARSEABLE: &str = "date-unparseable";
 pub(crate) const KIND_UNTERMINATED_HEADERS: &str = "unterminated-header-block";
+pub(crate) const KIND_TRANSFER_DECODE_LOSSY: &str = "transfer-decode-lossy";
 
 // Held as a const so the helper that uses it is one short line instead of a
 // chain across a multi-line literal.
@@ -72,6 +73,56 @@ const DETAIL_UNTERMINATED_HEADERS: &str = "the header block was not \
      terminated by an empty line (RFC 5322 2.1); the separator was restored \
      before parsing, so no part was lost -- the stdlib calls this defect \
      MissingHeaderBodySeparatorDefect";
+
+/// Offset of a quoted-printable escape a strict decoder would reject, if any.
+///
+/// mailparse decodes quoted-printable in robust mode, which passes an invalid
+/// escape through as literal text instead of failing. So `=ZZ` survives as three
+/// characters where the sender meant one byte, and the parse reports success --
+/// a lossy repair with no error, which is what this channel exists for (#100).
+///
+/// Only the two valid forms are skipped: `=` with two hex digits, and `=` before
+/// a line ending (a soft break). Everything else, including a trailing `=` with
+/// nothing after it, is what a strict decoder rejects.
+///
+/// Line-ending canonicalisation is deliberately NOT reported. Robust mode also
+/// turns a bare LF into CRLF, which a strict decoder rejects too -- but most mail
+/// written with bare LFs would then warn, and a channel whose empty list means
+/// something cannot afford that (see the note on `Warning`). The bytes-changed
+/// case worth a warning is the one where the sender's intent is lost.
+///
+/// Parts that are not quoted-printable return immediately. `#[inline(never)]` for
+/// the usual reason in this crate: this is called from the per-part loop.
+#[inline(never)]
+fn quoted_printable_invalid_escape(part: &ParsedMail<'_>) -> Option<usize> {
+    let Body::QuotedPrintable(body) = part.get_body_encoded() else {
+        return None;
+    };
+
+    let raw = body.get_raw();
+    let mut at = 0;
+
+    while at < raw.len() {
+        if raw[at] != b'=' {
+            at += 1;
+            continue;
+        }
+
+        let rest = &raw[at + 1..];
+        if rest.starts_with(b"\r\n") || rest.starts_with(b"\n") {
+            at += 2;
+            continue;
+        }
+        if rest.len() >= 2 && rest[0].is_ascii_hexdigit() && rest[1].is_ascii_hexdigit() {
+            at += 3;
+            continue;
+        }
+
+        return Some(at);
+    }
+
+    None
+}
 
 /// One lossy repair the parser performed, recorded instead of raised (#100).
 ///
@@ -138,6 +189,20 @@ fn warn_separator(warnings: &mut Vec<Warning>) {
         detail: DETAIL_UNTERMINATED_HEADERS.to_owned(),
     };
     warnings.insert(0, warning);
+}
+
+#[cold]
+#[inline(never)]
+fn warn_transfer_decode(warnings: &mut Vec<Warning>, field: &str, index: usize, at: usize) {
+    warnings.push(Warning {
+        kind: KIND_TRANSFER_DECODE_LOSSY,
+        part_path: format!("{field}[{index}]"),
+        detail: format!(
+            "the quoted-printable escape at byte {at} of the encoded body is \
+             neither `=` followed by two hex digits nor a soft line break; it \
+             was passed through as literal text rather than decoded"
+        ),
+    });
 }
 
 #[cold]
@@ -903,7 +968,15 @@ impl<'a> Mail {
             // Python as `ParseError`.
             let content = part.get_body_raw()?;
 
+            // Checked once per part, reported below with the index the part
+            // actually lands at, so `part_path` locates it in the result.
+            let lossy_escape = quoted_printable_invalid_escape(&part);
+
             if !is_body {
+                if let Some(at) = lossy_escape {
+                    warn_transfer_decode(&mut warnings, "attachments", attachments.len(), at);
+                }
+
                 let content_id = part
                     .get_headers()
                     .get_first_value("Content-ID")
@@ -927,6 +1000,9 @@ impl<'a> Mail {
                     let index = text_html.len();
                     warn_charset(&mut warnings, "text_html", index, &part.ctype.charset);
                 }
+                if let Some(at) = lossy_escape {
+                    warn_transfer_decode(&mut warnings, "text_html", text_html.len(), at);
+                }
                 text_html.push(text);
             } else {
                 // Only `text/plain` reaches here: `is_body` is false for every
@@ -935,6 +1011,9 @@ impl<'a> Mail {
                 if fell_back {
                     let index = text_plain.len();
                     warn_charset(&mut warnings, "text_plain", index, &part.ctype.charset);
+                }
+                if let Some(at) = lossy_escape {
+                    warn_transfer_decode(&mut warnings, "text_plain", text_plain.len(), at);
                 }
                 text_plain.push(text);
             }

--- a/tests/test_parse_warnings.py
+++ b/tests/test_parse_warnings.py
@@ -523,3 +523,94 @@ def test__full_mode_accepts_strict_alongside_an_explicit_mode():
 
     with pytest.raises(DecodeError):
         parse_email(BAD_DATE, mode="full", strict=True)
+
+
+# --- transfer-decode-lossy -----------------------------------------------------
+#
+# mailparse decodes quoted-printable in robust mode, which passes an invalid
+# escape through as literal text rather than failing. So the parse succeeds and
+# the sender's intent is silently lost, which is the shape this channel is for.
+
+
+def _quoted_printable(body: bytes, content_type: bytes = b"text/plain") -> bytes:
+    return (
+        b"Subject: qp\r\n"
+        b"Content-Type: " + content_type + b"; charset=utf-8\r\n"
+        b"Content-Transfer-Encoding: quoted-printable\r\n"
+        b"\r\n" + body
+    )
+
+
+def test__an_invalid_quoted_printable_escape_is_reported():
+    # `=ZZ` is not a hex escape and not a soft line break, so a strict decoder
+    # rejects it and robust decoding keeps it as three literal characters.
+    mail = parse_email(_quoted_printable(b"before =ZZ after\r\n"))
+
+    kinds = [w.kind for w in mail.warnings]
+    assert kinds == ["transfer-decode-lossy"], kinds
+    assert mail.warnings[0].part_path == "text_plain[0]"
+    assert "hex digits" in mail.warnings[0].detail
+
+
+def test__the_invalid_escape_survives_in_the_content():
+    # The best-effort content is asserted alongside the warning: the escape is
+    # still there, undecoded, which is exactly the loss being reported.
+    mail = parse_email(_quoted_printable(b"before =ZZ after\r\n"))
+
+    assert "=ZZ" in mail.text_plain[0]
+
+
+def test__valid_escapes_and_soft_breaks_are_not_a_repair():
+    # `=3D` is a hex escape, `=\r\n` is a soft line break. Neither is lossy, and
+    # a channel whose empty list means something cannot cry wolf on ordinary mail.
+    mail = parse_email(_quoted_printable(b"a=3Db and a soft=\r\n break\r\n"))
+
+    assert mail.warnings == []
+    assert "a=b" in mail.text_plain[0]
+
+
+def test__a_bare_lf_body_is_not_reported_as_lossy():
+    # Robust mode also turns a bare LF into CRLF, which a strict decoder rejects
+    # too -- but reporting that would warn on most mail written with bare LFs.
+    # Deliberately out of scope; see the note on the scanner.
+    mail = parse_email(_quoted_printable(b"one\ntwo\nthree\n"))
+
+    assert mail.warnings == []
+
+
+def test__an_invalid_escape_in_an_attachment_names_the_attachment():
+    message = (
+        b"Subject: qp attachment\r\n"
+        b'Content-Type: application/octet-stream; name="x.bin"\r\n'
+        b"Content-Disposition: attachment\r\n"
+        b"Content-Transfer-Encoding: quoted-printable\r\n"
+        b"\r\n"
+        b"=ZZ\r\n"
+    )
+
+    mail = parse_email(message)
+
+    assert [w.kind for w in mail.warnings] == ["transfer-decode-lossy"]
+    assert mail.warnings[0].part_path == "attachments[0]"
+
+
+def test__strict_mode_rejects_an_invalid_escape():
+    with pytest.raises(DecodeError):
+        parse_email(_quoted_printable(b"before =ZZ after\r\n"), strict=True)
+
+
+def test__base64_is_not_scanned_for_quoted_printable_escapes():
+    # An `=` in base64 is padding, not an escape. Scanning it would report every
+    # padded attachment in existence.
+    message = (
+        b"Subject: b64\r\n"
+        b"Content-Type: text/plain; charset=utf-8\r\n"
+        b"Content-Transfer-Encoding: base64\r\n"
+        b"\r\n"
+        b"aGVsbG8=\r\n"
+    )
+
+    mail = parse_email(message)
+
+    assert mail.warnings == []
+    assert mail.text_plain == ["hello"]


### PR DESCRIPTION
Closes the last gap in #100's criteria. #188 shipped three of the four lossy paths that issue lists; this is the fourth.

## Why it was left, and why it matters

mailparse decodes quoted-printable in **robust** mode, which passes an invalid escape through as literal text rather than failing. So `=ZZ` survives as three characters where the sender meant one byte, the parse reports success, and nothing says anything — the same silent-loss shape as #150, which is what this channel exists for.

Base64 does not have this problem: a broken base64 body already raises `DecodeError`.

## Detection

Scan the **still-encoded** body for escapes a strict decoder would reject: anything that is neither `=` plus two hex digits nor a soft line break (`=` before the line ending), including a trailing `=` with nothing after it.

Only quoted-printable parts are scanned, so base64 padding is never mistaken for an escape — there is a test for that, since `=` in base64 is ubiquitous.

## What it deliberately does not report

**Line-ending canonicalisation.** Robust mode also turns a bare LF into CRLF, which a strict decoder rejects too — that is the same behaviour that produced 45 fuzz crashers in #190. But reporting it would warn on most mail written with bare LFs, and a channel whose empty list *is* its contract cannot cry wolf. The case worth a warning is where the sender's intent is lost, not where bytes are normalised.

## Checked before writing it

The corpus has **five** quoted-printable parts and none carries an invalid escape, so nothing that passes today starts warning — #100's "no warning inflation on good mail" criterion stays satisfied. I measured that first rather than adding the feature and hoping.

## Codegen

The scanner and the warning helper are both `#[inline(never)]`, the helper also `#[cold]`, matching the convention #188 established. The scanner is called once per part from the hot loop, so the gate's verdict on this is the thing to read — three changes today cost 25–95% from less than this.