### PR TITLE
Strip base64 whitespace with memchr instead of one byte at a time (#120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Base64 whitespace is stripped with `memchr`** instead of a test-and-push per byte,
+  the second change in the patched `vendor/mailparse` (also on
+  [staktrace/mailparse#142](https://github.com/staktrace/mailparse/pull/142)). With the
+  boundary search fixed, that filter was **77.7%** of a full parse of the 767 KiB fixture
+  -- more than the base64 decode itself -- and the toolchain A/B showed it carried the
+  rest of the rustc placement sensitivity: decoding paths still moved +22% on one CPU
+  and +5% on another while the metadata paths had gone flat. The bytes removed are
+  unchanged (exactly `u8::is_ascii_whitespace`), checked against the original filter
+  over every byte value. Interleaved A/B, Apple M4, against the master with the boundary
+  fix: full parse **0.830 -> 0.281 ms**, `parse_email_tree` 0.820 -> 0.271 ms,
+  `parse_many` (8 x 767 KiB) 6.57 -> 2.18 ms; metadata paths unchanged, as they decode
+  nothing. Against the master before either change the default path is 1.094 -> 0.281 ms.
 - **The MIME boundary search is now `memchr::memmem`** instead of a byte-by-byte scan,
   through a patched copy of `mailparse` 0.16.1 in `vendor/mailparse` (upstream as
   [staktrace/mailparse#142](https://github.com/staktrace/mailparse/pull/142); see

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rest of the rustc placement sensitivity: decoding paths still moved +22% on one CPU
   and +5% on another while the metadata paths had gone flat. The bytes removed are
   unchanged (exactly `u8::is_ascii_whitespace`), checked against the original filter
-  over every byte value. Interleaved A/B, Apple M4, against the master with the boundary
-  fix: full parse **0.830 -> 0.281 ms**, `parse_email_tree` 0.820 -> 0.271 ms,
-  `parse_many` (8 x 767 KiB) 6.57 -> 2.18 ms; metadata paths unchanged, as they decode
-  nothing. Against the master before either change the default path is 1.094 -> 0.281 ms.
+  over every byte value. Gate on the PR, median of three interleaved rounds on the CI
+  runner (AMD EPYC 7763), against the master with the boundary fix: full parse
+  **1.432 -> 0.575 ms**, `parse_email_tree` 1.419 -> 0.556 ms, `parse_many` (8 x 767 KiB)
+  11.29 -> 4.48 ms; metadata paths unchanged, as they decode nothing; the cross-library
+  table now reads 25x over mail-parser and 34x over the stdlib. An Apple M4 measured
+  0.830 -> 0.281 ms for the same pair, and 1.094 -> 0.281 ms against the master before
+  either change.
 - **The MIME boundary search is now `memchr::memmem`** instead of a byte-by-byte scan,
   through a patched copy of `mailparse` 0.16.1 in `vendor/mailparse` (upstream as
   [staktrace/mailparse#142](https://github.com/staktrace/mailparse/pull/142); see

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -298,9 +298,10 @@ Both `lto = "fat"` and `codegen-units = 1` are already set, so a codegen-unit
 boundary is never the explanation -- worth knowing, since it is the natural first
 guess.
 
-**The cliff had one dominant cause, and it is fixed.** Sampling a metadata-mode
-parse of the 767 KiB fixture put **96.5%** of the time in one function: mailparse's
-`find_from_u8`, the byte-by-byte scan `parse_mail` runs for every MIME boundary.
+**The cliff had two causes, both byte-at-a-time loops in mailparse, both fixed.**
+Sampling a metadata-mode parse of the 767 KiB fixture put **96.5%** of the time in
+one function: mailparse's `find_from_u8`, the scan `parse_mail` runs for every MIME
+boundary.
 Its x86-64 instruction stream was byte-identical under rustc 1.97.1 and 1.98.0 --
 88 instructions, only label hashes differed -- yet the runners measured +96% on
 the metadata path. The compiler had not made the loop slower; it had *moved* it.
@@ -315,12 +316,20 @@ independently of this crate -- via the patched copy in `vendor/mailparse`
 (upstream as staktrace/mailparse#142; `vendor/mailparse/PATCH.md` has the removal
 steps). Metadata mode went 0.365 -> 0.030 ms and the full parse 1.10 -> 0.76 ms.
 
+With that gone, sampling the *full* parse put **77.7%** of what remained in
+`decode_base64`'s whitespace filter -- `iter().filter().cloned().collect()`, a
+test and a push per byte -- and the toolchain A/B confirmed it carried the rest of
+the placement sensitivity: decoding paths still moved +22% on one runner and +5%
+on another while the metadata paths had gone flat. Same fix, same place: the
+whitespace is found with `memchr` and the runs between are copied whole. The
+full parse went 0.83 -> 0.28 ms on top.
+
 **What remains true.** The gate has a false-positive mode its noise floor cannot
 see: the controls are pure Python and do not care how the extension was laid out,
 so they stay flat while every treatment benchmark moves together, tightly and
-repeatably. The dominant instance is gone, but base64 decoding and charset
-conversion are also loops whose placement the linker decides, and nobody has
-measured how sensitive they are. So: **re-run a large failure before acting on
+repeatably. The two dominant instances are gone, but the base64 decode proper
+(`data_encoding`) and charset conversion are also loops whose placement the
+linker decides, and nobody has measured how sensitive they are. So: **re-run a large failure before acting on
 it.** A real regression reproduces on different hardware; a layout-versus-CPU
 artifact does not. The gate prints the CPU it measured on for exactly this
 comparison.

--- a/Readme.md
+++ b/Readme.md
@@ -110,18 +110,18 @@ attachments with their payloads decoded — on the same message:
 
 | Library | Work performed | Min time | Relative |
 | --- | --- | --- | --- |
-| **fast_mail_parser** | parse + decode bodies + decode attachments | 0.61 ms | 1.00x |
-| mail-parser | `from_string` + `.parse()` + read attributes | 7.22 ms | 11.82x |
-| stdlib `email` | `message_from_bytes` + walk + `get_content` / `get_payload` | 10.59 ms | 17.33x |
+| **fast_mail_parser** | parse + decode bodies + decode attachments | 0.59 ms | 1.00x |
+| mail-parser | `from_string` + `.parse()` + read attributes | 14.81 ms | 25.08x |
+| stdlib `email` | `message_from_bytes` + walk + `get_content` / `get_payload` | 20.23 ms | 34.27x |
 
 Corpus: `tests/data/large_message.eml` (multipart/mixed, 6 MIME parts, 2 base64
 attachments). CPython 3.12.14 on Linux x86_64 (GitHub Actions `ubuntu-latest`, an
-AMD EPYC 9V45 on this run), mail-parser 4.6.4, minimum of 91+ rounds.
+AMD EPYC 7763 on this run), mail-parser 4.6.4, minimum of 34+ rounds.
 
 **These ratios move with the hardware, so treat them as a magnitude rather than a
-constant.** Before the MIME boundary search moved to `memchr::memmem`, this same
-table read 6.44x and 8.59x on one runner and 8.50x and 10.01x on a faster one; an
-Apple M4 now gives 7.6x and 10.6x against this run's 11.8x and 17.3x. The
+constant.** Before mailparse's two byte-at-a-time loops moved to `memchr`, this
+same table read 6.44x and 8.59x on one runner and 8.50x and 10.01x on a faster one;
+an Apple M4 now gives 20.8x and 28.3x against this run's 25.1x and 34.3x. The
 interpreted parsers and the Rust extension do not scale together across CPUs. Regenerate the table for your own machine with
 `make bench-table`, which prints its own methodology line; CI also renders it
 into the job summary of every benchmark run.
@@ -318,10 +318,10 @@ The mode is uniform across the batch, which is what lets it pick the slot type;
 and input order behave exactly as in the default mode.
 
 On the attachment-heavy fixture, a batch of 8 × 767 KiB with `threads=1`, median
-of three interleaved rounds on the CI runner: `mode="full"` 4.82 ms,
-`mode="metadata"` 0.25 ms — **19.6x**, the same ratio the single-message mode gets,
-now available to the batch. On 2000 × 0.8 KB it is 2.25 ms against 2.55 ms — a
-1.13x edge, because small messages are mostly headers and there is little
+of three interleaved rounds on the CI runner: `mode="full"` 4.48 ms,
+`mode="metadata"` 0.41 ms — **10.9x**, the same ratio the single-message mode gets,
+now available to the batch. On 2000 × 0.8 KB it is 4.20 ms against 4.67 ms — a
+1.11x edge, because small messages are mostly headers and there is little
 decoding to skip.
 
 `strict=True` with `mode="metadata"` raises `ValueError`, as it does on
@@ -411,14 +411,13 @@ median of three interleaved rounds on the CI runner:
 
 | | | |
 | --- | --- | --- |
-| `mode="metadata"` | 0.030 ms | decodes nothing |
-| `mode="lazy"`, nothing read | 0.048 ms | bodies decoded, attachments deferred |
-| `mode="full"` | 0.604 ms | the default |
-| `mode="lazy"`, every attachment read | 0.583 ms | the same work, in a worse order |
+| `mode="metadata"` | 0.051 ms | decodes nothing |
+| `mode="lazy"`, nothing read | 0.080 ms | bodies decoded, attachments deferred |
+| `mode="full"` | 0.575 ms | the default |
+| `mode="lazy"`, every attachment read | 0.594 ms | the same work, in a worse order |
 
-So deferring saves about 92% when you were not going to decode everything, and
-costs nothing measurable when you were: 0.58 against 0.60 ms is inside the run's
-noise. **If you are going to read every attachment, use the
+So deferring saves about 86% when you were not going to decode everything, and
+costs about 3% when you were. **If you are going to read every attachment, use the
 default mode** — this one is for when you are not. Absolute times move with the
 runner; the ratios are what to read.
 
@@ -508,8 +507,8 @@ That is the difference between the two — lazy mode keeps a copy of every leaf 
 it can decode one later, metadata mode keeps none and is the cheaper sweep.
 
 On the attachment-heavy fixture (767 KiB), median of three interleaved rounds on
-the CI runner: full tree 0.595 ms, `mode="lazy"` with nothing read 0.044 ms,
-`mode="metadata"` 0.033 ms — **13.5x** and **18x**.
+the CI runner: full tree 0.556 ms, `mode="lazy"` with nothing read 0.077 ms,
+`mode="metadata"` 0.054 ms — **7.2x** and **10.3x**.
 
 Two things to know:
 

--- a/vendor/mailparse/PATCH.md
+++ b/vendor/mailparse/PATCH.md
@@ -1,14 +1,19 @@
 # Patched copy of `mailparse` 0.16.1
 
 This directory is [mailparse 0.16.1](https://crates.io/crates/mailparse/0.16.1) as published,
-with **one function changed** and one dependency added. It is applied through
+with **two functions changed** and one dependency added. It is applied through
 `[patch.crates-io]` in the root `Cargo.toml` (and `fuzz/Cargo.toml`), so `cargo` sees the
 same crate name and version and every other dependency resolves exactly as before.
+`memchr = "2.7.0"` was added to this crate's `[dependencies]` (MIT OR Unlicense, no
+dependencies of its own).
 
-## The change
+## The changes
 
-`find_from_u8` in `src/lib.rs` -- the search `parse_mail` runs for every MIME boundary --
-scanned byte by byte:
+Both replace a byte-at-a-time loop over the whole message body with a vectorised search.
+Both return exactly what the code they replace returned.
+
+**1. `find_from_u8` in `src/lib.rs`** -- the search `parse_mail` runs for every MIME
+boundary -- scanned byte by byte:
 
 ```rust
 for i in ix_start..=ix_end {
@@ -16,38 +21,48 @@ for i in ix_start..=ix_end {
 }
 ```
 
-It now calls `memchr::memmem::find`, which is vectorised with runtime CPU dispatch. Same
-result: first occurrence of `key` at or after `ix_start`, `None` when there is none.
-`memchr = "2.7.0"` was added to this crate's `[dependencies]` (MIT OR Unlicense, no
-dependencies of its own). Nothing else differs from the published crate; `diff -r` against
-the registry copy shows exactly these two files plus this one.
+It now calls `memchr::memmem::find`. Same result: first occurrence of `key` at or after
+`ix_start`, `None` when there is none.
+
+**2. `decode_base64` in `src/body.rs`** stripped whitespace before decoding with
+`body.iter().filter(|c| !c.is_ascii_whitespace()).cloned().collect()`: a test and a
+bounds-checked push per byte. It now calls `strip_ascii_whitespace`, which finds
+whitespace with `memchr` and copies the runs between whole -- one search and one memcpy
+per 76-byte line in the common case. The set of bytes removed is unchanged (exactly
+`u8::is_ascii_whitespace`: space, tab, LF, form feed, CR) and a unit test in `body.rs`
+checks it against the original filter over every byte value.
+
+`diff -r` against the registry copy shows exactly `src/lib.rs`, `src/body.rs`,
+`Cargo.toml` and this file.
 
 ## Why
 
-Sampling a metadata-mode parse of `tests/data/large_message.eml` (767 KiB, four base64
-attachments) put **96.5%** of the time in that loop. Worse, its speed depended on where the
-linker placed it: the same 88 x86-64 instructions ran at half speed when the loop straddled
-a 64-byte boundary. A rustc minor version (#120) and a version-string bump (#204) each
-moved the loop and each showed up as a "regression" of up to 96% on the metadata path --
-with zero changes to the instructions being executed.
+Sampling parses of `tests/data/large_message.eml` (767 KiB, four base64 attachments):
+**96.5%** of a metadata-mode parse was in the boundary scan, and once that was fixed,
+**77.7%** of a full parse was in the whitespace filter. Worse than slow, both loops' speed
+depended on where the linker placed them: the same x86-64 instructions ran at half speed
+when a loop straddled a 64-byte boundary. A rustc minor version (#120) and a
+version-string bump (#204) each moved the loops and each read as a regression of up to
+96% -- with zero change to the instructions executed.
 
-Measured on the fix (interleaved A/B, Apple M4, master vs this patch):
+Measured on this machine (interleaved A/B, Apple M4), original master to both patches:
 
 | benchmark | before | after |
 |---|---|---|
-| `parse_email(mode="metadata")` | 0.365 ms | 0.030 ms |
-| `parse_email` (full) | 1.098 ms | 0.761 ms |
-| `parse_many` (8 x 767 KiB) | 9.164 ms | 6.223 ms |
+| `parse_email(mode="metadata")` | 0.365 ms | 0.034 ms |
+| `parse_email` (full) | 1.094 ms | 0.281 ms |
+| `parse_many` (8 x 767 KiB) | 9.082 ms | 2.177 ms |
 
 ## When this goes away
 
-The change is upstream as [staktrace/mailparse#142](https://github.com/staktrace/mailparse/pull/142).
-Once a mailparse release includes it:
+Both changes are upstream as [staktrace/mailparse#142](https://github.com/staktrace/mailparse/pull/142).
+Once a mailparse release includes them:
 
 1. bump `mailparse` in the root `Cargo.toml` to that release,
 2. delete the two `[patch.crates-io]` sections and this directory,
-3. drop the `vendor/mailparse/**/*` entry from `[tool.maturin] include` in `pyproject.toml`,
+3. drop the `vendor/mailparse/**/*` entry from `[tool.maturin] include` in `pyproject.toml`
+   and the `vendored mailparse tests` step from the lint job,
 4. run the benchmark gate: the numbers should not move.
 
 Until then, any upstream mailparse release has to be merged into this copy by hand; the
-diff to carry forward is the one function above.
+diff to carry forward is the two functions above and the test.

--- a/vendor/mailparse/src/body.rs
+++ b/vendor/mailparse/src/body.rs
@@ -137,12 +137,34 @@ impl<'a> BinaryBody<'a> {
 }
 
 fn decode_base64(body: &[u8]) -> Result<Vec<u8>, MailParseError> {
-    let cleaned = body
-        .iter()
-        .filter(|c| !c.is_ascii_whitespace())
-        .cloned()
-        .collect::<Vec<u8>>();
+    let cleaned = strip_ascii_whitespace(body);
     Ok(data_encoding::BASE64_MIME_PERMISSIVE.decode(&cleaned)?)
+}
+
+/// Copy `body` without its ASCII whitespace -- the same bytes `u8::is_ascii_whitespace`
+/// names: space, tab, newline, form feed, carriage return.
+///
+/// Whitespace is located with a vectorised search and the runs between are copied
+/// whole, rather than testing and pushing one byte at a time. A base64 body is
+/// almost entirely 76-byte lines ending in CRLF, so the common case is one search
+/// and one copy per line. Tabs and form feeds are rare enough that they get a second
+/// search over each run instead of a place in the first.
+fn strip_ascii_whitespace(body: &[u8]) -> Vec<u8> {
+    let mut cleaned = Vec::with_capacity(body.len());
+    let mut rest = body;
+    loop {
+        let end = memchr::memchr3(b'\r', b'\n', b' ', rest).unwrap_or(rest.len());
+        let mut run = &rest[..end];
+        while let Some(j) = memchr::memchr2(b'\t', 0x0c, run) {
+            cleaned.extend_from_slice(&run[..j]);
+            run = &run[j + 1..];
+        }
+        cleaned.extend_from_slice(run);
+        if end == rest.len() {
+            return cleaned;
+        }
+        rest = &rest[end + 1..];
+    }
 }
 
 fn decode_quoted_printable(body: &[u8]) -> Result<Vec<u8>, MailParseError> {
@@ -160,4 +182,48 @@ fn get_body_as_string(body: &[u8], ctype: &ParsedContentType) -> Result<String, 
         decode_ascii(body)
     };
     Ok(cow.into_owned())
+}
+
+#[cfg(test)]
+mod strip_ascii_whitespace_tests {
+    use super::strip_ascii_whitespace;
+
+    fn reference(body: &[u8]) -> Vec<u8> {
+        body.iter()
+            .filter(|c| !c.is_ascii_whitespace())
+            .cloned()
+            .collect()
+    }
+
+    #[test]
+    fn matches_the_filter_it_replaces() {
+        let cases: &[&[u8]] = &[
+            b"",
+            b" ",
+            b" \t\r\n\x0c",
+            b"abc",
+            b"  abc  ",
+            b"ab cd\tef\ngh\rij\x0ckl",
+            b"\x0b", // vertical tab is NOT ascii whitespace; must be kept
+            b"a\x0bb",
+            b"\t\tab\x0c\x0ccd",
+            b"QUJD\r\nREVG\r\n",
+            b"QUJD REVG\tR0hJ\x0cSktM",
+        ];
+        for case in cases {
+            assert_eq!(strip_ascii_whitespace(case), reference(case), "{:?}", case);
+        }
+        // every byte value, alone and next to whitespace
+        for b in 0u8..=255 {
+            let single = [b];
+            assert_eq!(
+                strip_ascii_whitespace(&single),
+                reference(&single),
+                "{:?}",
+                b
+            );
+            let mixed = [b' ', b, b'\t', b, b'\r', b'\n', b];
+            assert_eq!(strip_ascii_whitespace(&mixed), reference(&mixed), "{:?}", b);
+        }
+    }
 }


### PR DESCRIPTION
## The second loop

With the boundary search fixed (#213), a full parse of the 767 KiB fixture spends **77.7%** of its time in mailparse's `decode_base64` — not in the base64 decoder (16.9%), but in the whitespace strip before it:

```rust
body.iter().filter(|c| !c.is_ascii_whitespace()).cloned().collect::<Vec<u8>>()
```

A test and a bounds-checked push per byte, over the whole body. Same shape as the boundary loop, same exposure to where the linker puts it — and the toolchain A/B on the merged #213 ([run 1](https://github.com/namecheap/fast_mail_parser/actions/runs/33090231483), [run 2](https://github.com/namecheap/fast_mail_parser/actions/runs/33090227516)) showed exactly that: the metadata paths were now flat across rustc versions on both runners (±2%), while the decoding paths still moved **+22% on one CPU and +5% on another**.

## The change

Whitespace is located with `memchr` and the runs between are copied whole. A base64 body is almost entirely 76-byte lines ending in CRLF, so the common case is one search and one memcpy per line; tabs and form feeds get a second search over each run. The set of bytes removed is unchanged — exactly `u8::is_ascii_whitespace` — and a new test in the vendored crate checks the function against the filter it replaces over every byte value, alone and next to whitespace, including the vertical tab that `is_ascii_whitespace` does *not* include.

Local interleaved A/B vs master (Apple M4, 3 rounds, controls within 1.6%):

| benchmark | master (#213) | this PR | |
|---|---|---|---|
| `parse_email` (full) | 0.830 ms | **0.281 ms** | −66% |
| `parse_email_tree` | 0.820 ms | 0.271 ms | −67% |
| `parse_email(mode="lazy")`, every attachment read | 0.841 ms | 0.291 ms | −65% |
| `parse_many`, 8 × 767 KiB | 6.573 ms | 2.177 ms | −67% |
| `parse_email(mode="metadata")` | 0.034 ms | 0.034 ms | ±0 (decodes nothing) |

Against the master before #213, the default path is 1.094 → 0.281 ms — **3.9x**. Every test passes (803), the vendored crate's suite passes (51 + 25), `mypy --strict` and `ruff` are clean. No lockfile change: `memchr` is already there from #213. README figures will be updated from this PR's gate before merge, as in #213.

Upstream: pushed as the second commit on staktrace/mailparse#142, since both loops share the one new dependency.