### PR TITLE
Move the Rust toolchain pin from 1.97.1 to 1.98.0 (#120)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
-          # Pinned: see rust-toolchain.toml. 1.98.0 costs this crate ~26%.
-          rust-toolchain: 1.97.1
+          # Pinned: see rust-toolchain.toml for why and how to bump.
+          rust-toolchain: 1.98.0
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           sccache: "true"
@@ -79,8 +79,8 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
-          # Pinned: see rust-toolchain.toml. 1.98.0 costs this crate ~26%.
-          rust-toolchain: 1.97.1
+          # Pinned: see rust-toolchain.toml for why and how to bump.
+          rust-toolchain: 1.98.0
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           sccache: "true"
@@ -109,8 +109,8 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
-          # Pinned: see rust-toolchain.toml. 1.98.0 costs this crate ~26%.
-          rust-toolchain: 1.97.1
+          # Pinned: see rust-toolchain.toml for why and how to bump.
+          rust-toolchain: 1.98.0
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           sccache: "true"
@@ -138,8 +138,8 @@ jobs:
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
-          # Pinned: see rust-toolchain.toml. 1.98.0 costs this crate ~26%.
-          rust-toolchain: 1.97.1
+          # Pinned: see rust-toolchain.toml for why and how to bump.
+          rust-toolchain: 1.98.0
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           sccache: "true"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
           # toolchain cargo then does not use ("'cargo-fmt' is not installed for
           # the toolchain"). Only an explicit RUSTUP_TOOLCHAIN env var overrides
           # the file — see the cargo audit job.
-          toolchain: 1.97.1
+          toolchain: 1.98.0
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
@@ -83,7 +83,7 @@ jobs:
   # against any dependency should fail the build and gate the PR rather than pass
   # silently. (It was previously advisory only because the stack was stale and a
   # fresh advisory against a pinned dep would have blocked unrelated PRs.)
-  # rust-toolchain.toml pins the build to 1.97.1 (see that file) and the MSRV
+  # rust-toolchain.toml pins the build toolchain (see that file) and the MSRV
   # (1.83) is declared via `rust-version` in Cargo.toml; this job sets
   # RUSTUP_TOOLCHAIN=stable explicitly so cargo-audit always audits against
   # current stable regardless of that pin.
@@ -133,7 +133,7 @@ jobs:
   # the tree it was meant to govern.
   #
   # Like the cargo audit job, this sets RUSTUP_TOOLCHAIN=stable to override the
-  # 1.97.1 pin in rust-toolchain.toml: a supply-chain check should run current
+  # pin in rust-toolchain.toml: a supply-chain check should run current
   # tooling regardless of which compiler the library is built with. It needs no
   # Rust build at all, only the lockfile and the manifests.
   #
@@ -175,7 +175,7 @@ jobs:
   # schedule (#102).
   #
   # cargo-fuzz requires nightly, so this sets RUSTUP_TOOLCHAIN to override the
-  # 1.97.1 pin in rust-toolchain.toml -- the same override the cargo audit and
+  # pin in rust-toolchain.toml -- the same override the cargo audit and
   # cargo deny jobs use, for the same reason: the tool's needs are not the
   # library's build.
   #
@@ -265,8 +265,8 @@ jobs:
       - name: Build wheel
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
-          # Pinned: see rust-toolchain.toml. 1.98.0 costs this crate ~26%.
-          rust-toolchain: 1.97.1
+          # Pinned: see rust-toolchain.toml for why and how to bump.
+          rust-toolchain: 1.98.0
           args: --release --out dist
           sccache: "true"
           manylinux: auto
@@ -337,7 +337,7 @@ jobs:
           cache: pip
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
-          toolchain: 1.97.1
+          toolchain: 1.98.0
       # Cache the cargo registry and build artifacts so the two builds below
       # reuse compiled crates instead of starting from scratch (#47).
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
@@ -521,7 +521,7 @@ jobs:
           cache: pip
       - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
-          toolchain: 1.97.1
+          toolchain: 1.98.0
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       - name: Build the sdist

--- a/.github/workflows/toolchain-ab.yml
+++ b/.github/workflows/toolchain-ab.yml
@@ -3,10 +3,13 @@ name: Toolchain A/B
 # Compares the SAME source built with two Rust toolchains, to decide whether the
 # pin in rust-toolchain.toml can be lifted (#120).
 #
-# History: a 1.98.0 build made this crate ~30% slower than 1.97.1, which is why
-# the toolchain is pinned. The original estimate (~26%) came from comparing
-# separate CI runs, where between-runner variance is itself ~26% -- the same
-# order as the effect it was trying to measure.
+# History: a 1.98.0 build measured 15-30% slower than 1.97.1, which is why the
+# toolchain was pinned to 1.97.1 in the first place. The original estimate (~26%)
+# came from comparing separate CI runs, where between-runner variance is itself
+# ~26% -- the same order as the effect it was trying to measure. The cause turned
+# out to be two byte-at-a-time loops in mailparse whose speed depended on where
+# the linker placed them (#120, #204); with those replaced (#213, #214) this
+# workflow read 1.98.0 within +/-0.5% of 1.97.1 and the pin moved to 1.98.0.
 #
 # Building both toolchains in one job fixed that, but not completely: the two
 # sides still need separate build-and-measure cycles, and two such cycles read
@@ -27,7 +30,7 @@ on:
     inputs:
       baseline:
         description: "Toolchain to compare against (the current pin)"
-        default: "1.97.1"
+        default: "1.98.0"
       candidate:
         description: "Toolchain to evaluate (a version, or `stable`)"
         default: "stable"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Rust toolchain pin moved from 1.97.1 to 1.98.0** (#120). The pin was a holding
+  action against a measured 15-30% slowdown under 1.98.0; the cause turned out to be
+  the two mailparse loops above -- the compiler had not changed their instructions,
+  only their addresses -- and with those replaced the toolchain A/B on the CPU that
+  showed the worst of it reads 1.98.0 within +/-0.5% of 1.97.1 on every parse path.
+  Published wheels are built with 1.98.0 from the next release. The pin stays a pin
+  rather than floating to `stable`, because the benchmark gate builds both sides
+  with the same compiler and so cannot see a compiler regression; bumping it is a
+  measured change (`toolchain-ab.yml`), described in `rust-toolchain.toml`.
 - **Base64 whitespace is stripped with `memchr`** instead of a test-and-push per byte,
   the second change in the patched `vendor/mailparse` (also on
   [staktrace/mailparse#142](https://github.com/staktrace/mailparse/pull/142)). With the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,10 +13,12 @@ discuss what you would like to change.
 ## Prerequisites
 
 - **Rust** — the toolchain is pinned in
-  [`rust-toolchain.toml`](rust-toolchain.toml) to **1.97.1**; if you use
+  [`rust-toolchain.toml`](rust-toolchain.toml) to **1.98.0**; if you use
   `rustup`, the correct version is selected automatically in this directory.
-  The pin is deliberate: rustc 1.98.0 makes this crate ~26% slower and trips the
-  benchmark gate — see the comment in that file before changing it. The MSRV is
+  The pin is deliberate: the benchmark gate builds both sides with the same
+  compiler, so a compiler change is the one regression it cannot see — bump the
+  pin with the `toolchain-ab.yml` measurement, as the comment in that file
+  describes. The MSRV is
   a separate, lower bound (**1.83**, declared as `rust-version` in
   [`Cargo.toml`](Cargo.toml)). Some CI checks (`cargo audit`) run on **stable**
   rather than the pinned version.
@@ -282,8 +284,9 @@ Two things to know before changing anything in `src/`:
 
 **This crate is unusually sensitive to codegen.** A rustc minor version alone
 moved the parse path 15-96% (#120), which is why `rust-toolchain.toml` pins one.
-That case has since been traced to a single loop and fixed -- see below -- but
-the lesson stands: do not assume a change is free because it looks free.
+That case has since been traced to two loops and fixed -- see below -- and the
+pin has moved on to 1.98.0, but the lesson stands: do not assume a change is
+free because it looks free.
 
 **Cold code can slow the hot path.** `catch_panics` is generic, so every entry
 point instantiates it, and adding a third instantiation stopped the one wrapping

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,24 +1,35 @@
-# Rust toolchain for this crate. Pinned deliberately — do not float to `stable`
-# without re-measuring the benchmark gate.
+# Rust toolchain for this crate. Pinned deliberately: bump it on purpose, with a
+# measurement, rather than letting `stable` float.
 #
-# rustc 1.98.0 makes this crate ~26% slower. Identical source, same
-# ubuntu-24.04 runner image, one week apart:
+# Why a pin at all. The benchmark gate builds a revision and its base with the
+# SAME toolchain, so a compiler change is the one kind of regression it cannot
+# see -- both sides move together. A floating `stable` would put an unmeasured
+# compiler into every published wheel. A pin makes the compiler a change like
+# any other: proposed, measured, reviewed.
 #
-#   1.97.1 (2026-08-19)  parse 1.894 ms  ->  7.50x vs mail-parser  gate PASS
-#   1.98.0 (2026-08-26)  parse 2.378 ms  ->  6.08x vs mail-parser  gate FAIL
+# How to bump. Run the A/B that exists for this (#120):
 #
-# The pure-Python baseline barely moved (14.205 -> 14.456 ms), so this is the
-# Rust extension's codegen, not runner noise. The pin keeps published wheels on
-# the fast compiler and keeps the 7.0x floor honest instead of lowering it.
+#   gh workflow run toolchain-ab.yml -f candidate=<version>
 #
-# Before unpinning, benchmark the candidate toolchain and confirm it clears the
-# floor.
+# It builds this source with both toolchains in one job and measures them
+# interleaved. If the candidate is within tolerance, change the version here and
+# in every workflow that names it (`grep -rn <old version> .github`), since the
+# jobs must install components for the toolchain cargo actually uses (below).
+#
+# History. 1.97.1 was pinned on 2026-08-26 when 1.98.0 measured 15-30% slower.
+# That turned out not to be codegen: two byte-at-a-time loops in mailparse ran at
+# half speed when the linker happened to place them across a 64-byte boundary on
+# the runners' CPUs, and a new rustc moved them (as did a version bump -- #204).
+# With those loops replaced (vendor/mailparse, PRs #213 and #214) the same A/B
+# reads 1.98.0 within +/-0.5% of 1.97.1 on the CPU that showed the worst of it,
+# so the pin moved to 1.98.0 on 2026-08-27. See CONTRIBUTING.md, Performance.
 #
 # Precedence, verified in CI: this file beats dtolnay/rust-toolchain's
 # `toolchain:` input, and an explicit RUSTUP_TOOLCHAIN env var beats this file.
-# So a job requesting a different toolchain here still gets 1.97.1 — and if it
-# needs components (rustfmt, clippy) it must request them for 1.97.1 or cargo
-# reports them "not installed". `cargo audit` intentionally opts out via
-# RUSTUP_TOOLCHAIN=stable, so it audits against current stable.
+# So a job requesting a different toolchain there still gets this one -- and if
+# it needs components (rustfmt, clippy) it must request them for this version or
+# cargo reports them "not installed". `cargo audit`, `cargo deny` and the fuzz
+# job intentionally opt out via RUSTUP_TOOLCHAIN, since a tool's needs are not
+# the library's build.
 [toolchain]
-channel = "1.97.1"
+channel = "1.98.0"


### PR DESCRIPTION
Closes #120.

## Why the pin can move

The pin was a holding action against a measured 15–30% slowdown under rustc 1.98.0. The cause turned out not to be the compiler's codegen: two byte-at-a-time loops in mailparse ran at half speed when the linker placed them across a 64-byte boundary on the runners' Zen CPUs, and a new rustc — like a version bump, #204 — moved them. Their x86-64 instruction streams were byte-identical under both compilers (`find_from_u8_line_prefix`: 88 = 88; `decode_base64`: 147 = 147).

With both loops replaced (#213, #214), the toolchain A/B on the CPU that showed the worst of it — the EPYC 9V74, +96% this morning, +22% after #213 alone — now reads **1.98.0 within ±0.5% of 1.97.1 on every parse path** ([run 33092063031](https://github.com/namecheap/fast_mail_parser/actions/runs/33092063031), noise floor 4.0%, worst +2.3% on a metadata batch). Locally on an M4, same source under both compilers: worst +0.9%.

## Why it stays a pin rather than floating to `stable`

The benchmark gate builds a revision and its base with the *same* toolchain, so a compiler change is the one regression it cannot see — both sides move together. A floating `stable` would put an unmeasured compiler into every published wheel. Keeping a pin makes the compiler a change like any other: proposed, measured with `toolchain-ab.yml`, reviewed. `rust-toolchain.toml` now says this and describes the bump procedure; the `toolchain-ab.yml` baseline default follows the pin.

## What changed

- `rust-toolchain.toml`: `1.97.1` → `1.98.0`; comment rewritten (the old one quoted the ~26% figure #120 later showed to be a measurement artifact, and a 7.0x floor the gate no longer has).
- `test.yml` (3 dtolnay inputs + maturin-action), `publish.yml` (4 maturin-action inputs): `1.98.0`, because components must be installed for the toolchain cargo actually uses (precedence note in the toolchain file).
- `toolchain-ab.yml`: baseline default and history comment.
- CONTRIBUTING prerequisites + Performance intro; CHANGELOG.

Verified locally under 1.98.0 before pushing: `cargo fmt --check` clean (blocking in CI), clippy unchanged from master, vendored crate's tests pass, 803 tests pass on a 1.98.0-built wheel.