### PR TITLE
Stop telling readers a warning kind does not exist

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -614,11 +614,16 @@ is worse than one that is unavailable. Metadata mode has no `warnings` attribute
 for the same reason — the same reasoning that leaves `text_plain` absent from it
 rather than empty.
 
-**What is not reported.** A broken quoted-printable body is repaired silently by
-the decoder rather than reported by it — mailparse decodes quoted-printable in
-its robust mode — so there is nothing this crate can observe without decoding
-twice. That is why there is no `transfer-decode-lossy` kind, and why the honest
-place to say so is here rather than in a list a reader would take as complete.
+**What is not reported.** Robust quoted-printable decoding also canonicalises
+line endings, turning a bare LF into CRLF. A strict decoder rejects that too, but
+reporting it would warn on most mail written with bare LFs, and a channel whose
+empty list is its whole contract cannot cry wolf. `transfer-decode-lossy` covers
+the case where the sender's intent is lost — an escape that is neither `=` plus
+two hex digits nor a soft line break — not the case where bytes are merely
+normalised.
+
+Nothing else is knowingly unreported. If you find a lossy repair with no warning,
+that is a bug worth filing: the empty list is only useful if it is exact.
 
 ### Bodies vs. attachments
 


### PR DESCRIPTION
The README's "what is not reported" paragraph said there is **no `transfer-decode-lossy` kind**. #194 added it, and the table forty lines above lists it — so the document contradicted itself, and the half a reader is more likely to trust is the prose.

That paragraph was written when the gap was real, and I added the kind without going back to it. My leftover, found by the agent implementing #97 while reading the section it had to extend.

Replaced with what is genuinely unreported: robust decoding canonicalises line endings (bare LF → CRLF), which a strict decoder rejects too, but reporting it would warn on most mail written with bare LFs — the same behaviour that produced 45 fuzz crashers in #190.

It now also says plainly that nothing else is knowingly unreported, and that a lossy repair with no warning is a bug worth filing. The empty list is only worth having if it is exact, and a reader should know which of those two things the project is claiming.