### PR TITLE
PROBE (do not merge): what did the version bump cost?

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "fast_mail_parser"
 description = "Very fast Python library for .eml files parsing."
 edition = "2021"
 rust-version = "1.83"
-version = "0.8.0"
+version = "0.7.0"
 authors = ["Andrii Sokyrko <wartwvister@gmail.com>"]
 readme = "Readme.md"
 # Both fields: `license` is the SPDX expression tooling reads (cargo-deny warns


### PR DESCRIPTION
Diagnostic only — **draft, not for merge** (merging would un-release 0.8.0).

#197 cut the release. Its only Rust-affecting content was `Cargo.toml`'s version string, and its gate measured **+3.8% to +4.4%** on every decoding benchmark — above its noise floor, under the 7% threshold — and I merged it having read only "no failures".

This branch reverts **only** the version, against current master. Now that the gate resolves its base as `origin/master` (#200), the delta it reports is exactly what that string is worth:

- **near −4%** → the release cut really did cost that, and 0.8.0 as published is a few percent slower than 0.7.0 by codegen accident. Worth documenting, and worth knowing this crate is that sensitive to a metadata change.
- **near 0%** → #197's run was noise sitting above its own floor, and the published release is fine. Also worth knowing, because I have been treating that gate's numbers as authoritative all day.

Either way the answer goes on the issue and the branch is closed.