### PR TITLE
Quote the CI runner's numbers, not this laptop's (#202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,17 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **`parse_many(payloads, mode="metadata")`** is the mailbox sweep the mode was
     built for. The batch API removes per-message overhead (#96: ~12x at
     2000 × 0.8 KB) and metadata mode removes the decoding (#97: ~3x on an
-    attachment-heavy message); they now compose. Measured on the 767 KiB fixture,
-    8 messages, `threads=1`: full 8.96 ms, metadata 2.94 ms — **3.0x**, the same
-    ratio the single-message mode gets. On 2000 × 0.8 KB it is 2.80 ms against
-    3.04 ms, because small messages are mostly headers and there is little
-    decoding to skip.
+    attachment-heavy message); they now compose. Median of three interleaved
+    rounds on the CI runner, 767 KiB fixture, 8 messages, `threads=1`: full
+    16.16 ms, metadata 4.68 ms — **3.5x**, the same ratio the single-message mode
+    gets. On 2000 × 0.8 KB it is 4.11 ms against 4.67 ms, a 1.14x edge, because
+    small messages are mostly headers and there is little decoding to skip.
   - **`parse_email_tree(payload, mode="lazy")`** is the forensics case: walk the
     structure of a large message and decode the one part you want. A full-mode
     tree decodes every leaf, which is the wrong bill for exactly what the tree is
     best at. `mode="metadata"` decodes nothing *and retains nothing*. On the same
-    fixture: full tree 1.10 ms, lazy with nothing read 0.38 ms, metadata
-    0.37 ms — **~2.9x**.
+    fixture and runner: full tree 2.02 ms, lazy with nothing read 0.61 ms,
+    metadata 0.58 ms — **3.3x** and **3.5x**.
   - **Two new node types, `PyLazyMimePart` and `PyMimePartMetadata`**, rather than
     a wider `PyMimePart`. `PyMimePart.content` is `bytes | None` and its `None`
     *means* "this node is a `multipart/*` container"; a mode where it also meant
@@ -68,12 +68,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     implementation was already duck-typed; the stub now says so with a
     value-restricted `TypeVar`, which is non-breaking — walking a `PyMimePart`
     still yields `PyMimePart`.
-  - **Measured, not assumed.** Interleaved A/B against `master`, three rounds a
-    side: worst treatment delta +0.5% against a 4.4% control noise floor, with
-    `parse_message` at -1.2% and `parse_many` at -0.2%. The default paths are
-    answered in the first lines of their entry points and are byte-for-byte what
-    they were; every new binding function carries `#[inline(never)]`, the two error
-    constructors are the existing `#[cold]` ones, and each new mode pair shares one
+  - **Measured, not assumed.** The CI benchmark gate's interleaved A/B against
+    `origin/master`: worst treatment delta **+0.8%** against an 8.2% control noise
+    floor, `parse_message` +0.5%, `parse_many` -0.2%, `parse_tree` +0.7%,
+    `parse_metadata` -0.0% — no significant difference, and positive means the
+    base was the slower side. The default paths are answered in the first lines of
+    their entry points and are byte-for-byte what they were; every new binding
+    function carries `#[inline(never)]`, the two error constructors are the
+    existing `#[cold]` ones, and each new mode pair shares one
     `catch_panics` call site. #99, #100, #135 and #180 are four records of code
     that never executes costing this hot path 15-96%.
   - The batch scheduler is now shared rather than copied: `parse_many_as` takes the

--- a/Readme.md
+++ b/Readme.md
@@ -315,11 +315,12 @@ The mode is uniform across the batch, which is what lets it pick the slot type;
 `ParseError` instances still occupy failed slots, and `raise_on_error`, `threads`
 and input order behave exactly as in the default mode.
 
-On the attachment-heavy fixture, a batch of 8 × 767 KiB with `threads=1`:
-`mode="full"` 8.96 ms, `mode="metadata"` 2.94 ms — **3.0x**, the same ratio the
-single-message mode gets, now available to the batch. On 2000 × 0.8 KB it is
-2.80 ms against 3.04 ms: small messages are mostly headers, so there is little
-decoding to skip, and the mode neither helps nor hurts much.
+On the attachment-heavy fixture, a batch of 8 × 767 KiB with `threads=1`, median
+of three interleaved rounds on the CI runner: `mode="full"` 16.16 ms,
+`mode="metadata"` 4.68 ms — **3.5x**, the same ratio the single-message mode gets,
+now available to the batch. On 2000 × 0.8 KB it is 4.11 ms against 4.67 ms — a
+1.14x edge, because small messages are mostly headers and there is little
+decoding to skip.
 
 `strict=True` with `mode="metadata"` raises `ValueError`, as it does on
 `parse_email` — a mode that never reads the bodies cannot promise nothing in them
@@ -503,8 +504,9 @@ data = pdf.content            # decoded here, and only this one
 That is the difference between the two — lazy mode keeps a copy of every leaf so
 it can decode one later, metadata mode keeps none and is the cheaper sweep.
 
-On the attachment-heavy fixture (767 KiB): full tree 1.10 ms, `mode="lazy"` with
-nothing read 0.38 ms, `mode="metadata"` 0.37 ms — **~2.9x**.
+On the attachment-heavy fixture (767 KiB), median of three interleaved rounds on
+the CI runner: full tree 2.02 ms, `mode="lazy"` with nothing read 0.61 ms,
+`mode="metadata"` 0.58 ms — **3.3x** and **3.5x**.
 
 Two things to know:
 


### PR DESCRIPTION
Docs only. Follow-up to #210, which landed while this correction was in flight.

The README's other measured tables say "median of three interleaved rounds on the
CI runner". The two new sections #210 added did not: their numbers were the local
A/B's minima on an Apple Silicon laptop, where absolute times are about half CI's
and the mode ratios differ by half a turn. Two tables in one document measured on
two machines is the sort of thing a reader has no way to notice.

Replaced with the gate's own figures from #210's run:

| | full | metadata | lazy, nothing read |
| --- | --- | --- | --- |
| `parse_email_tree` | 2.02 ms | 0.58 ms (**3.5x**) | 0.61 ms (**3.3x**) |
| `parse_many`, 8 × 767 KiB, `threads=1` | 16.16 ms | 4.68 ms (**3.5x**) | — |
| `parse_many`, 2000 × 0.8 KB | 4.67 ms | 4.11 ms (1.14x) | — |

The ratios move the right way and the caveat moves with them: the small-message
batch sweep is a 1.14x edge rather than 1.09x, which is still the honest "small
mail is mostly headers, so there is little decoding to skip".

The CHANGELOG's hot-path note now quotes the gate's verdict — worst treatment
delta +0.8% against an 8.2% control noise floor, positive meaning the base was the
slower side — instead of the local one, since that is the measurement with a ~0.3%
within-job noise floor rather than a 2.7% laptop one.

No source change, so the extension is byte-identical to the base and the gate will
say so.
