### PR TITLE
Publish as fast-mail-parser again, and cut 0.8.0

### DIFF
--- a/.github/scripts/bench_table.py
+++ b/.github/scripts/bench_table.py
@@ -75,7 +75,7 @@ def main() -> int:
         f"CPython {machine.get('python_version', platform.python_version())} "
         f"on {machine.get('system', platform.system())} "
         f"{machine.get('machine', platform.machine())}. "
-        f"fast-mail-parser-ng {_version('fast-mail-parser-ng')}, "
+        f"fast-mail-parser {_version('fast-mail-parser')}, "
         f"mail-parser {_version('mail-parser')}. "
         f"Minimum of {report['benchmarks'][0]['stats']['rounds']}+ rounds."
     )

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -196,15 +196,21 @@ jobs:
       # silently IGNORED if an explicit username/password is set, so do NOT add
       # `user`/`password` here.
       #
-      # The distribution is `fast-mail-parser-ng` (the import path stays
+      # The distribution is `fast-mail-parser` (the import path is the same,
       # `fast_mail_parser`; see [tool.maturin] module-name in pyproject.toml).
+      #
+      # It was `fast-mail-parser-ng` for 0.6.0-0.7.0, while the original name was
+      # owned elsewhere. Ownership has since been transferred, so releases go back
+      # to the original name -- which means PyPI needs a Trusted Publisher for
+      # THAT project before the first upload under it, or this step 403s.
       # Requires a one-time PyPI setup — add a Trusted Publisher for
       # namecheap/fast_mail_parser, workflow "publish.yml", environment blank:
       #
-      #   before the project exists (pending publisher, creates it on first
-      #   upload):  https://pypi.org/manage/account/publishing/
-      #   afterwards:
-      #     https://pypi.org/manage/project/fast-mail-parser-ng/settings/publishing/
+      #     https://pypi.org/manage/project/fast-mail-parser/settings/publishing/
+      #
+      # A pending publisher (https://pypi.org/manage/account/publishing/) is only
+      # for a project that does not exist yet; `fast-mail-parser` does, so the
+      # per-project page above is the one to use.
       #
       # The `environment:` field there must match this job exactly — this job
       # declares none, so leave it blank.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-08-27
+
+### Changed
+
+- **The distribution is published as `fast-mail-parser` again.** `pip install
+  fast-mail-parser`. Releases 0.6.0–0.7.0 went out as `fast-mail-parser-ng`
+  because the original name belonged to an account this project no longer
+  controlled and was frozen at 0.2.5 from June 2022; ownership has since been
+  transferred directly, so the PEP 541 request was withdrawn.
+  - **The import path is unchanged**, as it has been throughout:
+    `from fast_mail_parser import parse_email`.
+  - On `fast-mail-parser-ng`? Change the name in your requirements file and
+    nothing else. That project stays on PyPI so nothing pinning it breaks, but it
+    receives no further releases.
+
 ### Added
 
 - **`PyMail.warnings`** reports the lossy repairs a parse performed, and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "fast_mail_parser"
 description = "Very fast Python library for .eml files parsing."
 edition = "2021"
 rust-version = "1.83"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Andrii Sokyrko <wartwvister@gmail.com>"]
 readme = "Readme.md"
 # Both fields: `license` is the SPDX expression tooling reads (cargo-deny warns

