### PR TITLE
Correct the -ng version count and archiving tense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`fast-mail-parser-ng` 0.7.1** was published as that distribution's final
+  release, ahead of archiving it on PyPI. It is 0.7.0's code with a deprecation
+  notice for a description — PyPI's guidance is to leave a retired name pointing
+  somewhere rather than going quiet, and an archived project's page is the last
+  thing a reader of a stale pin will see. Building it from `v0.7.0` rather than
+  from master was deliberate: shipping 0.8.x features under the retired name would
+  have created a second source of truth and removed the reason to migrate. The
+  four versions under that name remain installable.
+
 ### Added
 
 - **`mode=` on `parse_many` and `parse_email_tree`** (#202), honouring the same

--- a/Readme.md
+++ b/Readme.md
@@ -75,12 +75,14 @@ transfer request sat unattended for months. Rather than hold releases behind tha
 queue, 0.6.0 through 0.7.0 shipped as `fast-mail-parser-ng`, with the import path
 deliberately unchanged so the switch cost one line in a requirements file.
 
-Ownership has since been transferred directly, so releases go back to the
-original name from 0.8.0 on, and `fast-mail-parser-ng` is **archived** on PyPI:
-read-only, taking no further releases. The three versions published under it stay
-installable, so nothing pinning them breaks — archiving marks the project as
-finished rather than removing anything. If you are on it, change the name in your
-requirements file; there is nothing else to do.
+Ownership has since been transferred directly, so releases go back to the original
+name from 0.8.0 on, and `fast-mail-parser-ng` is being **archived** on PyPI:
+read-only, taking no further releases. Its last release, **0.7.1**, is 0.7.0's code
+with a deprecation notice for a description and nothing else — a signpost, not an
+upgrade. The four versions published under that name stay installable, so nothing
+pinning them breaks; archiving marks a project finished rather than removing
+anything. If you are on it, change the name in your requirements file; there is
+nothing else to do.
 
 Full history in the [changelog](https://github.com/namecheap/fast_mail_parser/blob/master/CHANGELOG.md).
 


### PR DESCRIPTION
Docs only. The README's name section predates the final -ng release: it says three versions exist under that name (there are four now, 0.7.1 is the tombstone) and that the project is already archived (archiving is still pending). Also states what 0.7.1 is -- 0.7.0's code with a deprecation notice, not an upgrade -- and records in the changelog why it was cut from v0.7.0 rather than master.