### PR TITLE
Say that the old distribution name is archived, not merely quiet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **The import path is unchanged**, as it has been throughout:
     `from fast_mail_parser import parse_email`.
   - On `fast-mail-parser-ng`? Change the name in your requirements file and
-    nothing else. That project stays on PyPI so nothing pinning it breaks, but it
-    receives no further releases.
+    nothing else. That project is archived on PyPI -- read-only, no further
+    releases -- and the three versions published under it stay installable, so
+    nothing pinning them breaks.
 
 ### Added
 

--- a/Readme.md
+++ b/Readme.md
@@ -27,8 +27,9 @@
 > from fast_mail_parser import parse_email
 > ```
 >
-> `fast-mail-parser-ng` stays on PyPI so nothing installing it breaks, but new
-> releases go to `fast-mail-parser`. See [The name](#the-name).
+> `fast-mail-parser-ng` is archived on PyPI: the versions published under it stay
+> installable, so nothing pinning them breaks, but it takes no further releases.
+> See [The name](#the-name).
 
 A very fast Python library for parsing `.eml` files. It is built on the Rust
 [mailparse](https://github.com/staktrace/mailparse) crate via
@@ -75,10 +76,11 @@ queue, 0.6.0 through 0.7.0 shipped as `fast-mail-parser-ng`, with the import pat
 deliberately unchanged so the switch cost one line in a requirements file.
 
 Ownership has since been transferred directly, so releases go back to the
-original name from 0.8.0 on. `fast-mail-parser-ng` is left in place — the
-releases published under it keep working, and nothing pinning it breaks — but it
-receives no new versions. If you are on it, change the name in your requirements
-file; there is nothing else to do.
+original name from 0.8.0 on, and `fast-mail-parser-ng` is **archived** on PyPI:
+read-only, taking no further releases. The three versions published under it stay
+installable, so nothing pinning them breaks — archiving marks the project as
+finished rather than removing anything. If you are on it, change the name in your
+requirements file; there is nothing else to do.
 
 Full history in the [changelog](https://github.com/namecheap/fast_mail_parser/blob/master/CHANGELOG.md).
 


### PR DESCRIPTION
Documentation only, to match the decision to **archive** `fast-mail-parser-ng` on PyPI now that releases have moved back to `fast-mail-parser` (#197, v0.8.0).

"Stays on PyPI but receives no new releases" understated it. Archived means **read-only**, which is a stronger and more useful promise to someone deciding whether to migrate.

What does not change is that the three versions published under that name stay installable — archiving marks a project finished, it removes nothing, so anything pinning them keeps working. Said explicitly in both the banner and the name section, because "archived" reads like "deleted" to a lot of people.

The archiving itself is owner-only in PyPI's UI (Manage project → Settings → Archive project); this PR only makes the docs match it.