### PR TITLE
Cut 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-08-28
+
+Measured against the published 0.8.0 wheel on an Apple M4 (interleaved, 3 rounds, controls
+within 3.8%): full parse **1.079 -> 0.225 ms**, `parse_email_tree` 1.071 -> 0.216 ms,
+`parse_many` (8 x 767 KiB) 8.852 -> 1.835 ms, `mode="metadata"` **0.365 -> 0.030 ms**.
+
+The version bump itself moved the decoding paths **+3-7%** against the last master commit on
+the M4 (two interleaved A/Bs, metadata paths within 0.7%) -- the code-layout effect #204
+describes, now measured at release time rather than discovered later. The two loops that made
+it 0-96% are fixed; what remains is the base64 decode proper.
+
 ### Changed
 
 - **The base64 whitespace strip in the vendored mailparse is now dependency-free**, and
@@ -698,7 +709,9 @@ The package version is single-sourced from `Cargo.toml`'s `[package].version`.
 `pyproject.toml` declares `dynamic = ["version"]`, so maturin reads the version
 from `Cargo.toml` at build time. Bump the version in `Cargo.toml` only.
 
-[Unreleased]: https://github.com/namecheap/fast_mail_parser/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/namecheap/fast_mail_parser/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/namecheap/fast_mail_parser/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/namecheap/fast_mail_parser/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/namecheap/fast_mail_parser/compare/v0.6.1...v0.7.0
 [0.6.1]: https://github.com/namecheap/fast_mail_parser/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/namecheap/fast_mail_parser/compare/v0.5.0...v0.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "fast_mail_parser"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "charset",
  "mailparse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "fast_mail_parser"
 description = "Very fast Python library for .eml files parsing."
 edition = "2021"
 rust-version = "1.83"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["Andrii Sokyrko <wartwvister@gmail.com>"]
 readme = "Readme.md"
 # Both fields: `license` is the SPDX expression tooling reads (cargo-deny warns


### PR DESCRIPTION
Version 0.8.0 → **0.9.0**: the unreleased changes add API (`mode=` on `parse_many` and `parse_email_tree`, #202) on top of the performance work, so a minor bump. Version is single-sourced from `Cargo.toml`; the lockfile follows. The changelog gains its `[0.9.0]` section and the compare links the 0.8.0 cut forgot (`[Unreleased]` still pointed at v0.7.0 and there was no `[0.8.0]` link).

## What users get, measured against the published 0.8.0 wheel

Installed `fast-mail-parser==0.8.0` from PyPI into a venv and A/B'd it against this build, interleaved, 3 rounds, Apple M4, controls within 3.8%:

| benchmark | PyPI 0.8.0 | 0.9.0 | |
|---|---|---|---|
| `parse_email` (full) | 1.079 ms | **0.225 ms** | −79% (4.8x) |
| `parse_email_tree` | 1.071 ms | 0.216 ms | −80% |
| `parse_many`, 8 × 767 KiB | 8.852 ms | 1.835 ms | −79% |
| `parse_email(mode="metadata")` | 0.365 ms | **0.030 ms** | −92% (12x) |

## The version bump itself, measured

Per #204's finding that a version string alone moves code layout: this build differs from master (`454bd07`) only in that string, and two interleaved A/Bs on the M4 (3 and 5 rounds, per-round spread under 0.5%) put the **decoding paths at +3–7%** and the metadata paths at ±0.7%. Recorded in the changelog entry rather than hidden; the gate on this PR is the same measurement on an x86 runner and its number will be added before merge. The two loops that used to make this 0–96% are fixed; what remains is the base64 decode proper, which is the follow-up.

## Verified locally before pushing

803 tests on the built 0.9.0 wheel; vendored crate's suite; `cargo fmt --check`; `mypy --strict`; `ruff`; sdist builds with the vendored crate inside (15 entries, 780 KB).

After merge: tag `v0.9.0`, GitHub release (marked latest), `publish.yml` uploads, verify on PyPI.