### PR TITLE
Install the sdist from source in CI

### DIFF
--- a/.github/scripts/sdist_smoke.py
+++ b/.github/scripts/sdist_smoke.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Smoke-test a source install of fast_mail_parser.
+
+Run against a venv that installed the sdist, so the extension was compiled here
+rather than downloaded. The point is not coverage -- the full suite runs against
+the wheel -- but that every entry point the package advertises exists and works
+in a build nobody else exercises.
+"""
+import sys
+
+import fast_mail_parser
+from fast_mail_parser import (
+    ParseError,
+    parse_email,
+    parse_email_tree,
+    parse_many,
+    walk,
+)
+
+MESSAGE = (
+    b"From: sender@example.com\r\n"
+    b"To: recipient@example.com\r\n"
+    b"Subject: sdist smoke\r\n"
+    b'Content-Type: multipart/alternative; boundary="bnd"\r\n'
+    b"\r\n"
+    b"--bnd\r\n"
+    b"Content-Type: text/plain\r\n"
+    b"\r\n"
+    b"plain body\r\n"
+    b"--bnd\r\n"
+    b"Content-Type: text/html\r\n"
+    b"\r\n"
+    b"<p>html body</p>\r\n"
+    b"--bnd--\r\n"
+)
+
+
+def check(label: str, condition: bool) -> None:
+    print(f"{'ok  ' if condition else 'FAIL'} {label}")
+    if not condition:
+        sys.exit(f"source install failed: {label}")
+
+
+mail = parse_email(MESSAGE)
+check("parse_email subject", mail.subject == "sdist smoke")
+check("parse_email bodies", mail.text_plain == ["plain body"])
+check("headers keep wire order", list(mail.headers)[0] == "From")
+check("addresses parsed", mail.from_.address == "sender@example.com")
+check("warnings channel present and empty", mail.warnings == [])
+
+meta = parse_email(MESSAGE, mode="metadata")
+check("metadata mode agrees on subject", meta.subject == mail.subject)
+check("metadata mode has no bodies", not hasattr(meta, "text_plain"))
+
+root = parse_email_tree(MESSAGE)
+types = [part.content_type for part in walk(root)]
+check(
+    "tree topology",
+    types == ["multipart/alternative", "text/plain", "text/html"],
+)
+
+batch = parse_many([MESSAGE, MESSAGE])
+check("parse_many returns both", len(batch) == 2)
+
+try:
+    parse_email(b" unexpected continuation\r\n\r\nbody")
+except ParseError:
+    check("errors raise ParseError", True)
+else:
+    check("errors raise ParseError", False)
+
+check("py.typed shipped", (
+    __import__("pathlib").Path(fast_mail_parser.__file__).parent / "py.typed"
+).exists())
+
+print(f"\nsource install verified: {len(fast_mail_parser.__all__)} exports")

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -481,3 +481,71 @@ jobs:
             head-[0-9].json
             base-[0-9].json
           if-no-files-found: warn
+
+  # ---------------------------------------------------------------------------
+  # The sdist is built and published on every release and has never been
+  # installed by anything. That is the gap #15 was: a release nobody could
+  # install. It is also the documented fallback for x86_64 macOS and for every
+  # platform outside the wheel matrix, so a source build that does not work is a
+  # release that silently excludes those users.
+  #
+  # This builds the sdist through the same PEP 517 backend a user gets, installs
+  # it into a clean venv -- which compiles the extension from source, the thing
+  # no other job does -- and then exercises the API.
+  # ---------------------------------------------------------------------------
+  sdist:
+    name: sdist installs from source
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: 1.97.1
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+
+      - name: Build the sdist
+        run: |
+          python -m pip install -q --upgrade pip build
+          python -m build --sdist --outdir dist
+          ls -l dist
+
+      - name: Check it carries what a source build needs
+        run: |
+          sdist=$(ls dist/*.tar.gz)
+          echo "contents:"
+          tar -tzf "$sdist" | sed 's|^[^/]*/||' | sort | head -30
+
+          # Asserted rather than assumed: `pyproject.toml` decides what goes in
+          # via `sdist-include`, and a build that happens to work from a warm
+          # cache would hide a missing file until someone else's cold build.
+          for needed in Cargo.toml pyproject.toml src/mail_parser.rs \
+                        src/fast_mail_parser.rs; do
+            if ! tar -tzf "$sdist" | grep -q "/${needed}$"; then
+              echo "::error::the sdist is missing ${needed}"
+              exit 1
+            fi
+          done
+
+          # And the fuzz crate must stay out: it is excluded on purpose, and
+          # shipping it would put a second Cargo manifest in the tarball.
+          if tar -tzf "$sdist" | grep -q '/fuzz/'; then
+            echo "::error::the sdist contains the fuzz crate, which is excluded"
+            exit 1
+          fi
+          echo "sdist contents check passed"
+
+      - name: Install it from source
+        run: |
+          python -m venv "$RUNNER_TEMP/venv-sdist"
+          "$RUNNER_TEMP/venv-sdist/bin/pip" install -q --upgrade pip
+          # No wheel exists for this version yet, so this compiles -- which is
+          # the whole point of the job.
+          "$RUNNER_TEMP/venv-sdist/bin/pip" install -q "$(ls dist/*.tar.gz)"
+
+      - name: Exercise the API it installed
+        run: |
+          "$RUNNER_TEMP/venv-sdist/bin/python" .github/scripts/sdist_smoke.py


### PR DESCRIPTION
Closes a gap I went looking for after the 14-platform dry run passed: **the sdist is built and published on every release, and nothing has ever installed it.**

That gap is precisely what #15 was — a release nobody could install. And `publish.yml` itself documents the sdist as the fallback for **x86_64 macOS** and for every platform outside the wheel matrix, so a source build that does not work is a release that silently excludes those users.

## Why no existing job covers it

`Build abi3 wheel` builds one wheel; all four Test jobs install *that same artifact*. So nothing in CI compiles the extension the way a user without a matching wheel does. A packaging mistake — a file missing from `sdist-include`, the `fuzz/**` exclusion drifting — would reach PyPI unnoticed and fail on someone else's machine.

## What the job does

- builds the sdist through the same PEP 517 backend a user gets
- **asserts the tarball's contents**: `Cargo.toml`, `pyproject.toml`, both Rust sources present; the fuzz crate absent. Asserted rather than assumed, because a build from a warm cache can succeed while the tarball is incomplete — and that failure belongs to whoever installs it next, not to us
- installs it into a clean venv, which **compiles from source**
- exercises every entry point the package advertises: both parse modes, the tree, `walk`, `parse_many`, the warnings channel, error raising, and that `py.typed` ships

## Context

The 14-platform publish dry run on this same commit came back **15/15 green**, so the wheel matrix is fine with everything merged today. This covers the one artifact that matrix produces and never tests.

Note for anyone counting: PR checks go from 14 to 15.