### PR TITLE
Extend mode= to parse_many and parse_email_tree (#202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,78 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`mode=` on `parse_many` and `parse_email_tree`** (#202), honouring the same
+  `"full"` / `"lazy"` / `"metadata"` values `parse_email` honours. The mode axis
+  shipped on one entry point of three; these are the two where it is worth the
+  most, and until now a caller had to choose between a mode and the API.
+  - **`parse_many(payloads, mode="metadata")`** is the mailbox sweep the mode was
+    built for. The batch API removes per-message overhead (#96: ~12x at
+    2000 × 0.8 KB) and metadata mode removes the decoding (#97: ~3x on an
+    attachment-heavy message); they now compose. Measured on the 767 KiB fixture,
+    8 messages, `threads=1`: full 8.96 ms, metadata 2.94 ms — **3.0x**, the same
+    ratio the single-message mode gets. On 2000 × 0.8 KB it is 2.80 ms against
+    3.04 ms, because small messages are mostly headers and there is little
+    decoding to skip.
+  - **`parse_email_tree(payload, mode="lazy")`** is the forensics case: walk the
+    structure of a large message and decode the one part you want. A full-mode
+    tree decodes every leaf, which is the wrong bill for exactly what the tree is
+    best at. `mode="metadata"` decodes nothing *and retains nothing*. On the same
+    fixture: full tree 1.10 ms, lazy with nothing read 0.38 ms, metadata
+    0.37 ms — **~2.9x**.
+  - **Two new node types, `PyLazyMimePart` and `PyMimePartMetadata`**, rather than
+    a wider `PyMimePart`. `PyMimePart.content` is `bytes | None` and its `None`
+    *means* "this node is a `multipart/*` container"; a mode where it also meant
+    "not decoded yet" would make a leaf indistinguishable from a container, which
+    is the silent-wrong-answer shape #150 and metadata mode's absent `text_plain`
+    were both about. A metadata node therefore has no `content` attribute at all
+    and reports `encoded_size` instead — `None` in the same place, and with the
+    same meaning, as `content`'s `None`. Making `PyMimePart.content` lazy would
+    also have re-timed a shipped attribute and moved where it raises, which is
+    what #104 batches into an API-v2 window; adding a type is not.
+  - **Two rather than one**, because the two differ in more than presentation:
+    lazy mode retains a copy of every leaf so it can decode one later, metadata
+    mode retains none. On a tree that difference is the memory, which is the point
+    of the sweep.
+  - **The tree is the same tree in every mode.** Every per-node field except the
+    body is asserted equal to full mode's across the whole fixture and RFC corpus,
+    and on arbitrary input by the `parse_agreement` fuzz target, which gained the
+    #202 derivations. A mode that quietly reshaped a message would be the exact
+    failure that target exists to catch, and it has caught two already.
+  - **`message/rfc822` is still decoded, in every mode.** Its body *is* the
+    embedded message, so parsing it is what gives the node children — deferring it
+    would defer the structure, which is the one thing a tree API has to deliver
+    eagerly. The bytes are published rather than dropped and decoded again, so
+    such a node has `is_decoded == True` from the start; and unlike
+    `parse_email(mode="metadata")`, a deferred tree can raise `DecodeError` for
+    such a part. Documented, and pinned as a test.
+  - **The lazy tree extends the `raw_bytes` claim to a root.** Flat lazy mode
+    defers only subparts; a single-part message's tree root *is* the leaf, so the
+    retained slice is the whole payload. That the re-parse still reproduces full
+    mode's bytes is asserted per fixture and on arbitrary input rather than
+    assumed.
+  - **Combinations that cannot mean anything are refused.** `strict=True` with
+    `mode="metadata"` raises `ValueError` on `parse_many` with the same message it
+    raises on `parse_email`, and before any parsing happens. `strict=True` with
+    `mode="lazy"` is honoured per slot and means what it means everywhere else.
+    The tree has no `strict` in any mode, because it has no warnings channel to be
+    strict about.
+  - `walk` accepts a node from any mode and yields nodes of the same type. Its
+    implementation was already duck-typed; the stub now says so with a
+    value-restricted `TypeVar`, which is non-breaking — walking a `PyMimePart`
+    still yields `PyMimePart`.
+  - **Measured, not assumed.** Interleaved A/B against `master`, three rounds a
+    side: worst treatment delta +0.5% against a 4.4% control noise floor, with
+    `parse_message` at -1.2% and `parse_many` at -0.2%. The default paths are
+    answered in the first lines of their entry points and are byte-for-byte what
+    they were; every new binding function carries `#[inline(never)]`, the two error
+    constructors are the existing `#[cold]` ones, and each new mode pair shares one
+    `catch_panics` call site. #99, #100, #135 and #180 are four records of code
+    that never executes costing this hot path 15-96%.
+  - The batch scheduler is now shared rather than copied: `parse_many_as` takes the
+    per-message parse as a `fn` pointer, and `parse_many` is a call to it. The
+    dynamic cursor and the order restoration are where a bug would be subtle, so
+    there is one of them and not three.
+
 - **`parse_email(payload, mode="lazy")`** decodes the bodies as usual and defers
   each attachment: `PyLazyAttachment.content` decodes on first access and caches,
   returning a `PyLazyMail` (#97). This completes the issue: `mode="metadata"`

--- a/Readme.md
+++ b/Readme.md
@@ -296,6 +296,35 @@ The break-even point is not portable — the parse scales with cores while the
 per-call overhead does not — so treat the second table as the shape of the
 trade-off and measure your own mix if it matters.
 
+#### Batching in a mode
+
+`parse_many` takes the same `mode=` as `parse_email`, and it means the same thing
+per message. This is the mailbox sweep: the batch API removes the per-message
+overhead and the mode removes the decoding, and they compose.
+
+```python
+from fast_mail_parser import parse_many
+
+for mail in parse_many(payloads, mode="metadata"):     # list[PyMailMetadata | ParseError]
+    print(mail.subject, [a.filename for a in mail.attachments])
+
+results = parse_many(payloads, mode="lazy")            # list[PyLazyMail | ParseError]
+```
+
+The mode is uniform across the batch, which is what lets it pick the slot type;
+`ParseError` instances still occupy failed slots, and `raise_on_error`, `threads`
+and input order behave exactly as in the default mode.
+
+On the attachment-heavy fixture, a batch of 8 × 767 KiB with `threads=1`:
+`mode="full"` 8.96 ms, `mode="metadata"` 2.94 ms — **3.0x**, the same ratio the
+single-message mode gets, now available to the batch. On 2000 × 0.8 KB it is
+2.80 ms against 3.04 ms: small messages are mostly headers, so there is little
+decoding to skip, and the mode neither helps nor hurts much.
+
+`strict=True` with `mode="metadata"` raises `ValueError`, as it does on
+`parse_email` — a mode that never reads the bodies cannot promise nothing in them
+was repaired.
+
 ### Metadata-only parsing
 
 Scanning a mailbox to classify by sender, subject and attachment inventory does
@@ -332,12 +361,18 @@ loudly instead.
 `Content-Transfer-Encoding` passes silently here and raises `DecodeError` in full
 mode. Header errors are reported in both.
 
-The type follows the mode, so nothing changes for callers of the default:
+The type follows the mode, so nothing changes for callers of the default — and
+all three entry points take the same three modes:
 
 ```python
-parse_email(payload)                    # PyMail
-parse_email(payload, mode="lazy")       # PyLazyMail
-parse_email(payload, mode="metadata")   # PyMailMetadata
+parse_email(payload)                         # PyMail
+parse_email(payload, mode="lazy")            # PyLazyMail
+parse_email(payload, mode="metadata")        # PyMailMetadata
+
+parse_many(payloads, mode="metadata")        # list[PyMailMetadata | ParseError]
+
+parse_email_tree(payload, mode="metadata")   # PyMimePartMetadata
+parse_email_tree(payload, mode="lazy")       # PyLazyMimePart
 ```
 
 If you want structure rather than an inventory, `parse_email_tree` is the API
@@ -443,6 +478,49 @@ print(bounced.children[0].headers["Subject"])   # the original message's subject
 
 Embedded nesting counts against the same recursion cap as multipart nesting, so
 an onion of forwards cannot recurse further than a multipart tree can.
+
+#### Walking without decoding
+
+A full-mode tree decodes every leaf, which is the wrong bill for the thing the
+tree is best at: walking a large message to pull one part out of it. `mode=`
+takes the same three values here, and the shape of the tree is identical in all
+three — only what a leaf's bytes cost changes.
+
+```python
+from fast_mail_parser import parse_email_tree, walk
+
+root = parse_email_tree(payload, mode="lazy")
+
+for part in walk(root):
+    print(part.content_type, part.encoded_size, part.is_decoded)
+
+pdf = next(p for p in walk(root) if p.content_type == "application/pdf")
+data = pdf.content            # decoded here, and only this one
+```
+
+`mode="metadata"` decodes nothing *and retains nothing*: a node reports
+`encoded_size` in place of `content` and there is no way to ask for the bytes.
+That is the difference between the two — lazy mode keeps a copy of every leaf so
+it can decode one later, metadata mode keeps none and is the cheaper sweep.
+
+On the attachment-heavy fixture (767 KiB): full tree 1.10 ms, `mode="lazy"` with
+nothing read 0.38 ms, `mode="metadata"` 0.37 ms — **~2.9x**.
+
+Two things to know:
+
+**A metadata node has no `content` at all**, not `content = None`. On a
+`PyMimePart`, `content is None` means "this is a container" and only that; a mode
+where it also meant "not decoded" would make the two indistinguishable. A missing
+attribute fails loudly instead, exactly as `PyMailMetadata` omits `text_plain`.
+
+**A `message/rfc822` body is still decoded, in every mode.** That body *is* the
+embedded message, and parsing it is what gives the node children — so a tree that
+deferred it would be deferring the structure, which is the one thing every mode
+has to deliver eagerly. Its node therefore arrives with `is_decoded` already
+`True`, and unlike `parse_email(mode="metadata")` a deferred tree *can* raise
+`DecodeError` for such a part. Nothing else is decoded.
+
+`walk` accepts a node from any mode and yields nodes of the same type.
 
 #### Which API when
 

--- a/fast_mail_parser/__init__.py
+++ b/fast_mail_parser/__init__.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterator
+from typing import TypeVar
 
 from .fast_mail_parser import (
     DecodeError,
@@ -11,20 +12,31 @@ from .fast_mail_parser import (
     PyAttachmentMetadata,
     PyLazyAttachment,
     PyLazyMail,
+    PyLazyMimePart,
     PyMail,
     PyMailMetadata,
     PyMimePart,
+    PyMimePartMetadata,
     parse_email,
     parse_email_tree,
     parse_many,
 )
 
+# `walk` reads only `children`, which every tree node type has, so one
+# implementation serves all three modes. The TypeVar is what makes that visible
+# to a type checker: walking a `PyLazyMimePart` yields `PyLazyMimePart`, not the
+# `PyMimePart` the single-mode signature used to promise (#202).
+_Node = TypeVar("_Node", PyMimePart, PyLazyMimePart, PyMimePartMetadata)
 
-def walk(part: PyMimePart) -> Iterator[PyMimePart]:
+
+def walk(part: _Node) -> Iterator[_Node]:
     """Yield `part` and every part beneath it, depth first.
 
     The same order as the stdlib's `email.message.Message.walk`, so code written
     against that reads the same here.
+
+    Accepts a node from any `parse_email_tree` mode: the three node types differ
+    in what a leaf's bytes cost and not in the shape of the tree.
 
     Written in Python rather than Rust deliberately: it is a generator, so a
     caller that stops early -- the common case, looking for the first part of some
@@ -44,6 +56,8 @@ __all__ = [
     "PyLazyMail",
     "PyMailMetadata",
     "PyMimePart",
+    "PyLazyMimePart",
+    "PyMimePartMetadata",
     "PyAttachment",
     "PyLazyAttachment",
     "PyAttachmentMetadata",

--- a/fast_mail_parser/__init__.pyi
+++ b/fast_mail_parser/__init__.pyi
@@ -1,6 +1,6 @@
 from collections.abc import Iterator
 from datetime import datetime
-from typing import Literal, overload
+from typing import Literal, TypeVar, overload
 
 __all__ = [
     "parse_email",
@@ -11,6 +11,8 @@ __all__ = [
     "PyLazyMail",
     "PyMailMetadata",
     "PyMimePart",
+    "PyLazyMimePart",
+    "PyMimePartMetadata",
     "PyAttachment",
     "PyLazyAttachment",
     "PyAttachmentMetadata",
@@ -64,6 +66,109 @@ class PyMimePart:
         self.is_message = is_message
         self.content = content
         self.children = children
+
+
+class PyMimePartMetadata:
+    """One node of a MIME tree, described but not decoded.
+
+    Returned by ``parse_email_tree(payload, mode="metadata")``. Everything
+    ``PyMimePart`` says about the *shape* of a message it says too -- and nothing
+    about what the leaves carry beyond ``encoded_size``, the bytes a part's body
+    occupies in the message *before* transfer-decoding.
+
+    ``encoded_size`` is ``None`` for a ``multipart/*`` container, in the same
+    place and with the same meaning as ``PyMimePart.content``'s ``None``: a
+    container's body is its children with boundaries between them, so it has none
+    of its own.
+
+    There is deliberately no ``content``, not even ``None``. A mode where ``None``
+    also meant "not decoded" would make a leaf indistinguishable from a container;
+    a missing attribute fails loudly instead, as ``PyMailMetadata`` omits
+    ``text_plain`` rather than returning an empty list.
+
+    The tree is the same tree in every mode. The one thing this mode still decodes
+    is a ``message/rfc822`` body, because that body *is* the embedded message and
+    parsing it is what gives the node children -- so unlike
+    ``parse_email(mode="metadata")``, this can raise ``DecodeError``.
+    """
+
+    def __init__(
+        self,
+        content_type: str,
+        headers: dict[str, list[str]],
+        filename: str,
+        content_id: str | None,
+        disposition: str | None,
+        is_message: bool,
+        encoded_size: int | None,
+        children: list[PyMimePartMetadata],
+    ) -> None:
+        self.content_type = content_type
+        self.headers = headers
+        self.filename = filename
+        self.content_id = content_id
+        self.disposition = disposition
+        self.is_message = is_message
+        self.encoded_size = encoded_size
+        self.children = children
+
+
+class PyLazyMimePart:
+    """One node of a MIME tree whose bytes are decoded on first access.
+
+    Returned by ``parse_email_tree(payload, mode="lazy")``: walk a large message's
+    structure and decode the one part you want. ``PyMimePart`` plus
+    ``encoded_size`` and ``is_decoded``, with ``content`` a property that decodes
+    rather than a value the parse already paid for.
+
+    ``content`` is ``None`` for a ``multipart/*`` container, exactly as on
+    ``PyMimePart`` -- it never means "not decoded", which is what ``is_decoded``
+    is for. Every read after the first returns **the same** ``bytes`` object, and
+    a part whose ``Content-Transfer-Encoding`` cannot be decoded raises
+    ``DecodeError`` from here rather than failing the whole tree.
+
+    ``is_decoded`` answers whether reading ``content`` is free. It is ``True``
+    from the start for a container and for a ``message/rfc822`` node: the first
+    has nothing to decode, and the second was decoded during the walk because its
+    body is the embedded message that gives it children.
+
+    Memory: a leaf retains a copy of itself as it sits in the message. For a
+    single-part message that is the whole payload, because the root is the leaf --
+    so this is for walking a large multipart message, not for small mail in bulk.
+
+    A separate type rather than a lazy ``PyMimePart.content``, for the reason
+    ``PyLazyAttachment`` is one: re-timing an existing attribute, and moving where
+    it raises, is a change to a shipped contract, and those batch into one API-v2
+    window. Adding a type is not.
+    """
+
+    def __init__(
+        self,
+        content_type: str,
+        headers: dict[str, list[str]],
+        filename: str,
+        content_id: str | None,
+        disposition: str | None,
+        is_message: bool,
+        encoded_size: int | None,
+        children: list[PyLazyMimePart],
+    ) -> None:
+        self.content_type = content_type
+        self.headers = headers
+        self.filename = filename
+        self.content_id = content_id
+        self.disposition = disposition
+        self.is_message = is_message
+        self.encoded_size = encoded_size
+        self.children = children
+
+    @property
+    def content(self) -> bytes | None:
+        """The transfer-decoded bytes of a leaf, decoded on first access."""
+
+    @property
+    def is_decoded(self) -> bool:
+        """Whether reading ``content`` is free."""
 
 
 class PyAttachmentMetadata:
@@ -466,6 +571,7 @@ def parse_email(
 ) -> PyMailMetadata: ...
 
 
+@overload
 def parse_email_tree(payload: str | bytes) -> PyMimePart:
     """Parse a message into its MIME tree, structure intact.
 
@@ -475,15 +581,56 @@ def parse_email_tree(payload: str | bytes) -> PyMimePart:
     Use this when the shape of the message matters -- forensics, bounce
     processing, deciding which body belongs to which alternative -- and
     ``parse_email`` when the flat projection is what you want.
+
+    ``mode`` takes the same three values ``parse_email`` takes, and picks the node
+    type through these overloads so no existing caller's types change:
+
+    * ``"full"`` (the default) returns a ``PyMimePart`` tree, every leaf decoded.
+    * ``"lazy"`` returns a ``PyLazyMimePart`` tree, each leaf decoded on first
+      access and cached -- walk a large message and decode the one part you want.
+    * ``"metadata"`` returns a ``PyMimePartMetadata`` tree, which decodes nothing
+      and retains nothing; a leaf reports ``encoded_size`` instead of ``content``.
+
+    The shape of the tree is identical in all three modes. The one exception to
+    "decodes nothing" is a ``message/rfc822`` body, which has to be decoded before
+    the message inside it can be parsed -- so the deferred modes can still raise
+    ``DecodeError`` for such a part, and its node arrives already decoded.
+
+    There is no ``strict``, in any mode: the tree has no warnings channel to be
+    strict about. See the note on ``PyMimePart``.
     """
 
 
-def walk(part: PyMimePart) -> Iterator[PyMimePart]:
+@overload
+def parse_email_tree(payload: str | bytes, *, mode: Literal["full"]) -> PyMimePart: ...
+
+
+@overload
+def parse_email_tree(
+    payload: str | bytes, *, mode: Literal["lazy"]
+) -> PyLazyMimePart: ...
+
+
+@overload
+def parse_email_tree(
+    payload: str | bytes, *, mode: Literal["metadata"]
+) -> PyMimePartMetadata: ...
+
+
+_Node = TypeVar("_Node", PyMimePart, PyLazyMimePart, PyMimePartMetadata)
+
+
+def walk(part: _Node) -> Iterator[_Node]:
     """Yield ``part`` and every part beneath it, depth first.
 
     The same order as the stdlib's ``email.message.Message.walk``. It is a
     generator, so stopping early costs nothing for the rest of the tree.
+
+    Accepts a node from any ``parse_email_tree`` mode and yields nodes of the same
+    type: the three node types differ in what a leaf's bytes cost, not in the
+    shape of the tree.
     """
+@overload
 def parse_many(
     payloads: list[str | bytes],
     *,
@@ -520,4 +667,53 @@ def parse_many(
     begins -- scales with total bytes. For a few very large messages a Python
     thread pool over ``parse_email`` is currently faster. See the README for
     measured figures.
+
+    ``mode`` takes the same three values ``parse_email`` takes and means the same
+    things, and picks the slot type through these overloads. It is uniform across
+    the batch, which is what makes that sound -- one call cannot mix node types.
+
+    * ``"full"`` (the default): each slot is a ``PyMail``.
+    * ``"metadata"``: each slot is a ``PyMailMetadata``. This is the mailbox sweep
+      the mode was built for -- headers for a whole mailbox without decoding any
+      of it. ``strict=True`` is rejected with ``ValueError``, as on
+      ``parse_email``, because the mode never reads the bodies.
+    * ``"lazy"``: each slot is a ``PyLazyMail``. Note that this retains the
+      encoded bytes of every attachment in the batch for as long as the result
+      lives, so it is for pulling a few parts out of a batch rather than for
+      holding a large one undecoded.
+
+    ``ParseError`` instances still occupy failed slots in every mode, and
+    ``raise_on_error`` still applies.
     """
+
+
+@overload
+def parse_many(
+    payloads: list[str | bytes],
+    *,
+    mode: Literal["full"],
+    threads: int | None = None,
+    raise_on_error: bool = False,
+    strict: bool = False,
+) -> list[PyMail | ParseError]: ...
+
+
+@overload
+def parse_many(
+    payloads: list[str | bytes],
+    *,
+    mode: Literal["lazy"],
+    threads: int | None = None,
+    raise_on_error: bool = False,
+    strict: bool = False,
+) -> list[PyLazyMail | ParseError]: ...
+
+
+@overload
+def parse_many(
+    payloads: list[str | bytes],
+    *,
+    mode: Literal["metadata"],
+    threads: int | None = None,
+    raise_on_error: bool = False,
+) -> list[PyMailMetadata | ParseError]: ...

--- a/fuzz/fuzz_targets/parse_agreement.rs
+++ b/fuzz/fuzz_targets/parse_agreement.rs
@@ -35,6 +35,12 @@
 //!    parser's slicing. The envelope, the bodies and the whole warning list must
 //!    agree too -- the last of those is what lets `strict=True` mean the same
 //!    thing in both modes.
+//! 8. **A tree is the same tree in all three modes** (#202). `mode=` on
+//!    `parse_email_tree` adds two more derivations of one message, so it adds the
+//!    failure this target exists for. Every per-node field except the body must be
+//!    identical to full mode's, and a deferred leaf must decode to exactly the
+//!    bytes full mode decoded -- which extends the `raw_bytes` claim above to a
+//!    case flat lazy mode never reaches, a message whose *root* is the leaf.
 
 #![no_main]
 
@@ -83,6 +89,79 @@ fn rendered_warnings(warnings: &[mail_parser::Warning]) -> Vec<(&str, &str, &str
             )
         })
         .collect()
+}
+
+/// A deferred tree rendered like `canonical_tree`, minus the body, so the three
+/// modes can be compared on everything except what they deliberately differ on.
+fn canonical_node(node: &mail_parser::TreeNode) -> String {
+    let mut out = String::new();
+    render_node(node, 0, &mut out);
+    out
+}
+
+fn render_node(node: &mail_parser::TreeNode, depth: usize, out: &mut String) {
+    out.push_str(&format!(
+        "{depth}|{}|{}|{:?}|{:?}|{}\n",
+        node.content_type, node.filename, node.content_id, node.disposition, node.is_message,
+    ));
+    for (name, values) in &node.headers {
+        out.push_str(&format!("{depth}h|{name}|{values:?}\n"));
+    }
+    for child in &node.children {
+        render_node(child, depth + 1, out);
+    }
+}
+
+/// The same rendering for a full-mode tree, so the two can be compared directly.
+fn canonical_full(part: &mail_parser::MimePart) -> String {
+    let mut out = String::new();
+    render_full(part, 0, &mut out);
+    out
+}
+
+fn render_full(part: &mail_parser::MimePart, depth: usize, out: &mut String) {
+    out.push_str(&format!(
+        "{depth}|{}|{}|{:?}|{:?}|{}\n",
+        part.content_type, part.filename, part.content_id, part.disposition, part.is_message,
+    ));
+    for (name, values) in &part.headers {
+        out.push_str(&format!("{depth}h|{name}|{values:?}\n"));
+    }
+    for child in &part.children {
+        render_full(child, depth + 1, out);
+    }
+}
+
+/// Every node's body as the full parse produced it, in walk order.
+fn full_bodies(part: &mail_parser::MimePart, out: &mut Vec<Option<Vec<u8>>>) {
+    out.push(part.content.clone());
+    for child in &part.children {
+        full_bodies(child, out);
+    }
+}
+
+/// Every node's body as a deferred tree would produce it: decoded from what the
+/// node retained, or `None` for a container.
+///
+/// A leaf that cannot decode from its retained bytes returns an `Err`, which is a
+/// failure of the retention rather than of the message -- the full parse decoded
+/// the same part.
+fn deferred_bodies(
+    node: &mail_parser::TreeNode,
+    out: &mut Vec<Option<Vec<u8>>>,
+) -> Result<(), ()> {
+    match &node.body {
+        mail_parser::NodeBody::Container => out.push(None),
+        mail_parser::NodeBody::Decoded { content, .. } => out.push(Some(content.clone())),
+        mail_parser::NodeBody::Undecoded { raw, .. } => {
+            let raw = raw.as_ref().ok_or(())?;
+            out.push(Some(mail_parser::decode_part(raw).map_err(|_| ())?));
+        }
+    }
+    for child in &node.children {
+        deferred_bodies(child, out)?;
+    }
+    Ok(())
 }
 
 /// Every leaf's content, for the containment check against the flat parse.
@@ -260,4 +339,87 @@ fuzz_target!(|data: &[u8]| {
         (Err(_), Err(_)) => {}
         _ => panic!("parsing the same input into a tree twice disagreed on success"),
     }
+
+    // The deferred tree modes (#202): two more derivations of the same message,
+    // so two more chances for one to drift from the others.
+    let described = mail_parser::parse_tree_deferred(data, false);
+    let deferred = mail_parser::parse_tree_deferred(data, true);
+
+    if let Ok(full) = &first {
+        let described = described.expect(
+            "metadata mode failed to build a tree the full mode built, though it \
+             decodes strictly less: only a message/rfc822 body, which full mode \
+             decodes too",
+        );
+        let deferred = deferred.expect(
+            "lazy mode failed to build a tree the full mode built, though it \
+             decodes strictly less",
+        );
+
+        let shape = canonical_full(full);
+        assert_eq!(
+            shape,
+            canonical_node(&described),
+            "the metadata tree's shape disagrees with full mode"
+        );
+        assert_eq!(
+            shape,
+            canonical_node(&deferred),
+            "the lazy tree's shape disagrees with full mode"
+        );
+
+        // Which nodes have a body of their own, and how big it is on the wire,
+        // must be one answer across the two deferred modes -- `encoded_size is
+        // None` is the same question as `content is None`.
+        let mut sizes = Vec::new();
+        node_sizes(&described, &mut sizes);
+        let mut deferred_sizes = Vec::new();
+        node_sizes(&deferred, &mut deferred_sizes);
+        assert_eq!(
+            sizes, deferred_sizes,
+            "the two deferred modes disagree about encoded sizes"
+        );
+
+        let mut expected = Vec::new();
+        full_bodies(full, &mut expected);
+        assert_eq!(
+            sizes.len(),
+            expected.len(),
+            "the deferred tree has a different number of nodes"
+        );
+        for (size, body) in sizes.iter().zip(&expected) {
+            assert_eq!(
+                size.is_none(),
+                body.is_none(),
+                "a node reports a body in one mode and not the other"
+            );
+            if let (Some(size), Some(body)) = (size, body) {
+                // The same bound the flat modes assert: decoding cannot amplify
+                // a part beyond doubling it.
+                assert!(
+                    body.len() <= size * 2,
+                    "decoded size {} is more than double the encoded size {size}",
+                    body.len()
+                );
+            }
+        }
+
+        // The claim the lazy tree rests on, and the one flat lazy mode cannot
+        // reach: a retained *root* re-parses to the part it was taken from.
+        let mut produced = Vec::new();
+        deferred_bodies(&deferred, &mut produced)
+            .expect("a node the full parse decoded failed to decode from its retained bytes");
+        assert_eq!(
+            expected, produced,
+            "a deferred decode disagrees with the full parse"
+        );
+    }
 });
+
+/// Every node's `encoded_size`, in walk order.
+fn node_sizes(node: &mail_parser::TreeNode, out: &mut Vec<Option<usize>>) {
+    out.push(node.body.encoded_size());
+    for child in &node.children {
+        node_sizes(child, out);
+    }
+}

--- a/src/fast_mail_parser.rs
+++ b/src/fast_mail_parser.rs
@@ -415,6 +415,254 @@ impl PyMimePart {
     }
 }
 
+/// One node of a MIME tree, described but not decoded (#202).
+///
+/// Returned by `parse_email_tree(payload, mode="metadata")`. Everything
+/// `PyMimePart` says about the *shape* of a message it says too -- content type,
+/// headers, filename, content id, disposition, `is_message`, children -- with
+/// `content` replaced by `encoded_size`.
+///
+/// There is deliberately no `content`, not even `None`. `PyMimePart.content` is
+/// `None` for exactly one reason, that the node is a `multipart/*` container, and
+/// a mode where `None` also meant "not decoded" would make a leaf with no body
+/// indistinguishable from a container. A missing attribute fails loudly instead
+/// -- the same choice as `PyMailMetadata`, which omits `text_plain` rather than
+/// returning an empty list.
+#[pyclass(skip_from_py_object)]
+pub struct PyMimePartMetadata {
+    #[pyo3(get)]
+    pub content_type: String,
+    pub headers: Vec<(String, Vec<String>)>,
+    #[pyo3(get)]
+    pub filename: String,
+    #[pyo3(get)]
+    pub content_id: Option<String>,
+    #[pyo3(get)]
+    pub disposition: Option<String>,
+    #[pyo3(get)]
+    pub is_message: bool,
+    /// Bytes this part's body occupies in the message, **before**
+    /// transfer-decoding -- as on `PyAttachmentMetadata`. `None` for a
+    /// `multipart/*` container, in the same place and with the same meaning as
+    /// `PyMimePart.content`'s `None`: a container has no body of its own.
+    #[pyo3(get)]
+    pub encoded_size: Option<usize>,
+    pub children: Vec<Py<PyMimePartMetadata>>,
+}
+
+#[pymethods]
+impl PyMimePartMetadata {
+    /// This part's headers, every value kept, keys in wire order.
+    #[getter]
+    fn headers<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let dict = PyDict::new(py);
+        for (name, values) in &self.headers {
+            dict.set_item(name, values)?;
+        }
+        Ok(dict)
+    }
+
+    /// The parts nested directly inside this one, in message order.
+    #[getter]
+    fn children<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        PyList::new(py, self.children.iter().map(|child| child.clone_ref(py)))
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "<PyMimePartMetadata {} children={}>",
+            self.content_type,
+            self.children.len()
+        )
+    }
+}
+
+/// One node of a MIME tree whose bytes are decoded on first access (#202).
+///
+/// Returned by `parse_email_tree(payload, mode="lazy")`. `PyMimePart` plus
+/// `encoded_size` and `is_decoded`, with `content` a property that does the work
+/// rather than a value the parse already paid for -- the same relationship
+/// `PyLazyAttachment` has to `PyAttachment`, and a new type for the same reason:
+/// re-timing an existing attribute, and moving where it raises, is a change to a
+/// shipped contract that #104 batches into an API-v2 window.
+///
+/// Memory: a leaf retains a copy of itself as it sits in the message. For a
+/// single-part message that is the whole payload, because the root *is* the leaf
+/// -- so this mode is for walking a large multipart message and decoding one part
+/// of it, which is what the tree is for, and not for small mail in bulk.
+#[pyclass(skip_from_py_object)]
+pub struct PyLazyMimePart {
+    #[pyo3(get)]
+    pub content_type: String,
+    pub headers: Vec<(String, Vec<String>)>,
+    #[pyo3(get)]
+    pub filename: String,
+    #[pyo3(get)]
+    pub content_id: Option<String>,
+    #[pyo3(get)]
+    pub disposition: Option<String>,
+    #[pyo3(get)]
+    pub is_message: bool,
+    /// Bytes this part's body occupies before transfer-decoding, or `None` for a
+    /// `multipart/*` container -- the same value and name as on
+    /// `PyMimePartMetadata` and `PyLazyAttachment`. Choosing which part to decode
+    /// must not require decoding any of them, which is what this is for.
+    #[pyo3(get)]
+    pub encoded_size: Option<usize>,
+    /// The part as it sits in the message, still encoded. `None` for a container
+    /// and for a `message/rfc822` node, whose bytes are already published below.
+    raw: Option<Vec<u8>>,
+    /// The decoded bytes, published exactly once -- as on `PyLazyAttachment`, so
+    /// that `part.content is part.content`.
+    content: OnceLock<Py<PyBytes>>,
+    pub children: Vec<Py<PyLazyMimePart>>,
+}
+
+#[pymethods]
+impl PyLazyMimePart {
+    /// This part's headers, every value kept, keys in wire order.
+    #[getter]
+    fn headers<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let dict = PyDict::new(py);
+        for (name, values) in &self.headers {
+            dict.set_item(name, values)?;
+        }
+        Ok(dict)
+    }
+
+    /// The parts nested directly inside this one, in message order.
+    #[getter]
+    fn children<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        PyList::new(py, self.children.iter().map(|child| child.clone_ref(py)))
+    }
+
+    /// Transfer-decoded bytes of a leaf, decoded on first access and cached, or
+    /// `None` for a `multipart/*` container.
+    ///
+    /// `None` means what it means on `PyMimePart`: a container's body is its
+    /// children with boundaries between them, so returning it would hand back the
+    /// same bytes twice. It never means "not decoded" -- `is_decoded` answers
+    /// that, and reading this attribute is what changes the answer.
+    ///
+    /// Raises `DecodeError` when this part's `Content-Transfer-Encoding` cannot be
+    /// decoded, exactly as `PyLazyAttachment.content` does: full mode fails the
+    /// whole tree, this mode fails only the part.
+    #[getter]
+    fn content<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyBytes>>> {
+        if let Some(cached) = self.content.get() {
+            return Ok(Some(cached.bind(py).clone()));
+        }
+        let Some(raw) = self.raw.as_ref() else {
+            return Ok(None);
+        };
+        self.decode(py, raw).map(Some)
+    }
+
+    /// Whether reading `content` is free.
+    ///
+    /// True once the part has been decoded, and true from the start for a
+    /// container and for a `message/rfc822` node -- neither has a decode pending.
+    /// That is the question a caller holding a large tree actually has, and it is
+    /// also what makes "a part nobody reads is never decoded" an assertion rather
+    /// than a timing argument.
+    #[getter]
+    fn is_decoded(&self) -> bool {
+        self.content.get().is_some() || self.raw.is_none()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "<PyLazyMimePart {} children={} decoded={}>",
+            self.content_type,
+            self.children.len(),
+            self.is_decoded()
+        )
+    }
+}
+
+impl PyLazyMimePart {
+    /// Decode this part and publish the result, exactly as `PyLazyAttachment`
+    /// does -- see the long note there for why a race duplicates work rather than
+    /// needing a lock, and why the GIL is released for the decode.
+    #[cold]
+    #[inline(never)]
+    fn decode<'py>(&self, py: Python<'py>, raw: &[u8]) -> PyResult<Bound<'py, PyBytes>> {
+        let decoded = py
+            .detach(|| mail_parser::decode_part(raw))
+            .map_err(to_py_err)?;
+        let bytes = PyBytes::new(py, decoded.as_slice()).unbind();
+
+        Ok(self.content.get_or_init(|| bytes).bind(py).clone())
+    }
+}
+
+/// Build the two deferred node types from one core tree.
+///
+/// Two `#[inline(never)]` recursions rather than one generic, because the two
+/// differ in what they do with the body and in nothing else, and a generic over
+/// that would be two instantiations of the same code with an extra layer to read.
+/// Both are cold by construction: no flat path reaches either.
+#[inline(never)]
+fn metadata_node(py: Python<'_>, node: mail_parser::TreeNode) -> PyResult<PyMimePartMetadata> {
+    let children = node
+        .children
+        .into_iter()
+        .map(|child| Py::new(py, metadata_node(py, child)?))
+        .collect::<PyResult<Vec<_>>>()?;
+
+    Ok(PyMimePartMetadata {
+        content_type: node.content_type,
+        headers: node.headers,
+        filename: node.filename,
+        content_id: node.content_id,
+        disposition: node.disposition,
+        is_message: node.is_message,
+        encoded_size: node.body.encoded_size(),
+        children,
+    })
+}
+
+#[inline(never)]
+fn lazy_node(py: Python<'_>, node: mail_parser::TreeNode) -> PyResult<PyLazyMimePart> {
+    let children = node
+        .children
+        .into_iter()
+        .map(|child| Py::new(py, lazy_node(py, child)?))
+        .collect::<PyResult<Vec<_>>>()?;
+
+    // A `message/rfc822` body was decoded to reach the children below it, so it
+    // arrives already decoded and is published rather than thrown away: the cell
+    // is filled here and `is_decoded` is true from the start.
+    let (encoded_size, raw, content) = match node.body {
+        mail_parser::NodeBody::Container => (None, None, OnceLock::new()),
+        mail_parser::NodeBody::Undecoded { encoded_size, raw } => {
+            (Some(encoded_size), raw, OnceLock::new())
+        }
+        mail_parser::NodeBody::Decoded {
+            encoded_size,
+            content,
+        } => {
+            let cell = OnceLock::new();
+            let bytes = PyBytes::new(py, content.as_slice()).unbind();
+            let _ = cell.set(bytes);
+            (Some(encoded_size), None, cell)
+        }
+    };
+
+    Ok(PyLazyMimePart {
+        content_type: node.content_type,
+        headers: node.headers,
+        filename: node.filename,
+        content_id: node.content_id,
+        disposition: node.disposition,
+        is_message: node.is_message,
+        encoded_size,
+        raw,
+        content,
+        children,
+    })
+}
+
 /// One lossy repair a parse performed, reported rather than raised (#100).
 ///
 /// Read-only, three `str` fields, no interior mutability -- the same shape as
@@ -1175,21 +1423,94 @@ fn parse_email_inner(py: Python<'_>, payload: Py<PyAny>) -> PyResult<PyMail> {
 /// Warnings ride along per message on each `PyMail.warnings`; `strict=True`
 /// turns a lossy parse into that slot's error, exactly as it turns one into a
 /// raise for `parse_email`, so the two APIs agree on what "strict" means.
+///
+/// `mode=` takes the same three values `parse_email` takes and means the same
+/// things, so each slot holds a `PyMail`, a `PyLazyMail` or a `PyMailMetadata`.
+/// The mode is uniform across the batch -- it picks the slot type through the
+/// stub's overloads, which is only sound because one call cannot mix them.
+/// `strict=True` with `mode="metadata"` raises `ValueError`, exactly as it does
+/// on `parse_email`, and for the same reason: that mode never reads the bodies.
 #[pyfunction]
-#[pyo3(signature = (payloads, *, threads = None, raise_on_error = false, strict = false))]
+#[pyo3(signature = (
+    payloads, *, mode = "full", threads = None, raise_on_error = false, strict = false
+))]
 pub fn parse_many(
     py: Python<'_>,
     payloads: Vec<Py<PyAny>>,
+    mode: &str,
     threads: Option<usize>,
     raise_on_error: bool,
     strict: bool,
 ) -> PyResult<Py<PyList>> {
+    // `mode` is answered first and then forgotten, so everything below this line
+    // is byte-for-byte the revision before the mode existed -- the pattern #100,
+    // #99 and #180 each arrived at the hard way, and the reason `parse_email`
+    // reads the way it does.
+    if mode != "full" {
+        return parse_many_other_mode(py, payloads, mode, threads, raise_on_error, strict);
+    }
+
     // A panic fails the whole batch rather than one slot, unlike a parse error.
     // Per-item isolation would need the panic to ride in the core's error type,
     // and `MailParseError::Generic` holds a `&'static str`, so a payload cannot
     // travel that way -- worth revisiting only if a panic is ever actually seen.
     let inner = || parse_many_inner(py, payloads, threads, raise_on_error, strict);
     catch_panics(inner)
+}
+
+/// One `catch_panics` call site for both non-default batch modes, as
+/// `parse_email_other_mode` is for the flat ones (#99).
+#[inline(never)]
+fn parse_many_other_mode(
+    py: Python<'_>,
+    payloads: Vec<Py<PyAny>>,
+    mode: &str,
+    threads: Option<usize>,
+    raise_on_error: bool,
+    strict: bool,
+) -> PyResult<Py<PyList>> {
+    let lazy = match mode {
+        "lazy" => true,
+        "metadata" => {
+            // The same rejection, with the same message, as `parse_email`. A
+            // batch of metadata cannot promise more about the bodies than one
+            // message of it can.
+            if strict {
+                return Err(strict_needs_decoded_bodies());
+            }
+            false
+        }
+        other => return Err(unknown_mode(other)),
+    };
+
+    catch_panics(|| {
+        if lazy {
+            return parse_many_lazy(py, payloads, threads, raise_on_error, strict);
+        }
+        parse_many_metadata(py, payloads, threads, raise_on_error)
+    })
+}
+
+/// Turn the `threads` argument into a worker cap, rejecting zero.
+///
+/// `threads=0` is meaningless, and silently treating it as "the default" hides a
+/// caller bug: `threads=os.cpu_count() - 1` on a one-core machine, or an unset
+/// config value, would quietly get full parallelism instead. Reject it and let
+/// `None` be the way to ask for the default. `threads` is unsigned, so a negative
+/// value already raises OverflowError at conversion.
+///
+/// Out of line and shared by all three modes rather than written three times: the
+/// message is part of the API, and three copies of it are three chances for them
+/// to stop agreeing. `#[inline(never)]` for the usual reason in this module --
+/// the error construction is cold and belongs nowhere near a caller's body.
+#[inline(never)]
+fn resolve_workers(threads: Option<usize>) -> PyResult<Option<NonZeroUsize>> {
+    match threads {
+        Some(0) => Err(exceptions::PyValueError::new_err(
+            "threads must be at least 1; pass threads=None for the default",
+        )),
+        other => Ok(other.and_then(NonZeroUsize::new)),
+    }
 }
 
 fn parse_many_inner(
@@ -1208,19 +1529,7 @@ fn parse_many_inner(
         .map(|payload| payload_to_bytes(payload, py))
         .collect::<PyResult<_>>()?;
 
-    // `threads=0` is meaningless, and silently treating it as "the default"
-    // hides a caller bug: `threads=os.cpu_count() - 1` on a one-core machine, or
-    // an unset config value, would quietly get full parallelism instead. Reject
-    // it and let `None` be the way to ask for the default. `threads` is unsigned,
-    // so a negative value already raises OverflowError at conversion.
-    let workers = match threads {
-        Some(0) => {
-            return Err(exceptions::PyValueError::new_err(
-                "threads must be at least 1; pass threads=None for the default",
-            ));
-        }
-        other => other.and_then(NonZeroUsize::new),
-    };
+    let workers = resolve_workers(threads)?;
 
     // The whole batch parses with the GIL released, so other Python threads keep
     // running for its full duration rather than per message.
@@ -1256,6 +1565,110 @@ fn parse_many_inner(
     Ok(items.unbind())
 }
 
+/// `parse_many(..., mode="metadata")`: headers and an attachment inventory per
+/// message, decoding nothing (#202).
+///
+/// The mailbox sweep the mode was built for. #96 measured the batch API at ~12x
+/// on 2000 small messages, and #97 measured metadata mode at ~4x on an
+/// attachment-heavy one; before this a caller had to pick one of the two.
+///
+/// No `strict`: rejected at the boundary above, as on `parse_email`.
+///
+/// `#[inline(never)]`, like every other cold binding function in this module.
+#[inline(never)]
+fn parse_many_metadata(
+    py: Python<'_>,
+    payloads: Vec<Py<PyAny>>,
+    threads: Option<usize>,
+    raise_on_error: bool,
+) -> PyResult<Py<PyList>> {
+    // Borrowed, not copied, exactly as in full mode (#96).
+    let messages: Vec<Payload> = payloads
+        .iter()
+        .map(|payload| payload_to_bytes(payload, py))
+        .collect::<PyResult<_>>()?;
+
+    let workers = resolve_workers(threads)?;
+
+    let parsed = py.detach(|| {
+        mail_parser::parse_many_as(&messages, workers, mail_parser::parse_email_metadata)
+    });
+
+    let items = PyList::empty(py);
+    for result in parsed {
+        match result {
+            Ok(metadata) => {
+                items.append(Py::new(py, PyMailMetadata::from_metadata(metadata))?)?;
+            }
+            Err(error) => {
+                let err = to_py_err(error);
+                if raise_on_error {
+                    return Err(err);
+                }
+                items.append(err.value(py))?;
+            }
+        }
+    }
+    Ok(items.unbind())
+}
+
+/// `parse_many(..., mode="lazy")`: bodies decoded, attachments deferred (#202).
+///
+/// `strict=True` means here what it means everywhere else, and is honoured
+/// per slot the way full mode honours it: lazy mode finds every repair the full
+/// parse finds, so the verdict is the same verdict.
+///
+/// Worth a caution the single-message mode does not need: this retains the
+/// encoded bytes of every attachment in the *whole batch* until the batch is
+/// dropped, which is the opposite of what the mode saves on one message. Use it
+/// to sweep a batch and pull a few parts out of it, not to hold ten thousand
+/// messages' attachments undecoded.
+#[inline(never)]
+fn parse_many_lazy(
+    py: Python<'_>,
+    payloads: Vec<Py<PyAny>>,
+    threads: Option<usize>,
+    raise_on_error: bool,
+    strict: bool,
+) -> PyResult<Py<PyList>> {
+    let messages: Vec<Payload> = payloads
+        .iter()
+        .map(|payload| payload_to_bytes(payload, py))
+        .collect::<PyResult<_>>()?;
+
+    let workers = resolve_workers(threads)?;
+
+    let parsed =
+        py.detach(|| mail_parser::parse_many_as(&messages, workers, mail_parser::parse_email_lazy));
+
+    let items = PyList::empty(py);
+    for result in parsed {
+        // Folded into one `Err` arm as in full mode: one notion of "this slot
+        // failed", two ways to reach it.
+        let outcome = match result {
+            Ok(mail) => {
+                let mail = PyLazyMail::from_lazy(py, mail)?;
+                if strict && !mail.warnings.is_empty() {
+                    Err(strict_rejection(&mail.warnings))
+                } else {
+                    Ok(mail)
+                }
+            }
+            Err(error) => Err(to_py_err(error)),
+        };
+        match outcome {
+            Ok(mail) => items.append(Py::new(py, mail)?)?,
+            Err(err) => {
+                if raise_on_error {
+                    return Err(err);
+                }
+                items.append(err.value(py))?;
+            }
+        }
+    }
+    Ok(items.unbind())
+}
+
 /// Parse a message into its MIME tree, structure intact.
 ///
 /// Additive: `parse_email` is untouched. Accepts the same `str`/`bytes` payloads
@@ -1269,9 +1682,54 @@ fn parse_many_inner(
 /// message. A tree-shaped channel is also the one that should carry real MIME
 /// coordinates, which this traversal has for free and the flat one does not --
 /// see `ParseWarning.part_path`. Both are one decision, and not this one.
+///
+/// `mode="lazy"` returns a [`PyLazyMimePart`] tree, whose leaves decode on first
+/// access -- walk a large message, decode the one part you want.
+/// `mode="metadata"` returns a [`PyMimePartMetadata`] tree, which decodes nothing
+/// and retains nothing. The shape is identical in all three modes; the modes
+/// differ only in what a leaf's bytes cost.
 #[pyfunction]
-pub fn parse_email_tree(py: Python<'_>, payload: Py<PyAny>) -> PyResult<PyMimePart> {
-    catch_panics(|| parse_email_tree_inner(py, payload))
+#[pyo3(signature = (payload, *, mode = "full"))]
+pub fn parse_email_tree(py: Python<'_>, payload: Py<PyAny>, mode: &str) -> PyResult<Py<PyAny>> {
+    // `mode` is answered here and then forgotten, and the default arm is one
+    // comparison followed by the call this function has always made. Same shape
+    // as `parse_email` and for the same measured reason: in this crate a match
+    // with a `format!` arm, inlined into the closure `catch_panics` inlines, has
+    // cost the parse path 30% while never executing.
+    if mode == "full" {
+        return catch_panics(|| Ok(Py::new(py, parse_email_tree_inner(py, payload)?)?.into_any()));
+    }
+
+    parse_email_tree_other_mode(py, payload, mode)
+}
+
+/// One `catch_panics` call site for both deferred tree modes, as
+/// `parse_email_other_mode` is for the flat ones -- #99 is the record of a third
+/// instantiation of that generic costing the hot path 24% while never running.
+#[inline(never)]
+fn parse_email_tree_other_mode(
+    py: Python<'_>,
+    payload: Py<PyAny>,
+    mode: &str,
+) -> PyResult<Py<PyAny>> {
+    let defer = match mode {
+        "lazy" => true,
+        "metadata" => false,
+        other => return Err(unknown_mode(other)),
+    };
+
+    catch_panics(|| {
+        let message = payload_to_bytes(&payload, py)?;
+
+        let tree = py
+            .detach(|| mail_parser::parse_tree_deferred(message.as_ref(), defer))
+            .map_err(to_py_err)?;
+
+        if defer {
+            return Ok(Py::new(py, lazy_node(py, tree)?)?.into_any());
+        }
+        Ok(Py::new(py, metadata_node(py, tree)?)?.into_any())
+    })
 }
 
 #[inline(never)]
@@ -1311,6 +1769,8 @@ fn fast_mail_parser(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyLazyMail>()?;
     m.add_class::<PyMailMetadata>()?;
     m.add_class::<PyMimePart>()?;
+    m.add_class::<PyLazyMimePart>()?;
+    m.add_class::<PyMimePartMetadata>()?;
     m.add_class::<PyAttachment>()?;
     m.add_class::<PyLazyAttachment>()?;
     m.add_class::<PyAttachmentMetadata>()?;

--- a/src/mail_parser.rs
+++ b/src/mail_parser.rs
@@ -323,10 +323,37 @@ pub(crate) fn parse_email(payload: &[u8]) -> Result<Mail, MailParseError> {
 ///
 /// `threads` caps the worker count; `None` uses the machine's parallelism.
 /// Callers with a batch smaller than the thread count do not spawn idle workers.
+///
+/// The batching itself lives in [`parse_many_as`], which the other modes reuse;
+/// this is the full-mode call into it (#202).
 pub(crate) fn parse_many<P: AsRef<[u8]> + Sync>(
     payloads: &[P],
     threads: Option<NonZeroUsize>,
 ) -> Vec<Result<Mail, MailParseError>> {
+    parse_many_as(payloads, threads, Mail::new)
+}
+
+/// The scheduler above, with the per-message parse as a parameter (#202).
+///
+/// `mode=` on `parse_many` needs the identical batching for three different
+/// result types, and the batching is the part worth not having two copies of:
+/// the dynamic cursor and the order restoration are where a bug would be subtle,
+/// while the per-message parse is a single call. So the modes vary the call and
+/// share everything around it.
+///
+/// A `fn` pointer rather than `impl Fn`, so the number of instantiations is the
+/// number of result types and not also the number of call sites. Each of the
+/// three parse functions is a plain `fn` item, and the indirect call happens once
+/// per message around a whole parse.
+pub(crate) fn parse_many_as<P, T>(
+    payloads: &[P],
+    threads: Option<NonZeroUsize>,
+    parse: fn(&[u8]) -> Result<T, MailParseError>,
+) -> Vec<Result<T, MailParseError>>
+where
+    P: AsRef<[u8]> + Sync,
+    T: Send,
+{
     if payloads.is_empty() {
         return Vec::new();
     }
@@ -340,12 +367,12 @@ pub(crate) fn parse_many<P: AsRef<[u8]> + Sync>(
     if workers == 1 {
         return payloads
             .iter()
-            .map(|payload| Mail::new(payload.as_ref()))
+            .map(|payload| parse(payload.as_ref()))
             .collect();
     }
 
     let cursor = AtomicUsize::new(0);
-    let collected: Vec<Vec<(usize, Result<Mail, MailParseError>)>> = thread::scope(|scope| {
+    let collected: Vec<Vec<(usize, Result<T, MailParseError>)>> = thread::scope(|scope| {
         let handles: Vec<_> = (0..workers)
             .map(|_| {
                 scope.spawn(|| {
@@ -358,7 +385,7 @@ pub(crate) fn parse_many<P: AsRef<[u8]> + Sync>(
                         if index >= payloads.len() {
                             break;
                         }
-                        mine.push((index, Mail::new(payloads[index].as_ref())));
+                        mine.push((index, parse(payloads[index].as_ref())));
                     }
                     mine
                 })
@@ -379,7 +406,7 @@ pub(crate) fn parse_many<P: AsRef<[u8]> + Sync>(
     });
 
     // Restore input order. Slots are filled exactly once, so no gaps.
-    let mut ordered: Vec<Option<Result<Mail, MailParseError>>> =
+    let mut ordered: Vec<Option<Result<T, MailParseError>>> =
         (0..payloads.len()).map(|_| None).collect();
     for (index, result) in collected.into_iter().flatten() {
         ordered[index] = Some(result);
@@ -942,6 +969,166 @@ pub(crate) fn parse_email_tree(payload: &[u8]) -> Result<MimePart, MailParseErro
     // message whose header block was never terminated (#150).
     let repaired = repair_missing_separator(payload);
     MimePart::build(&parse_mail(repaired.as_deref().unwrap_or(payload))?, 0)
+}
+
+/// What a tree node carries where full mode carries decoded bytes (#202).
+///
+/// One enum rather than a second and third node struct: the three cases below are
+/// what `mode=` varies about a tree node, and everything else about a node --
+/// content type, headers, filename, content id, disposition, children -- is the
+/// same in all three modes and is derived by the same code. Splitting the struct
+/// would have split that derivation too, which is the thing the modes must not
+/// disagree about.
+#[derive(Debug)]
+pub(crate) enum NodeBody {
+    /// A `multipart/*` container. Its body is its children with boundaries
+    /// between them, so it has none of its own -- the same statement full mode
+    /// makes by setting `content` to `None`.
+    Container,
+    /// A leaf's body, not decoded: its size on the wire, and `raw` set to the
+    /// part exactly as it sits in the message when the mode intends to decode it
+    /// later. `raw` is mailparse's `raw_bytes` for this part, which is what makes
+    /// a later `decode_part` reproduce full mode's `content` -- the same
+    /// mechanism, and the same claim, as flat lazy mode (#97). Metadata mode
+    /// leaves it `None` and keeps only the size.
+    Undecoded {
+        encoded_size: usize,
+        raw: Option<Vec<u8>>,
+    },
+    /// Decoded during the walk, because the structure below it needed it.
+    ///
+    /// Only `message/rfc822`. Its body *is* the embedded message, so parsing it
+    /// is what gives the node children at all -- and deferring the decode would
+    /// mean deferring the structure, which is the one thing every mode of a tree
+    /// API has to deliver eagerly. The bytes are already in hand by then, so they
+    /// are published rather than dropped and decoded again.
+    Decoded {
+        encoded_size: usize,
+        content: Vec<u8>,
+    },
+}
+
+impl NodeBody {
+    /// Bytes this body occupies before transfer-decoding, or `None` for a
+    /// container -- which has no body of its own.
+    pub(crate) fn encoded_size(&self) -> Option<usize> {
+        match self {
+            NodeBody::Container => None,
+            NodeBody::Undecoded { encoded_size, .. } | NodeBody::Decoded { encoded_size, .. } => {
+                Some(*encoded_size)
+            }
+        }
+    }
+}
+
+/// One node of the MIME tree with its body undecoded or merely described (#202).
+///
+/// Deliberately not `MimePart` with a wider `content`. `MimePart.content` is
+/// `Option<Vec<u8>>` and its `None` *means* "this is a container"; a mode where
+/// `None` could also mean "not decoded yet" would make the two
+/// indistinguishable, which is the silent-wrong-answer shape this crate has
+/// rejected twice already (#150, and metadata mode's absent `text_plain`).
+#[derive(Debug)]
+pub(crate) struct TreeNode {
+    pub(crate) content_type: String,
+    pub(crate) headers: Vec<(String, Vec<String>)>,
+    pub(crate) filename: String,
+    pub(crate) content_id: Option<String>,
+    pub(crate) disposition: Option<String>,
+    pub(crate) is_message: bool,
+    pub(crate) body: NodeBody,
+    pub(crate) children: Vec<TreeNode>,
+}
+
+/// Parse a message into its MIME tree without decoding the leaves (#202).
+///
+/// `defer` picks what a leaf keeps: a copy of the part, to decode on demand
+/// (`mode="lazy"`), or only the size its body occupies on the wire
+/// (`mode="metadata"`). The traversal, the classification and the caps are the
+/// same either way, which is what keeps the two modes agreeing with each other
+/// and with full mode about the shape of a message.
+///
+/// Unlike flat metadata mode this can still raise a decode failure, for one
+/// reason: a `message/rfc822` body has to be decoded before the message inside
+/// it can be parsed, and a tree that dropped those children in one mode would
+/// not be the same tree. Nothing else is decoded.
+pub(crate) fn parse_tree_deferred(payload: &[u8], defer: bool) -> Result<TreeNode, MailParseError> {
+    if payload.len() > MAX_INPUT_BYTES {
+        return Err(MailParseError::Generic(ERR_INPUT_TOO_LARGE));
+    }
+
+    // The same repair as every other entry point, so no two views of a message
+    // whose header block was never terminated can disagree about it (#150).
+    let repaired = repair_missing_separator(payload);
+    build_node(
+        &parse_mail(repaired.as_deref().unwrap_or(payload))?,
+        0,
+        defer,
+    )
+}
+
+/// `#[inline(never)]`, like `MimePart::build`: it recurses, it returns a large
+/// struct, and no hot path reaches it.
+#[inline(never)]
+fn build_node(
+    part: &ParsedMail<'_>,
+    depth: usize,
+    defer: bool,
+) -> Result<TreeNode, MailParseError> {
+    if depth >= MAX_MIME_DEPTH {
+        return Err(MailParseError::Generic(ERR_MIME_DEPTH));
+    }
+
+    let mime = part.ctype.mimetype.as_str();
+    let disposition = part.get_content_disposition();
+
+    let (body, children) = if mime.starts_with("multipart/") {
+        let children = part
+            .subparts
+            .iter()
+            .map(|child| build_node(child, depth + 1, defer))
+            .collect::<Result<Vec<_>, _>>()?;
+        (NodeBody::Container, children)
+    } else if mime == "message/rfc822" {
+        // Decoded here for the reason recorded on `NodeBody::Decoded`: the
+        // embedded message is this body, and it is the child.
+        let raw = part.get_body_raw()?;
+        let inner = {
+            let repaired = repair_missing_separator(&raw);
+            let parsed = parse_mail(repaired.as_deref().unwrap_or(raw.as_slice()))?;
+            build_node(&parsed, depth + 1, defer)?
+        };
+        let body = NodeBody::Decoded {
+            encoded_size: encoded_size(part),
+            content: raw,
+        };
+        (body, vec![inner])
+    } else {
+        let body = NodeBody::Undecoded {
+            encoded_size: encoded_size(part),
+            // The one copy lazy mode makes, and the encoded part rather than the
+            // decoded one. For the root of a single-part message that is the
+            // whole payload, since mailparse's `raw_bytes` for a root is the
+            // message -- see the note in the binding layer. Metadata mode keeps
+            // nothing.
+            raw: defer.then(|| part.raw_bytes.to_vec()),
+        };
+        (body, Vec::new())
+    };
+
+    Ok(TreeNode {
+        content_type: mime.to_string(),
+        headers: collect_headers(part),
+        filename: part_filename(&disposition, &part.ctype),
+        content_id: part
+            .get_headers()
+            .get_first_value("Content-ID")
+            .map(|raw| normalize_content_id(&raw)),
+        disposition: disposition_token(part, &disposition.disposition),
+        is_message: mime == "message/rfc822",
+        body,
+        children,
+    })
 }
 
 /// Month tokens `mailparse::dateparse` accepts.

--- a/tests/benchmark/test_read_message.py
+++ b/tests/benchmark/test_read_message.py
@@ -326,3 +326,81 @@ def test__fast_mail_parser___parse_lazy_all_attachments(large_message: str, benc
         return [len(attachment.content) for attachment in mail.attachments]
 
     benchmark(read_everything)
+
+
+def test__fast_mail_parser___parse_tree_metadata(large_message: str, benchmark: Callable):
+    # #202's tree metadata mode against `test__fast_mail_parser___parse_tree` in
+    # the same run: the same walk, the same node per part, and no leaf decoded.
+    # On this fixture -- 99% attachment by decoded content -- that is nearly all
+    # of the tree's work.
+    #
+    # Guarded, as the gate's documentation requires: the gate measures THIS
+    # revision's benchmarks against the BASE revision's build (#168), so a base
+    # predating this argument raises TypeError here instead of skipping and takes
+    # the whole gate down with it.
+    import pytest
+
+    from fast_mail_parser import parse_email_tree
+
+    payload = large_message.encode()
+
+    try:
+        parse_email_tree(payload, mode="metadata")
+    except (TypeError, ValueError):
+        pytest.skip('this build predates parse_email_tree(mode="metadata")')
+
+    benchmark(lambda: parse_email_tree(payload, mode="metadata"))
+
+
+def test__fast_mail_parser___parse_tree_lazy_untouched(large_message: str, benchmark: Callable):
+    # The other deferred tree mode with nothing read. It retains a copy of every
+    # leaf where metadata mode retains nothing, so the gap between this and the
+    # benchmark above is the price of being able to decode one part later.
+    import pytest
+
+    from fast_mail_parser import parse_email_tree
+
+    payload = large_message.encode()
+
+    try:
+        parse_email_tree(payload, mode="lazy")
+    except (TypeError, ValueError):
+        pytest.skip('this build predates parse_email_tree(mode="lazy")')
+
+    benchmark(lambda: parse_email_tree(payload, mode="lazy"))
+
+
+def test__fast_mail_parser___parse_many_metadata(large_message: str, benchmark: Callable):
+    # #202's headline case: the batch API and metadata mode composed. Compare with
+    # `test__fast_mail_parser___parse_many` in the same run -- same batch, same
+    # single worker, so the difference is the mode and nothing else.
+    import pytest
+
+    from fast_mail_parser import parse_many
+
+    batch = [large_message.encode()] * 8
+
+    try:
+        parse_many(batch[:1], mode="metadata")
+    except (TypeError, ValueError):
+        pytest.skip('this build predates parse_many(mode="metadata")')
+
+    benchmark(lambda: parse_many(batch, threads=1, mode="metadata"))
+
+
+def test__threaded___parse_many_metadata_small(benchmark: Callable):
+    # The mailbox sweep the mode was built for, at the size where the batch API's
+    # own saving lives (#96: 2000 x ~0.8 KiB). Informational, like its siblings:
+    # thread scheduling moves these more than a code change would.
+    import pytest
+
+    from fast_mail_parser import parse_many
+
+    batch = [_small_message()] * SMALL_BATCH
+
+    try:
+        parse_many(batch[:1], mode="metadata")
+    except (TypeError, ValueError):
+        pytest.skip('this build predates parse_many(mode="metadata")')
+
+    benchmark(lambda: parse_many(batch, mode="metadata"))

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -12,7 +12,10 @@ parse-warnings channel (#100) -- purely additive, so nothing an existing
 consumer reads changed name or type. `PyLazyMail`/`PyLazyAttachment` (#97) were
 added the same way, and are new types rather than changes to these ones for
 exactly that reason: `PyAttachment.content` still costs what it always cost and
-still raises where it always raised.
+still raises where it always raised. `PyLazyMimePart`/`PyMimePartMetadata` (#202)
+extend that pattern to the tree, for the same reason: `PyMimePart.content` is
+still a value rather than a decode, and its `None` still means "container" and
+nothing else.
 
 A failure here means a consumer-visible change. Treat it as a deliberate API
 break (update consumers, bump the version) — do not loosen the test to make it
@@ -38,6 +41,8 @@ EXPECTED_EXPORTS = {
     "PyLazyMail",
     "PyMailMetadata",
     "PyMimePart",
+    "PyLazyMimePart",
+    "PyMimePartMetadata",
     "PyAttachment",
     "PyLazyAttachment",
     "PyAttachmentMetadata",

--- a/tests/test_parse_many.py
+++ b/tests/test_parse_many.py
@@ -16,7 +16,15 @@ import time
 
 import pytest
 
-from fast_mail_parser import DecodeError, ParseError, PyMail, parse_email, parse_many
+from fast_mail_parser import (
+    DecodeError,
+    ParseError,
+    PyLazyMail,
+    PyMail,
+    PyMailMetadata,
+    parse_email,
+    parse_many,
+)
 
 
 def _message(subject: str) -> bytes:
@@ -287,3 +295,186 @@ def test__threads_and_raise_on_error_are_keyword_only():
     # Positional booleans at a call site read poorly, so they are keyword-only.
     with pytest.raises(TypeError):
         parse_many([_message("x")], 2)
+
+
+# --- mode= (#202) -------------------------------------------------------------
+#
+# The batch API and the mode axis were the two halves of the same saving and did
+# not compose: a caller who wanted headers for ten thousand messages had to pick
+# one. What has to hold is that a batch in a mode is exactly a loop of
+# `parse_email` in that mode -- the batching must not change what a message
+# parses to -- plus that the combinations which cannot mean anything are refused
+# rather than silently weakened.
+
+
+def _metadata_view(mail: PyMailMetadata) -> dict:
+    return {
+        "subject": mail.subject,
+        "date": mail.date,
+        "attachments": [
+            (a.mimetype, a.filename, a.encoded_size, a.content_id, a.disposition)
+            for a in mail.attachments
+        ],
+        "headers": {key: list(values) for key, values in mail.headers.items()},
+    }
+
+
+def _lazy_view(mail: PyLazyMail) -> dict:
+    return {
+        "subject": mail.subject,
+        "date": mail.date,
+        "text_plain": list(mail.text_plain),
+        "text_html": list(mail.text_html),
+        "attachments": [
+            (a.mimetype, a.filename, a.encoded_size, a.content)
+            for a in mail.attachments
+        ],
+        "headers": {key: list(values) for key, values in mail.headers.items()},
+        "warnings": [(w.kind, w.part_path) for w in mail.warnings],
+    }
+
+
+def test__the_default_mode_is_unchanged():
+    results = parse_many([_message("a")])
+
+    assert isinstance(results[0], PyMail)
+    assert isinstance(parse_many([_message("a")], mode="full")[0], PyMail)
+
+
+def test__metadata_mode_returns_metadata_per_slot():
+    results = parse_many([_message("a"), _message("b")], mode="metadata")
+
+    assert all(isinstance(result, PyMailMetadata) for result in results)
+    assert [result.subject for result in results] == ["a", "b"]
+
+
+def test__lazy_mode_returns_lazy_mail_per_slot():
+    results = parse_many([_message("a"), _message("b")], mode="lazy")
+
+    assert all(isinstance(result, PyLazyMail) for result in results)
+    assert [result.subject for result in results] == ["a", "b"]
+
+
+def test__metadata_batch_matches_the_single_parse_across_the_corpus():
+    payloads = [open(path, "rb").read() for path in CORPUS]
+
+    batch = parse_many(payloads, mode="metadata")
+
+    for path, payload, batched in zip(CORPUS, payloads, batch, strict=True):
+        assert _metadata_view(batched) == _metadata_view(
+            parse_email(payload, mode="metadata")
+        ), f"batch and single parse disagree on {os.path.basename(path)}"
+
+
+def test__lazy_batch_matches_the_single_parse_across_the_corpus():
+    payloads = [open(path, "rb").read() for path in CORPUS]
+
+    batch = parse_many(payloads, mode="lazy")
+
+    for path, payload, batched in zip(CORPUS, payloads, batch, strict=True):
+        assert _lazy_view(batched) == _lazy_view(
+            parse_email(payload, mode="lazy")
+        ), f"batch and single parse disagree on {os.path.basename(path)}"
+
+
+@pytest.mark.parametrize("mode", ["full", "lazy", "metadata"])
+def test__order_is_preserved_in_every_mode(mode: str):
+    payloads = [_message(f"msg-{i:03d}") for i in range(50)]
+
+    results = parse_many(payloads, mode=mode)
+
+    assert [r.subject for r in results] == [f"msg-{i:03d}" for i in range(50)]
+
+
+@pytest.mark.parametrize("mode", ["full", "lazy", "metadata"])
+def test__threads_still_caps_the_workers_in_every_mode(mode: str):
+    payloads = [_message(f"m{i}") for i in range(20)]
+
+    assert [r.subject for r in parse_many(payloads, mode=mode, threads=1)] == [
+        f"m{i}" for i in range(20)
+    ]
+
+
+@pytest.mark.parametrize("mode", ["lazy", "metadata"])
+def test__threads_zero_is_rejected_in_every_mode(mode: str):
+    with pytest.raises(ValueError, match="threads must be at least 1"):
+        parse_many([_message("x")], mode=mode, threads=0)
+
+
+@pytest.mark.parametrize("mode", ["full", "lazy", "metadata"])
+def test__an_empty_batch_is_empty_in_every_mode(mode: str):
+    assert parse_many([], mode=mode) == []
+
+
+def test__a_broken_message_occupies_its_slot_in_lazy_mode():
+    # Lazy mode defers the *attachments*, so a broken body still fails the parse
+    # and lands in the slot as an error instance -- exactly as in full mode.
+    results = parse_many([_message("ok"), BROKEN], mode="lazy")
+
+    assert isinstance(results[0], PyLazyMail)
+    assert isinstance(results[1], DecodeError)
+
+
+def test__metadata_mode_never_reaches_a_decode_failure():
+    # It does not decode, so the message that fails full mode parses here. The
+    # difference is the mode's, not the batch's.
+    results = parse_many([_message("ok"), BROKEN], mode="metadata")
+
+    assert all(isinstance(result, PyMailMetadata) for result in results)
+
+
+@pytest.mark.parametrize("mode", ["lazy", "metadata"])
+def test__raise_on_error_still_raises_in_every_mode(mode: str):
+    unparseable = b" unexpected continuation\r\n\r\nbody"
+
+    with pytest.raises(ParseError):
+        parse_many([_message("ok"), unparseable], mode=mode, raise_on_error=True)
+
+
+def test__strict_applies_per_slot_in_lazy_mode():
+    # Lazy mode finds every repair full mode finds, so the verdict is the same
+    # verdict -- see test_lazy_mode.py. Here it must also be reached per slot.
+    bad_date = b"Subject: s\r\nDate: not a date\r\n\r\nbody"
+
+    results = parse_many([_message("clean"), bad_date], mode="lazy", strict=True)
+
+    assert isinstance(results[0], PyLazyMail)
+    assert isinstance(results[1], ParseError)
+
+
+def test__strict_with_metadata_mode_is_rejected():
+    # The same refusal, with the same message, as parse_email: a mode that never
+    # reads the bodies cannot promise that nothing in them was repaired. Raised
+    # rather than quietly ignored, and raised before any parsing happens.
+    with pytest.raises(ValueError, match="strict=True needs"):
+        parse_many([_message("x")], mode="metadata", strict=True)
+
+
+def test__an_unknown_mode_is_rejected():
+    with pytest.raises(ValueError, match='"full", "lazy" or "metadata"'):
+        parse_many([_message("x")], mode="sweep")
+
+
+def test__mode_is_keyword_only():
+    with pytest.raises(TypeError):
+        parse_many([_message("x")], "metadata")
+
+
+@pytest.mark.parametrize("mode", ["lazy", "metadata"])
+def test__a_non_payload_entry_still_raises_type_error(mode: str):
+    with pytest.raises(TypeError):
+        parse_many([_message("ok"), 123], mode=mode)
+
+
+def test__a_lazy_batch_defers_every_attachment(attachment_message: str):
+    payloads = [attachment_message.encode()] * 4
+
+    results = parse_many(payloads, mode="lazy")
+
+    attachments = [a for mail in results for a in mail.attachments]
+    assert attachments, "the fixture must carry attachments"
+    assert not any(a.is_decoded for a in attachments)
+
+    assert isinstance(attachments[0].content, bytes)
+    assert attachments[0].is_decoded
+    assert not any(a.is_decoded for a in attachments[1:])

--- a/tests/test_tree_modes.py
+++ b/tests/test_tree_modes.py
@@ -1,0 +1,487 @@
+"""`parse_email_tree(payload, mode=...)` (#202).
+
+The tree is where the modes are worth the most and where nothing had them: a
+`mode="full"` tree decodes every leaf, so walking the structure of a large
+message to pull one part out of it decoded all the others first.
+
+`mode="lazy"` returns `PyLazyMimePart` nodes whose `content` decodes on first
+access and caches. `mode="metadata"` returns `PyMimePartMetadata` nodes, which
+decode nothing and retain nothing and report `encoded_size` in place of
+`content`.
+
+Three things have to hold, and this file is organised as them.
+
+**The tree is the same tree in every mode.** Not "similar": the topology and every
+per-node field except the body must be equal across all three, over the whole
+corpus. A caller who switches mode to save work must not be switching what the
+message looks like. The `parse_agreement` fuzz target asserts the same on
+arbitrary input.
+
+**A leaf's bytes must equal full mode's.** Lazy mode retains each part exactly as
+it sits in the message and re-parses that copy on access, which reproduces full
+mode's `content` only if mailparse's `raw_bytes` really is that part -- including
+for a *root*, which flat lazy mode never exercises because it defers only
+subparts.
+
+**A leaf nobody reads must never be decoded.** `is_decoded` makes that an
+assertion rather than a timing argument.
+"""
+import glob
+import os
+
+import pytest
+
+from fast_mail_parser import (
+    DecodeError,
+    HeaderParseError,
+    MimeStructureError,
+    PyLazyMimePart,
+    PyMimePart,
+    PyMimePartMetadata,
+    parse_email,
+    parse_email_tree,
+    walk,
+)
+
+_DATA = os.path.join(os.path.dirname(__file__), "data")
+
+# The same corpus as test_mime_tree.py, and like it nothing is excluded --
+# invalid_message.eml included, since every mode applies the #150 repair and so
+# the three must agree about it too.
+FIXTURES = sorted(glob.glob(os.path.join(_DATA, "rfc", "*.eml"))) + sorted(
+    glob.glob(os.path.join(_DATA, "*.eml"))
+)
+IDS = [os.path.basename(path) for path in FIXTURES]
+
+MODES = ["lazy", "metadata"]
+
+EXPECTED_LAZY_NODE_ATTRS = {
+    "content_type",
+    "headers",
+    "filename",
+    "content_id",
+    "disposition",
+    "is_message",
+    "encoded_size",
+    "content",
+    "is_decoded",
+    "children",
+}
+EXPECTED_METADATA_NODE_ATTRS = {
+    "content_type",
+    "headers",
+    "filename",
+    "content_id",
+    "disposition",
+    "is_message",
+    "encoded_size",
+    "children",
+}
+
+MIXED = (
+    b"From: sender@example.com\r\n"
+    b"Subject: mixed\r\n"
+    b'Content-Type: multipart/mixed; boundary="bnd"\r\n'
+    b"\r\n"
+    b"--bnd\r\n"
+    b"Content-Type: text/plain\r\n"
+    b"\r\n"
+    b"plain version\r\n"
+    b"--bnd\r\n"
+    b"Content-Type: application/pdf\r\n"
+    b"Content-Transfer-Encoding: base64\r\n"
+    b'Content-Disposition: attachment; filename="a.pdf"\r\n'
+    b"Content-ID: <pdf@example.com>\r\n"
+    b"\r\n"
+    b"aGVsbG8gd29ybGQ=\r\n"
+    b"--bnd--\r\n"
+)
+
+SINGLE_PART = (
+    b"From: sender@example.com\r\n"
+    b"Subject: single\r\n"
+    b"Content-Type: text/plain; charset=utf-8\r\n"
+    b"Content-Transfer-Encoding: base64\r\n"
+    b"\r\n"
+    b"aGVsbG8gd29ybGQ=\r\n"
+)
+
+BROKEN_BASE64_BODY = (
+    b"Subject: broken\r\n"
+    b"Content-Type: text/plain; charset=utf-8\r\n"
+    b"Content-Transfer-Encoding: base64\r\n"
+    b"\r\n"
+    b"!!!! not base64 !!!!\r\n"
+)
+
+MALFORMED_HEADERS = b" unexpected continuation\r\n\r\nbody"
+
+ORIGINAL = (
+    b"From: alice@example.com\r\n"
+    b"To: nobody@example.invalid\r\n"
+    b"Subject: the original message\r\n"
+    b"Content-Type: text/plain\r\n"
+    b"\r\n"
+    b"hello\r\n"
+)
+
+
+def _bounce(inner: bytes) -> bytes:
+    return (
+        b"From: postmaster@example.com\r\n"
+        b"Subject: Delivery failure\r\n"
+        b'Content-Type: multipart/mixed; boundary="outer"\r\n'
+        b"\r\n"
+        b"--outer\r\n"
+        b"Content-Type: text/plain\r\n"
+        b"\r\n"
+        b"Your message could not be delivered.\r\n"
+        b"--outer\r\n"
+        b"Content-Type: message/rfc822\r\n"
+        b"\r\n" + inner + b"\r\n--outer--\r\n"
+    )
+
+
+def _shape(root) -> list[tuple]:
+    """Every per-node field except the body, in walk order."""
+    return [
+        (
+            part.content_type,
+            part.filename,
+            part.content_id,
+            part.disposition,
+            part.is_message,
+            part.headers,
+            len(part.children),
+        )
+        for part in walk(root)
+    ]
+
+
+# --- the tree is the same tree in every mode -----------------------------------
+
+
+@pytest.mark.parametrize("path", FIXTURES, ids=IDS)
+@pytest.mark.parametrize("mode", MODES)
+def test__the_shape_is_identical_to_full_mode(path: str, mode: str):
+    with open(path, "rb") as handle:
+        raw = handle.read()
+
+    assert _shape(parse_email_tree(raw, mode=mode)) == _shape(parse_email_tree(raw))
+
+
+@pytest.mark.parametrize("path", FIXTURES, ids=IDS)
+def test__a_leafs_bytes_are_identical_to_full_mode(path: str):
+    # The load-bearing one for the lazy tree. Note it covers a case flat lazy mode
+    # cannot: a single-part message's root is itself the leaf, so this asserts
+    # that mailparse's `raw_bytes` is the part for a *root* too.
+    with open(path, "rb") as handle:
+        raw = handle.read()
+
+    assert [part.content for part in walk(parse_email_tree(raw, mode="lazy"))] == [
+        part.content for part in walk(parse_email_tree(raw))
+    ]
+
+
+@pytest.mark.parametrize("path", FIXTURES, ids=IDS)
+def test__encoded_size_is_present_exactly_where_content_is(path: str):
+    # `None` means "container" in every mode, and only that. The two modes must
+    # agree with full mode about which nodes have a body of their own, or
+    # `encoded_size is None` would be a different question than
+    # `content is None`.
+    with open(path, "rb") as handle:
+        raw = handle.read()
+
+    full = [part.content is None for part in walk(parse_email_tree(raw))]
+    for mode in MODES:
+        described = [
+            part.encoded_size is None for part in walk(parse_email_tree(raw, mode=mode))
+        ]
+        assert described == full, mode
+
+
+@pytest.mark.parametrize("path", FIXTURES, ids=IDS)
+def test__the_two_deferred_modes_report_the_same_encoded_size(path: str):
+    with open(path, "rb") as handle:
+        raw = handle.read()
+
+    assert [
+        part.encoded_size for part in walk(parse_email_tree(raw, mode="lazy"))
+    ] == [part.encoded_size for part in walk(parse_email_tree(raw, mode="metadata"))]
+
+
+@pytest.mark.parametrize("path", FIXTURES, ids=IDS)
+def test__decoding_a_leaf_does_not_more_than_double_it(path: str):
+    # The bound the fuzz target settled on: quoted-printable emits a line break
+    # as CRLF, so a decode can grow a body -- but not past 2x. This is what makes
+    # `encoded_size` usable for "is this part worth decoding".
+    with open(path, "rb") as handle:
+        raw = handle.read()
+
+    for part in walk(parse_email_tree(raw, mode="lazy")):
+        if part.content is None:
+            continue
+        assert len(part.content) <= part.encoded_size * 2, part.content_type
+
+
+def test__the_full_mode_default_is_unchanged():
+    assert isinstance(parse_email_tree(MIXED), PyMimePart)
+    assert isinstance(parse_email_tree(MIXED, mode="full"), PyMimePart)
+
+
+def test__each_mode_returns_its_own_node_type():
+    assert isinstance(parse_email_tree(MIXED, mode="lazy"), PyLazyMimePart)
+    assert isinstance(parse_email_tree(MIXED, mode="metadata"), PyMimePartMetadata)
+
+
+@pytest.mark.parametrize("mode", MODES)
+def test__a_str_payload_gives_the_same_tree_as_its_bytes(mode: str):
+    from_bytes = parse_email_tree(MIXED, mode=mode)
+    from_str = parse_email_tree(MIXED.decode("ascii"), mode=mode)
+
+    assert _shape(from_str) == _shape(from_bytes)
+
+
+@pytest.mark.parametrize("mode", MODES)
+def test__walk_yields_the_new_node_types(mode: str):
+    parts = list(walk(parse_email_tree(_bounce(ORIGINAL), mode=mode)))
+
+    assert [part.content_type for part in parts] == [
+        "multipart/mixed",
+        "text/plain",
+        "message/rfc822",
+        "text/plain",
+    ]
+
+
+# --- laziness ------------------------------------------------------------------
+
+
+def test__nothing_a_leaf_carries_is_decoded_by_the_parse(large_message: str):
+    root = parse_email_tree(large_message.encode(), mode="lazy")
+
+    leaves = [part for part in walk(root) if part.encoded_size is not None]
+    assert leaves, "the fixture must have leaves"
+    assert not any(part.is_decoded for part in leaves)
+
+
+def test__a_container_is_decoded_from_the_start(large_message: str):
+    # Nothing to decode, so reading `content` is free and `is_decoded` says so.
+    root = parse_email_tree(large_message.encode(), mode="lazy")
+
+    containers = [part for part in walk(root) if part.encoded_size is None]
+    assert containers, "the fixture must have containers"
+    for part in containers:
+        assert part.is_decoded
+        assert part.content is None
+
+
+def test__only_the_leaf_read_is_decoded(large_message: str):
+    root = parse_email_tree(large_message.encode(), mode="lazy")
+    leaves = [part for part in walk(root) if part.encoded_size is not None]
+    assert len(leaves) > 1, "the fixture must have several leaves"
+
+    assert isinstance(leaves[0].content, bytes)
+
+    assert leaves[0].is_decoded
+    assert not any(part.is_decoded for part in leaves[1:])
+
+
+def test__repeated_access_returns_the_same_object():
+    leaf = list(walk(parse_email_tree(MIXED, mode="lazy")))[1]
+
+    assert leaf.content is leaf.content
+
+
+def test__the_children_attribute_hands_back_the_same_objects():
+    # Which is what makes the caches worth anything: a fresh object per read
+    # would mean a fresh cache per read.
+    root = parse_email_tree(MIXED, mode="lazy")
+
+    assert root.children[0] is root.children[0]
+
+
+def test__the_tree_outlives_the_payload():
+    # The parse copies each part rather than borrowing the caller's bytes, so
+    # dropping the payload cannot invalidate a deferred decode.
+    payload = bytearray(MIXED)
+    root = parse_email_tree(bytes(payload), mode="lazy")
+    del payload
+
+    assert list(walk(root))[1].content == b"plain version"
+
+
+def test__a_single_part_message_defers_its_root():
+    # The root is the leaf here, so there is no subpart to defer -- the whole
+    # payload is what gets retained and re-parsed.
+    root = parse_email_tree(SINGLE_PART, mode="lazy")
+
+    assert root.children == []
+    assert not root.is_decoded
+    assert root.content == b"hello world"
+    assert root.is_decoded
+
+
+# --- embedded messages ---------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", MODES)
+def test__an_embedded_message_is_still_parsed_not_opaque(mode: str):
+    # The tree's whole reason to exist for bounce processing, so it cannot be a
+    # casualty of not decoding: a `message/rfc822` body *is* the embedded
+    # message, and parsing it is what gives the node children.
+    root = parse_email_tree(_bounce(ORIGINAL), mode=mode)
+
+    embedded = [part for part in walk(root) if part.is_message]
+    assert len(embedded) == 1
+
+    inner_root = embedded[0].children[0]
+    assert inner_root.headers["Subject"] == ["the original message"]
+    assert inner_root.headers["From"] == ["alice@example.com"]
+
+
+def test__an_embedded_message_arrives_already_decoded():
+    # It had to be decoded to reach the children below it, so the bytes are
+    # published rather than thrown away and decoded again.
+    root = parse_email_tree(_bounce(ORIGINAL), mode="lazy")
+
+    embedded = next(part for part in walk(root) if part.is_message)
+    assert embedded.is_decoded
+    assert embedded.content == parse_email_tree(_bounce(ORIGINAL)).children[1].content
+
+
+def test__metadata_mode_can_raise_on_a_broken_embedded_message():
+    # The documented exception to "metadata mode never decodes": it must decode a
+    # `message/rfc822` body to parse the message inside it. `parse_email(...,
+    # mode="metadata")` cannot raise DecodeError; this can, and says so.
+    payload = (
+        b"From: postmaster@example.com\r\n"
+        b"Content-Type: message/rfc822\r\n"
+        b"Content-Transfer-Encoding: base64\r\n"
+        b"\r\n"
+        b"!!!! not base64 !!!!\r\n"
+    )
+
+    with pytest.raises(DecodeError):
+        parse_email_tree(payload, mode="metadata")
+
+
+# --- errors --------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", MODES)
+def test__malformed_headers_still_raise(mode: str):
+    with pytest.raises(HeaderParseError):
+        parse_email_tree(MALFORMED_HEADERS, mode=mode)
+
+
+def test__a_broken_leaf_fails_full_mode_but_not_the_deferred_modes():
+    # The trade the modes make, pinned rather than left to be discovered: full
+    # mode loses the whole tree to one broken part.
+    with pytest.raises(DecodeError):
+        parse_email_tree(BROKEN_BASE64_BODY)
+
+    lazy = parse_email_tree(BROKEN_BASE64_BODY, mode="lazy")
+    assert lazy.content_type == "text/plain"
+    with pytest.raises(DecodeError):
+        _ = lazy.content
+
+    # Metadata mode never decodes a non-message leaf, so it cannot fail at all.
+    described = parse_email_tree(BROKEN_BASE64_BODY, mode="metadata")
+    assert described.encoded_size == len(b"!!!! not base64 !!!!\r\n")
+
+
+def test__a_failed_decode_is_not_cached():
+    lazy = parse_email_tree(BROKEN_BASE64_BODY, mode="lazy")
+
+    for _ in range(2):
+        with pytest.raises(DecodeError):
+            _ = lazy.content
+    assert not lazy.is_decoded
+
+
+@pytest.mark.parametrize("mode", MODES)
+def test__the_mime_depth_cap_holds(mode: str):
+    payload = ORIGINAL
+    for _ in range(300):
+        payload = b"Content-Type: message/rfc822\r\n\r\n" + payload
+
+    with pytest.raises(MimeStructureError):
+        parse_email_tree(payload, mode=mode)
+
+
+@pytest.mark.parametrize("mode", MODES)
+def test__the_input_size_cap_holds(mode: str):
+    oversized = b"Subject: big\r\n\r\n" + b"x" * (100 * 1024 * 1024 + 1)
+
+    with pytest.raises(MimeStructureError):
+        parse_email_tree(oversized, mode=mode)
+
+
+@pytest.mark.parametrize("mode", MODES)
+def test__a_non_payload_is_rejected(mode: str):
+    with pytest.raises(TypeError):
+        parse_email_tree(42, mode=mode)
+
+
+def test__an_unknown_mode_is_rejected():
+    with pytest.raises(ValueError, match='"full", "lazy" or "metadata"'):
+        parse_email_tree(MIXED, mode="deferred")
+
+
+def test__mode_is_keyword_only():
+    with pytest.raises(TypeError):
+        parse_email_tree(MIXED, "lazy")
+
+
+def test__there_is_no_strict_on_the_tree():
+    # The tree has no warnings channel to be strict about -- see the note on
+    # `parse_email_tree`. A silently accepted `strict=` would be worse than a
+    # TypeError.
+    with pytest.raises(TypeError):
+        parse_email_tree(MIXED, mode="lazy", strict=True)
+
+
+# --- surface -------------------------------------------------------------------
+
+
+def test__the_lazy_node_surface_is_frozen():
+    for part in walk(parse_email_tree(MIXED, mode="lazy")):
+        public = {name for name in dir(part) if not name.startswith("_")}
+        assert public == EXPECTED_LAZY_NODE_ATTRS
+
+
+def test__the_metadata_node_surface_is_frozen():
+    for part in walk(parse_email_tree(MIXED, mode="metadata")):
+        public = {name for name in dir(part) if not name.startswith("_")}
+        assert public == EXPECTED_METADATA_NODE_ATTRS
+
+
+def test__a_metadata_node_has_no_content_at_all():
+    # Not `content = None`. `PyMimePart.content` is None for exactly one reason,
+    # that the node is a container, and a mode where None also meant "not
+    # decoded" would make the two indistinguishable -- the same reason
+    # `PyMailMetadata` omits `text_plain` rather than returning [].
+    for part in walk(parse_email_tree(MIXED, mode="metadata")):
+        assert not hasattr(part, "content")
+
+
+def test__the_leaf_metadata_matches_the_flat_attachment_inventory():
+    # The tree and the flat projection must agree about a part's identity, not
+    # just its bytes.
+    described = parse_email_tree(MIXED, mode="metadata")
+    pdf = next(part for part in walk(described) if part.content_type == "application/pdf")
+    attachment = parse_email(MIXED, mode="metadata").attachments[0]
+
+    assert pdf.filename == attachment.filename
+    assert pdf.content_id == attachment.content_id
+    assert pdf.disposition == attachment.disposition
+    assert pdf.encoded_size == attachment.encoded_size
+
+
+def test__repr_names_the_type_and_the_child_count():
+    lazy = parse_email_tree(MIXED, mode="lazy")
+    described = parse_email_tree(MIXED, mode="metadata")
+
+    assert repr(lazy) == "<PyLazyMimePart multipart/mixed children=2 decoded=true>"
+    assert repr(described) == "<PyMimePartMetadata multipart/mixed children=2>"


### PR DESCRIPTION
Closes #202.

`mode=` shipped on one entry point of three. These are the two the issue names as
where it is worth the most, and until now a caller had to choose between a mode
and the API.

```python
parse_many(payloads, mode="metadata")        # list[PyMailMetadata | ParseError]
parse_many(payloads, mode="lazy")            # list[PyLazyMail | ParseError]

parse_email_tree(payload, mode="metadata")   # PyMimePartMetadata
parse_email_tree(payload, mode="lazy")       # PyLazyMimePart
```

Both defaults are untouched, and the mode picks the return type through the
stub's overloads, so no existing caller's types change.

## Measured

767 KiB attachment-heavy fixture, median of three interleaved rounds on the CI
runner (this PR's gate run, 4 vCPU):

| | full | metadata | lazy, nothing read |
| --- | --- | --- | --- |
| `parse_email_tree` | 2.02 ms | 0.58 ms (**3.5x**) | 0.61 ms (**3.3x**) |
| `parse_many`, 8 msgs, `threads=1` | 16.16 ms | 4.68 ms (**3.5x**) | — |
| `parse_many`, 2000 × 0.8 KB | 4.67 ms | 4.11 ms (1.14x) | — |

The small-message row is the honest one to publish next to the others: small mail
is mostly headers, so there is little decoding to skip and the mode neither helps
nor hurts. The batch API's own ~12x at that size (#96) is unaffected.

Four benchmarks added for these, each guarded with `pytest.skip` so the base
build — which has no `mode=` on either function — stays green while the gate
measures this revision's benchmarks against it.

## Hot path

**The gate's verdict on this PR: no significant difference.** Worst treatment
delta **+0.8%** against an **8.2%** control noise floor; `parse_message` +0.5%,
`parse_many` -0.2%, `parse_tree` +0.7%, `parse_metadata` -0.0%. Positive means the
*base* was the slower side, so nothing here reads as a cost. Absolute floor 5.00x
vs mail-parser — pass. There is no version change in this PR, so the #204
version-string effect is not in play.

Measured locally first, which is how the shape below was arrived at rather than
guessed: interleaved A/B against `origin/master`, five rounds a side, worst
treatment delta +2.8% against a 5.0% control floor. A **null run** — the same
wheel on both sides — reported up to -2.7% on that machine, so it could not
resolve anything smaller; CI's ~0.3% within-job noise can, and did.

The pattern the four earlier regressions taught: `mode` is answered in the first
lines of both entry points and their existing bodies are byte-for-byte what they
were. Every new binding function carries `#[inline(never)]`, the two error
constructors are the existing `#[cold]` ones (`unknown_mode`,
`strict_needs_decoded_bodies`) rather than new ones, and each new mode pair shares
a single `catch_panics` call site instead of one per mode.

## Design, and why

**Two new node types, not a wider `PyMimePart`.** `PyMimePart.content` is
`bytes | None` and its `None` *means* "this node is a `multipart/*` container".
A mode where `None` also meant "not decoded yet" would make a leaf
indistinguishable from a container — the silent-wrong-answer shape #150 and
metadata mode's absent `text_plain` were both about. So `PyMimePartMetadata` has
no `content` attribute **at all**, and reports `encoded_size`: `None` in the same
place and with the same meaning as `content`'s `None`, `int` everywhere else.
Making `PyMimePart.content` lazy would separately have re-timed a shipped
attribute and moved where it raises, which #104 batches into an API-v2 window;
adding a type needs no window.

**Two rather than one**, because they differ in more than presentation. Lazy mode
retains a copy of every leaf so it can decode one later; metadata mode retains
none. On a tree that difference *is* the memory, which is the point of a sweep —
one type with an optional strategy would have had to publish `content` and
`is_decoded` on nodes that can never decode, which is the same
"attribute-that-lies" problem in a new place.

**One traversal, not three.** In the core, `NodeBody` is a three-arm enum
(`Container` / `Undecoded { encoded_size, raw: Option }` / `Decoded`) on one
`TreeNode`, and one `build_node(part, depth, defer)` builds both deferred modes,
differing in a single `bool`. Everything the modes must agree about — the
`multipart/*` and `message/rfc822` discrimination, `collect_headers`,
`part_filename`, `disposition_token`, `normalize_content_id`, `encoded_size`, both
caps, the #150 separator repair — is one piece of code. Full mode's
`MimePart::build` is deliberately left byte-for-byte untouched, so the one thing
duplicated between it and `build_node` is the two-line classification, which is
now covered by an equality assertion rather than by shared code (the same trade
`parse_email_metadata` and `parse_email_lazy` already make with `Mail::new`'s
envelope extraction).

**One batch scheduler, not three.** `parse_many_as` takes the per-message parse as
a `fn` pointer; `parse_many` is a call to it. The dynamic cursor and the order
restoration are where a bug would be subtle, so there is one of them. A `fn`
pointer rather than `impl Fn` keeps the instantiation count at the number of
result types.

**`message/rfc822` is still decoded, in every mode.** Its body *is* the embedded
message, so parsing it is what gives the node children — deferring it would defer
the *structure*, which is the one thing a tree API has to deliver eagerly, and a
mode that dropped those children would not be returning the same tree. The bytes
are already in hand, so they are published rather than dropped and decoded again:
such a node reports `is_decoded == True` from the start. Two consequences,
documented and pinned as tests: a deferred tree **can** raise `DecodeError` for a
broken embedded message, where `parse_email(mode="metadata")` never can; and a
lazy tree over a bounce holds that message decoded.

**Combinations.** `strict=True` + `mode="metadata"` raises `ValueError` on
`parse_many` with the same message it raises on `parse_email`, and before any
parsing happens; the stub's overloads reject it statically too (`mypy --strict`
verified). `strict=True` + `mode="lazy"` is honoured per slot and means what it
means everywhere else, because lazy mode finds every repair full mode finds.
`threads`, `raise_on_error`, input order and `ParseError`-in-a-slot behave
identically in all three modes. The tree has no `strict` in any mode — it has no
warnings channel to be strict about, which is the same open decision #99 left.

## Verification

- **The tree is the same tree in every mode.** Every per-node field except the
  body asserted equal to full mode's over the whole fixture + RFC corpus, and each
  leaf's lazy bytes equal to full mode's.
- **`parse_agreement` extended** with the #202 derivations: shape equality against
  full mode for both deferred trees, `encoded_size` agreement between them,
  presence agreeing with full mode's `content`, the ≤2x decode bound per node, and
  every deferred leaf decoding to exactly full mode's bytes.
- **The `raw_bytes` claim now covers a root.** Flat lazy mode defers only
  subparts; a single-part message's tree root *is* the leaf, so the retained slice
  is the whole payload. Asserted per fixture and on arbitrary input rather than
  assumed.
- `walk` accepts a node from any mode and yields nodes of the same type. The
  implementation was already duck-typed; the stub now says so with a
  value-restricted `TypeVar`, which is non-breaking — walking a `PyMimePart` still
  yields `PyMimePart`.
- 801 tests pass (up from 623); `test_contract.py`, `test_stub_matches_runtime.py`
  and `test_readme_snippets.py` updated/green; `cargo fmt --check`, `cargo clippy
  --all-targets -D warnings`, `mypy --strict`, `ruff check` all clean.

## Not verified locally

- **`cargo fuzz` was not run locally**: no nightly and no `cargo-fuzz` on this
  machine. The target compiles, and its new invariants were exercised by a
  standalone driver over the corpus plus 38,024 deterministic mutations (bit
  flips, truncations, spliced `message/rfc822` and quoted-printable headers) — all
  held. CI's `fuzz (short pass)` is green on this branch; the deep run is where a
  real exploration happens.
- **Free-threaded builds.** `PyLazyMimePart`'s cache is the same `OnceLock`-on-the-
  Python-object shape `PyLazyAttachment` uses, so the #101 audit's invariant is
  untouched: nothing was added to the parsing core that is shared or mutable. The
  concurrency tests for the new type are the single-threaded ones only; the
  existing concurrent tests cover the identical mechanism on `PyLazyAttachment`.
- **`encoded_size` was not added to `PyMimePart`.** It would be additive and is
  arguably useful there too, but it is not what #202 asks for.
