### PR TITLE
Record that a version bump alone moves the decode path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -297,6 +297,18 @@ Both `lto = "fat"` and `codegen-units = 1` are already set, so a codegen-unit
 boundary is never the explanation -- worth knowing, since it is the natural first
 guess.
 
+**A version bump alone moves the decode path ~3.5%.** Measured both directions
+(#204): nothing in the crate reads `CARGO_PKG_VERSION`, but the version reaches
+the compiler as crate metadata, which feeds symbol naming and therefore layout.
+So the gate on a release-cut PR will report a few percent either way, above the
+noise floor, and that is the version string rather than the change. `parse_metadata`
+is the tell -- it never decodes, so it stays flat while everything else moves.
+
+This also bounds what the 7% threshold can police: a change that genuinely costs
+3% is not distinguishable from one that merely moved the version. If you need to
+know which you have, revert the version on a throwaway branch and let the gate
+measure that alone.
+
 ## Linting
 
 The following checks are run in CI. Run them locally before opening a PR:


### PR DESCRIPTION
Documentation for the finding measured in #204.

Reverting **only** the version string makes the decode path **3.2–3.9% faster**; the release cut that introduced it measured **+3.8–4.4%**. Same effect from both sides. Nothing in the crate reads `CARGO_PKG_VERSION` — the version reaches the compiler as crate metadata, which feeds symbol naming and therefore layout, and with fat LTO and one codegen unit that layout is decided across the whole graph at once.

Worth writing into the contributor guide because it changes how a gate reading should be interpreted: a release-cut PR shows a few percent above the noise floor, and that is the version string rather than the change. I merged the 0.8.0 cut having read only "no failures", and so shipped ~3.5% without noticing.

Two things a contributor can use:

- **`parse_metadata` is the tell.** It never decodes, so it stays flat while everything else moves — which is how to distinguish this effect from a real regression.
- **The honest bound**: a change that genuinely costs 3% cannot be distinguished from one that merely moved the version. That is what the 7% threshold is really policing, and pretending otherwise would make the gate look more precise than it is.