### PR TITLE
Report the CPU, and say that a large failure needs re-running

### DIFF
--- a/.github/scripts/ab_median.py
+++ b/.github/scripts/ab_median.py
@@ -44,6 +44,22 @@ CONTROL_PREFIXES = (
 )
 
 
+def read_machine(path):
+    """The hardware a report was produced on.
+
+    Reported because the same two binaries can measure identically on one runner
+    and 96% apart on another: code layout interacts with the microarchitecture,
+    and GitHub's fleet is not homogeneous (#204). Without the CPU printed, two
+    runs of the same commit cannot be compared at all.
+    """
+    with open(path) as fh:
+        info = json.load(fh).get("machine_info", {})
+    cpu = info.get("cpu", {})
+    brand = cpu.get("brand_raw") or info.get("processor") or "unknown CPU"
+    count = cpu.get("count")
+    return f"{brand}" + (f", {count} vCPU" if count else "")
+
+
 def read_mins(path):
     """Return {benchmark name: minimum seconds} from a pytest-benchmark report."""
     with open(path) as fh:
@@ -115,6 +131,7 @@ def main():
 
     lines = [
         f"### A/B: {args.a_label} vs {args.b_label}\n",
+        f"Measured on `{read_machine(args.a[0])}`.\n",
         f"Median of {a_count} interleaved rounds per side; each value is a "
         "benchmark's minimum. Positive delta = "
         f"`{args.a_label}` is slower.\n",
@@ -168,6 +185,18 @@ def main():
             f"**Verdict: significant.** `{args.a_label}` is {worst:+.1f}% slower "
             f"than `{args.b_label}`, past the {threshold:.0f}% threshold and "
             "clear of the noise floor.\n"
+        )
+        # Not hedging a real result -- naming a failure mode this gate cannot
+        # otherwise detect. The controls are pure Python and do not care how the
+        # extension was laid out, so they stay flat while a layout-versus-CPU
+        # difference moves every treatment benchmark tightly and repeatably.
+        lines.append(
+            "**Re-run before acting on this.** Two builds differing only in a "
+            "version string measured within 0.4% of each other on one runner and "
+            "**96% apart** on another, with per-round spread under 0.3% both "
+            "times and identical binaries (#204). A real regression reproduces on "
+            "different hardware; a code-layout artifact does not. Compare the CPU "
+            "line above between the two runs.\n"
         )
     elif worst > threshold:
         lines.append(

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -297,17 +297,23 @@ Both `lto = "fat"` and `codegen-units = 1` are already set, so a codegen-unit
 boundary is never the explanation -- worth knowing, since it is the natural first
 guess.
 
-**A version bump alone moves the decode path ~3.5%.** Measured both directions
-(#204): nothing in the crate reads `CARGO_PKG_VERSION`, but the version reaches
-the compiler as crate metadata, which feeds symbol naming and therefore layout.
-So the gate on a release-cut PR will report a few percent either way, above the
-noise floor, and that is the version string rather than the change. `parse_metadata`
-is the tell -- it never decodes, so it stays flat while everything else moves.
+**A version bump alone can move the decode path, and by how much depends on the
+CPU.** Nothing in the crate reads `CARGO_PKG_VERSION`, but the version reaches the
+compiler as crate metadata, which feeds symbol naming and therefore code layout.
+Measured (#204): one version pair differed by 3-4%, and another pair measured
+within 0.4% on one runner and **96% apart** on another -- identical binaries,
+per-round spread under 0.3% both times.
 
-This also bounds what the 7% threshold can police: a change that genuinely costs
-3% is not distinguishable from one that merely moved the version. If you need to
-know which you have, revert the version on a throwaway branch and let the gate
-measure that alone.
+So the gate has a false-positive mode that its own noise floor cannot see. The
+controls are pure Python and do not care how the extension was laid out, so they
+stay flat while every treatment benchmark moves together, tightly and repeatably.
+It looks exactly like a real regression.
+
+**Re-run a large failure before acting on it.** A real regression reproduces on
+different hardware; a layout-versus-CPU artifact does not. The gate prints the CPU
+it measured on for exactly this comparison. And note what it means for the 7%
+threshold: on unlucky hardware, a change that costs nothing can be reported well
+past it.
 
 ## Linting
 

--- a/tests/test_ab_median.py
+++ b/tests/test_ab_median.py
@@ -194,3 +194,25 @@ def test__without_the_exclusion_the_same_data_fails(tmp_path: Path):
 
     assert result.returncode == 1
     assert "Verdict: significant" in result.stdout
+
+
+def test__a_significant_verdict_tells_the_reader_to_re_run(tmp_path: Path):
+    # The gate has a false-positive mode its own noise floor cannot see: a code
+    # layout difference costs nothing on one CPU and ~2x on another, tightly and
+    # repeatably, while the pure-Python controls stay flat. The only cheap defence
+    # is re-running, so a failure has to say so.
+    slower = [(1.500, 10.0), (1.505, 10.1), (1.498, 9.95)]
+
+    result = _run(tmp_path, slower, BASE)
+
+    assert result.returncode == 1
+    assert "Re-run before acting on this" in result.stdout
+    assert "96% apart" in result.stdout
+
+
+def test__the_machine_is_reported(tmp_path: Path):
+    # Two runs of the same commit cannot be compared without knowing whether they
+    # ran on the same hardware.
+    result = _run(tmp_path, EQUAL, BASE)
+
+    assert "Measured on" in result.stdout


### PR DESCRIPTION
The gate has a false-positive mode its own noise floor cannot detect. I walked into it while investigating #204, and it is worth more than the finding I opened that issue for.

## What happened

A probe changing **nothing but the version string** measured **+27% on the decode path and +96% on metadata mode**. A re-run of the **identical commit** measured **±0.4%**. The `.so` hashes match across both attempts (`b93664d4…` head, `66dc7783…` base) — the same two binaries produced both verdicts.

**It was not noise.** Per-round values on the failing run were the tightest of the day:

| | head | base |
|---|---|---|
| `parse_metadata` | 1.135 / 1.135 / 1.135 | 0.577 / 0.578 / 0.578 |
| `parse_message` | 2.593 / 2.589 / 2.585 | 2.040 / 2.041 / 2.038 |

Spread under 0.3%, stable +27%/+96%. That run's absolutes were ~1.8x higher throughout (pure-Python control at 12.7 ms vs 7.2 ms), so it ran on slower, different hardware. Code layout interacts with the microarchitecture, and GitHub's runner fleet is not homogeneous.

## Why the noise floor cannot see it

The controls are **pure Python**. They do not care how the Rust extension was laid out, so they stay flat while every treatment benchmark moves together, tightly and repeatably. The result clears the floor, passes every internal consistency check the harness has, and is wrong.

That was the one thing I believed made the interleaved gate trustworthy, so it is worth being blunt: the controls bound *measurement* error, not *layout×CPU* error.

## What this changes

- the gate **prints the CPU** each run measured on — without it, two runs of one commit cannot be compared
- a significant verdict now says **re-run before acting on this**, and why: a real regression reproduces on different hardware, a layout artifact does not
- two tests pin both behaviours
- `CONTRIBUTING.md`'s claim that a version bump costs "~3.5%" is corrected to what was observed, including that on unlucky hardware a change costing **nothing** can be reported well past the 7% threshold

This does not weaken the gate. It caught a real +30% twice today and a real +15.7% toolchain regression. It means a large failure deserves one re-run before someone spends an afternoon bisecting — which is exactly what I did by hand here, and what nobody should have to rediscover.