--- a/Readme.md
+++ b/Readme.md
@@ -1,34 +1,34 @@
 # fast_mail_parser
 
 ![Test](https://github.com/namecheap/fast_mail_parser/workflows/Test/badge.svg)
-[![PyPI version](https://badge.fury.io/py/fast-mail-parser-ng.svg)](https://badge.fury.io/py/fast-mail-parser-ng)
-[![Downloads](https://pepy.tech/badge/fast-mail-parser-ng)](https://pepy.tech/project/fast-mail-parser-ng)
+[![PyPI version](https://badge.fury.io/py/fast-mail-parser.svg)](https://badge.fury.io/py/fast-mail-parser)
+[![Downloads](https://pepy.tech/badge/fast-mail-parser)](https://pepy.tech/project/fast-mail-parser)
 
-> ## 📦 Now published as `fast-mail-parser-ng`
->
-> **Install it under the new name:**
+> ## 📦 Back on `fast-mail-parser`
 >
 > ```bash
-> pip install fast-mail-parser-ng
+> pip install fast-mail-parser
 > ```
 >
-> **Your code does not change.** The import path is still `fast_mail_parser`:
+> **On `fast-mail-parser-ng`?** That name carried releases 0.6.0–0.7.0 while the
+> original was owned elsewhere. Ownership has since been transferred, so releases
+> are published under the original name again. Change the name in your
+> requirements file and nothing else — no code edits, same API:
+>
+> ```diff
+> - fast-mail-parser-ng
+> + fast-mail-parser
+> ```
+>
+> **Your code does not change either way.** The import path has always been
+> `fast_mail_parser`:
 >
 > ```python
 > from fast_mail_parser import parse_email
 > ```
 >
-> Migrating from `fast-mail-parser`? Change the name in your requirements file
-> and nothing else — no code edits, same API.
->
-> ```diff
-> - fast-mail-parser
-> + fast-mail-parser-ng
-> ```
->
-> Looking for the old `fast-mail-parser` package? It is a different,
-> unmaintained upload frozen at 0.2.5 (June 2022) that this project cannot
-> publish to. See [Why the name changed](#why-the-name-changed).
+> `fast-mail-parser-ng` stays on PyPI so nothing installing it breaks, but new
+> releases go to `fast-mail-parser`. See [The name](#the-name).
 
 A very fast Python library for parsing `.eml` files. It is built on the Rust
 [mailparse](https://github.com/staktrace/mailparse) crate via
@@ -39,7 +39,7 @@ pure-Python implementations, depending on the CPU — see
 ## Quickstart
 
 ```bash
-pip install fast-mail-parser-ng
+pip install fast-mail-parser
 ```
 
 ```python
@@ -61,20 +61,24 @@ executed in CI, so they cannot go stale — and
 [compatibility.md](https://github.com/namecheap/fast_mail_parser/blob/master/docs/compatibility.md) for every known
 difference from the stdlib, each one enforced by a test.
 
-## Why the name changed
+## The name
 
-The `fast-mail-parser` name on PyPI belongs to a PyPI account this project no
-longer controls, and it is frozen at an unmaintained **0.2.5 from June 2022**.
-Only a project owner can publish to a name, so fixes could not reach it — the
-PEP 541 transfer request
-([pypi/support#11044](https://github.com/pypi/support/issues/11044)) has been
-open and unattended since June 2026.
+Releases are published as **`fast-mail-parser`**, and the import path is
+`fast_mail_parser`.
 
-Rather than hold releases behind that queue indefinitely, this project publishes
-under a name it owns. The import path was deliberately left as
-`fast_mail_parser` so the change costs you one line in a requirements file and
-no code. If the transfer is ever granted, `fast-mail-parser` will resume as an
-alias.
+There was an interruption worth explaining, because two names exist on PyPI. The
+`fast-mail-parser` project belonged to an account this project no longer
+controlled and was frozen at an unmaintained **0.2.5 from June 2022**; only a
+project owner can publish to a name, so fixes could not reach it. A PEP 541
+transfer request sat unattended for months. Rather than hold releases behind that
+queue, 0.6.0 through 0.7.0 shipped as `fast-mail-parser-ng`, with the import path
+deliberately unchanged so the switch cost one line in a requirements file.
+
+Ownership has since been transferred directly, so releases go back to the
+original name from 0.8.0 on. `fast-mail-parser-ng` is left in place — the
+releases published under it keep working, and nothing pinning it breaks — but it
+receives no new versions. If you are on it, change the name in your requirements
+file; there is nothing else to do.
 
 Full history in the [changelog](https://github.com/namecheap/fast_mail_parser/blob/master/CHANGELOG.md).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "fast-mail-parser-ng"
+name = "fast-mail-parser"
 dynamic = ["version"]
 description = "Very fast Python library for .eml files parsing."
 authors = [{ name = "Andrii Sokyrko", email = "wartwvister@gmail.com" }]


### PR DESCRIPTION
Ownership of the original PyPI name has been transferred, so releases go back to it. The PEP 541 request that was waiting on this ([pypi/support#11044](https://github.com/pypi/support/issues/11044)) is withdrawn and closed.

## What changes

- `pyproject.toml`: distribution name → **`fast-mail-parser`**
- version → **0.8.0**, CHANGELOG cut with the rename recorded at the top
- PyPI badges, and the README's banner and name section rewritten in the other direction — including that `fast-mail-parser-ng` stays on PyPI and keeps working, rather than pretending the detour did not happen
- `bench_table.py`'s runtime version lookup, which resolves the **distribution** by name and would have raised `PackageNotFoundError` under the new one
- the publish workflow's Trusted Publisher notes

**The import path is untouched**, as it has been throughout — which was the whole point of changing the distribution name rather than the module name, and is why this costs a reader one line in a requirements file.

## ⚠️ One thing I cannot do, and it blocks the upload

PyPI needs a **Trusted Publisher registered for the `fast-mail-parser` project** before the first upload under that name, or the publish step fails with 403. Only a project owner can add it:

**https://pypi.org/manage/project/fast-mail-parser/settings/publishing/**

- Owner: `namecheap`
- Repository: `fast_mail_parser`
- Workflow: `publish.yml`
- Environment: **blank** (the publish job declares none, and the field must match exactly)

A *pending* publisher is only for a project that does not exist yet; `fast-mail-parser` does exist, so it has to be the per-project page above.

I will not create the release until that is confirmed — a release event triggers the real upload, and a 403 there leaves a published GitHub release with nothing on PyPI behind it.

## Release readiness

The 14-platform publish dry run on this content came back **15/15 green**, and CI now installs the sdist from source (#195), so both artifacts the release produces are exercised.