### PR TITLE
PROBE (do not merge): is the version effect a lottery?

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "fast_mail_parser"
 description = "Very fast Python library for .eml files parsing."
 edition = "2021"
 rust-version = "1.83"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Andrii Sokyrko <wartwvister@gmail.com>"]
 readme = "Readme.md"
 # Both fields: `license` is the SPDX expression tooling reads (cargo-deny warns


### PR DESCRIPTION
Diagnostic only — **draft, not for merge**. Follows #204.

#204 established that reverting 0.8.0's version string to 0.7.0 makes the decode path **3.2–3.9% faster**, with `parse_metadata` flat and controls under 0.1%. What it could not say is whether the effect is *arbitrary per version* or *monotonic in it*.

This bumps to **0.8.1** against master's 0.8.0, changing nothing else:

- **near −3.5%** → per-version lottery; 0.8.0 drew badly, and a patch release would recover it for free
- **near 0%** → 0.8.0 and 0.8.1 land alike, so recovery needs an actual layout lever rather than a version
- **near +3.5%** → something stranger, and worth more digging than a probe

Either way it goes on #204 and the branch is closed. Reading `parse_metadata` alongside is the control here: it never decodes, so it should stay flat whatever the decoding benchmarks do.