### PR TITLE
vendor/mailparse is a permanent carry: upstream declined the change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with the same compiler and so cannot see a compiler regression; bumping it is a
   measured change (`toolchain-ab.yml`), described in `rust-toolchain.toml`.
 - **Base64 whitespace is stripped with `memchr`** instead of a test-and-push per byte,
-  the second change in the patched `vendor/mailparse` (also on
-  [staktrace/mailparse#142](https://github.com/staktrace/mailparse/pull/142)). With the
+  the second change in the patched `vendor/mailparse`. With the
   boundary search fixed, that filter was **77.7%** of a full parse of the 767 KiB fixture
   -- more than the base64 decode itself -- and the toolchain A/B showed it carried the
   rest of the rustc placement sensitivity: decoding paths still moved +22% on one CPU
@@ -34,9 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   0.830 -> 0.281 ms for the same pair, and 1.094 -> 0.281 ms against the master before
   either change.
 - **The MIME boundary search is now `memchr::memmem`** instead of a byte-by-byte scan,
-  through a patched copy of `mailparse` 0.16.1 in `vendor/mailparse` (upstream as
-  [staktrace/mailparse#142](https://github.com/staktrace/mailparse/pull/142); see
-  `vendor/mailparse/PATCH.md` for the removal steps once it ships). That one loop was
+  through a patched copy of `mailparse` 0.16.1 in `vendor/mailparse`. The copy is
+  permanent: the change was proposed upstream and declined (staktrace/mailparse#142 --
+  no new external dependencies), so `vendor/mailparse/PATCH.md` describes how to merge
+  future mailparse releases into it rather than how to remove it. That one loop was
   **96.5%** of a metadata-mode parse, and it was the codegen cliff #120 and #204 were
   circling: the same 88 instructions ran at half speed on x86-64 depending on where the
   linker placed them, so a rustc minor version or a version-string bump could move the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -316,8 +316,9 @@ builds at +/-0.2%.
 
 The fix replaces that scan with `memchr::memmem` -- vectorised, and laid out
 independently of this crate -- via the patched copy in `vendor/mailparse`
-(upstream as staktrace/mailparse#142; `vendor/mailparse/PATCH.md` has the removal
-steps). Metadata mode went 0.365 -> 0.030 ms and the full parse 1.10 -> 0.76 ms.
+(a permanent carry: upstream declined the change as an added dependency;
+`vendor/mailparse/PATCH.md` has the sync procedure). Metadata mode went
+0.365 -> 0.030 ms and the full parse 1.10 -> 0.76 ms.
 
 With that gone, sampling the *full* parse put **77.7%** of what remained in
 `decode_base64`'s whitespace filter -- `iter().filter().cloned().collect()`, a

--- a/vendor/mailparse/PATCH.md
+++ b/vendor/mailparse/PATCH.md
@@ -53,16 +53,27 @@ Measured on this machine (interleaved A/B, Apple M4), original master to both pa
 | `parse_email` (full) | 1.094 ms | 0.281 ms |
 | `parse_many` (8 x 767 KiB) | 9.082 ms | 2.177 ms |
 
-## When this goes away
+## Keeping this in sync
 
-Both changes are upstream as [staktrace/mailparse#142](https://github.com/staktrace/mailparse/pull/142).
-Once a mailparse release includes them:
+This copy is permanent. The change was proposed upstream
+([staktrace/mailparse#142](https://github.com/staktrace/mailparse/pull/142)) and declined on
+2026-08-28: the project does not accept pull requests that add external dependencies,
+particularly ones relying heavily on unsafe code -- which describes `memchr`'s SIMD paths
+exactly. So no future mailparse release will carry these functions, and every upstream
+release has to be merged into this directory by hand:
 
-1. bump `mailparse` in the root `Cargo.toml` to that release,
-2. delete the two `[patch.crates-io]` sections and this directory,
-3. drop the `vendor/mailparse/**/*` entry from `[tool.maturin] include` in `pyproject.toml`
-   and the `vendored mailparse tests` step from the lint job,
-4. run the benchmark gate: the numbers should not move.
+1. `diff -r` the new release against the previous one (both in
+   `~/.cargo/registry/src/*/mailparse-<version>/`) and apply that diff to this copy --
+   *not* the other way round, or the two functions revert.
+2. Keep `find_from_u8`, `strip_ascii_whitespace` and the `strip_ascii_whitespace_tests`
+   module as they are here, and `memchr` in `Cargo.toml`.
+3. Bump the version in this copy's `Cargo.toml` and the `mailparse = "..."` requirement in
+   the root `Cargo.toml` and `fuzz/Cargo.toml` together, since `[patch]` only applies when
+   the patched version satisfies the requirement.
+4. Run this copy's own suite (the lint job does: `cargo test --manifest-path
+   vendor/mailparse/Cargo.toml`), then the benchmark gate. The numbers should not move.
 
-Until then, any upstream mailparse release has to be merged into this copy by hand; the
-diff to carry forward is the two functions above and the test.
+If upstreaming is ever wanted, the shape that could be accepted is a dependency-free one:
+a word-at-a-time (SWAR) scan in plain `std`, which is what `core`'s own `memchr` does
+internally. It would be slower than `memchr`'s SIMD paths and would need measuring against
+this copy before replacing it.


### PR DESCRIPTION
Docs only. `vendor/mailparse/PATCH.md`, the changelog and CONTRIBUTING all described the patched mailparse as a temporary carry with removal steps "once a release includes it". Upstream declined the change (staktrace/mailparse#142, closed 2026-08-28: the project does not accept new external dependencies, particularly ones relying on unsafe code), so those statements are now false.

What changes:

- **PATCH.md** — "When this goes away" becomes "Keeping this in sync": the copy is permanent, every upstream mailparse release is a hand-merge into it, and the procedure (diff the new release against the previous one, apply to the copy, keep the two functions and the test, run its suite via the lint job) is written down. It also records why upstream declined and what an upstreamable version would have to look like (dependency-free), without proposing one.
- **CHANGELOG / CONTRIBUTING** — the three references to "upstream as #142 / removal steps" now say what happened.

Nothing in code, config or CI changes; the patch itself and the `[patch.crates-io]` mechanism are unaffected. `tests/test_readme_snippets.py` unaffected (README not touched).