### PR TITLE
Say that a contended first read may decode twice

### DIFF
--- a/fast_mail_parser/__init__.pyi
+++ b/fast_mail_parser/__init__.pyi
@@ -235,6 +235,11 @@ class PyLazyAttachment:
     A separate type rather than a lazy ``PyAttachment.content``: changing what an
     existing attribute costs, and when it raises, is a change to a shipped
     contract, and those batch into one API-v2 window. Adding a type is not.
+    
+    Reading ``content`` from two threads for the first time simultaneously may
+    decode twice; both readers still get the same object back. The decode is
+    deliberately not held under the cache's lock, because doing so would risk a
+    deadlock against the GIL.
     """
 
     def __init__(

--- a/src/fast_mail_parser.rs
+++ b/src/fast_mail_parser.rs
@@ -703,6 +703,15 @@ pub struct PyLazyAttachment {
     /// access returns the *same* Python object rather than an equal copy of it.
     /// That is both what a cache should mean -- `a.content is a.content` -- and
     /// cheaper, since the second read allocates nothing at all.
+    ///
+    /// Published once, but *decoded* possibly twice: the decode deliberately
+    /// happens outside `get_or_init`, so two threads racing on a first access can
+    /// both do the work and one result is dropped. That is the right trade. The
+    /// alternative -- decoding inside the initialiser -- holds the cell's lock
+    /// across a `detach`, which is the shape that deadlocks: one thread waiting
+    /// on the lock while holding the GIL, the other waiting on the GIL while
+    /// holding the lock. Wasted CPU on a contended first read is cheaper than
+    /// that, and every reader still sees one object.
     content: OnceLock<Py<PyBytes>>,
 }
 
@@ -712,6 +721,9 @@ impl PyLazyAttachment {
     ///
     /// Every later read returns the same `bytes` object, so keeping a reference
     /// and re-reading the attribute cost the same thing.
+    ///
+    /// Two threads reading this for the first time at once may both decode; they
+    /// will still see one object. See the note on the field.
     ///
     /// Raises `DecodeError` when the part's `Content-Transfer-Encoding` cannot be
     /// decoded. Full mode raises that from `parse_email`; this mode raises it


### PR DESCRIPTION
Found reviewing the lazy path from #198 with fresh eyes. No behaviour change — the implementation is right; the documentation understates it.

`content` is described as "decoded on first access and cached", which reads as **at most once**. It is not: the decode sits *outside* `get_or_init`, so two threads reading it for the first time simultaneously can both decode. One result is dropped and every reader still sees the same object, so the cache contract holds — but the work can happen twice.

**That placement is correct**, and worth recording as a decision rather than leaving someone to find it. Decoding *inside* the initialiser would hold the cell's lock across a `detach`, which is the classic deadlock shape: one thread waiting on the lock while holding the GIL, another waiting on the GIL while holding the lock. Wasted CPU on a contended first read is far cheaper than that.

Documented in three places — the field, the getter, and the type stub — because a caller threading this API is precisely who would assume otherwise, and this library advertises releasing the GIL.