### PR TITLE
Compare against master as it is now, not as it was

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -338,13 +338,21 @@ jobs:
         env:
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          if [ -n "$PR_BASE_SHA" ]; then
-            base="$PR_BASE_SHA"
-          else
-            # workflow_dispatch: compare against the default branch. Falling
-            # back to HEAD (which disables the comparison below) is better than
-            # failing the job if the ref is unavailable.
-            base="$(git rev-parse origin/master 2>/dev/null || git rev-parse HEAD)"
+          # On a pull request the checkout is the MERGE ref: this branch already
+          # merged into the base branch as it is *now*. So the honest comparison
+          # is against the base branch as it is now, and not against
+          # `pull_request.base.sha`, which is the base as of the PR's last event
+          # and can lag behind it.
+          #
+          # Using the stale value attributes everything master did in between to
+          # the pull request. That is not hypothetical: #198 was reported at
+          # +15.2% on every decoding benchmark for a build that was byte-identical
+          # to one measuring +0.2% -- a 0.8.0 merge ref against a 0.7.0 base. It
+          # also means a release commit's own effect gets billed to whichever PR
+          # is open at the time instead of to the release.
+          base="$(git rev-parse origin/master 2>/dev/null || git rev-parse HEAD)"
+          if [ -n "$PR_BASE_SHA" ] && [ "$PR_BASE_SHA" != "$base" ]; then
+            echo "::notice::recorded base ${PR_BASE_SHA:0:8} is behind origin/master ${base:0:8}; comparing against origin/master, which is what merging this actually changes"
           fi
           echo "sha=$base" >> "$GITHUB_OUTPUT"
           if [ "$base" = "$(git rev-parse HEAD)" ]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -266,6 +266,12 @@ medians, failing on more than a 7% regression. The pure-Python benchmarks ride
 along as a noise floor: they cannot be affected by how the Rust extension was
 built, so a result is only believed once it clears them.
 
+The base it compares against is the base branch **as it is now**, not the commit
+recorded when the pull request was opened. A pull request is checked out as its
+merge ref, so a stale base would attribute everything master did in the meantime
+to the branch -- which is how #198 came to be reported at +15.2% for a build
+byte-identical to one measuring +0.2%.
+
 The interleaving is not ceremony. Pairing each build with its own measurement --
 which this gate used to do -- leaves a ~16% artifact from the build cycle itself,
 more than twice the threshold it is judging against. A toolchain comparison built


### PR DESCRIPTION
A flaw in the gate I added in #168, surfaced by #198's author having to prove their own change innocent.

## What was wrong

A pull request is checked out as its **merge ref** — the branch already merged into the base branch as it stands. The gate compared that against `pull_request.base.sha`, which is the base as of the PR's last event and can lag behind. So everything master did in the meantime was billed to the branch.

#198 was reported at **+15.2%** on every decoding benchmark for a build that was **byte-identical** to one measuring +0.2% — a 0.8.0 merge ref against a 0.7.0 base. Its author diagnosed it by comparing `.so` hashes, which is not a reasonable thing for a gate to require of someone.

## The part that matters more

It cuts the other way too. A release commit's own effect gets billed to whichever pull request is open rather than to the release.

**#197 — the 0.8.0 release cut — measured +3.8% to +4.4%** on every decoding benchmark (`parse_message`, `full_read`, `parse_tree`, `parse_many`, `parse_message_strict`), with `parse_metadata` at −0.0% and controls under 1.8%. Above its noise floor, under the 7% threshold, and **I merged it having read only "no failures"**. That is on me: the gate reported honestly and I did not look at what it said.

So 0.8.0 as published is a few percent slower on the decode path than 0.7.0, from a commit whose only Rust-affecting content was a version string. Consistent with everything else this crate has done today, and worth its own investigation rather than being buried in a diff.

## The fix

Resolve the base as **current `origin/master`**, which is what merging the branch actually changes. Emit a notice when the recorded base disagrees, so the lag is visible rather than silent. Documented in `CONTRIBUTING.md`, since it is now a property of the gate a contributor should be able to rely on.