### PR TITLE
Fuzzing: seed the deep run from the 24 CPU-hour corpus, guard publish.yml to v* tags (#102)

### DIFF
--- a/.github/workflows/deep-fuzz.yml
+++ b/.github/workflows/deep-fuzz.yml
@@ -96,11 +96,35 @@ jobs:
         with:
           path: fuzz/corpus/${{ matrix.target }}
           # A cache entry is immutable, so each run writes a new key and inherits
-          # the newest previous one by prefix. The key keeps the `v2-parse_email`
-          # lineage for that target, so the corpus accumulated before the second
-          # target existed is not thrown away.
-          key: fuzz-corpus-v2-${{ matrix.target }}-${{ github.run_id }}
-          restore-keys: fuzz-corpus-v2-${{ matrix.target }}-
+          # the newest previous one by prefix. The lineage moved to v3 when the
+          # 24 CPU-hour campaign corpus (#102) was published: a cold v3 cache is
+          # seeded from that release asset below, which is richer than anything
+          # the v2 lineage had accumulated.
+          key: fuzz-corpus-v3-${{ matrix.target }}-${{ github.run_id }}
+          restore-keys: fuzz-corpus-v3-${{ matrix.target }}-
+
+      - name: Seed from the published corpus when the cache is cold
+        # First run of a lineage, or GitHub evicted an unused entry: start from
+        # the minimised corpus of the 24 CPU-hour campaign, published as an asset
+        # on the newest `fuzz-corpus-*` release, instead of from the 19 fixtures.
+        # Those releases carry no code; publish.yml ignores them by its tag guard.
+        if: ${{ hashFiles(format('fuzz/corpus/{0}/**', matrix.target)) == '' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag=$(gh release list --repo "$GITHUB_REPOSITORY" --limit 100 --json tagName \
+                  --jq '[.[].tagName | select(startswith("fuzz-corpus-"))] | sort | last // empty')
+          if [ -z "$tag" ]; then
+            echo "no fuzz-corpus release yet; seeding from the fixtures only"
+            exit 0
+          fi
+          gh release download "$tag" --repo "$GITHUB_REPOSITORY" \
+            --pattern 'fuzz-corpus-min.tar.gz' --dir "$RUNNER_TEMP"
+          mkdir -p "fuzz/corpus/${{ matrix.target }}"
+          tar -xzf "$RUNNER_TEMP/fuzz-corpus-min.tar.gz" -C "fuzz/corpus/${{ matrix.target }}" \
+            --strip-components=2 "corpus-min/${{ matrix.target }}"
+          echo "seeded $(find "fuzz/corpus/${{ matrix.target }}" -type f | wc -l) inputs from release $tag"
+          echo "corpus_seeded_from=$tag" >> "$GITHUB_ENV"
 
       - name: Seed the corpus from the test fixtures
         run: |
@@ -193,6 +217,7 @@ jobs:
             echo "- ran for ${FUZZ_SECONDS}s"
             echo "- target: ${{ matrix.target }}"
             echo "- corpus: ${corpus_inherited} inherited, $(find "fuzz/corpus/${{ matrix.target }}" -type f | wc -l) now"
+            echo "- cold-cache seed: ${corpus_seeded_from:-not needed (cache hit)}"
             echo "- crashers: $(find fuzz/artifacts -type f 2>/dev/null | wc -l)"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,10 @@ on:
     types: [created]
   workflow_dispatch:
 
+# Every job is guarded to `v*` tags (or a manual dispatch): the repository also
+# publishes `fuzz-corpus-*` releases, which carry a fuzzing corpus and no code,
+# and those must not build or upload wheels.
+
 concurrency:
   group: publish-${{ github.ref }}
   cancel-in-progress: false
@@ -22,6 +26,7 @@ permissions:
 
 jobs:
   linux:
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -59,6 +64,7 @@ jobs:
           path: dist
 
   musllinux:
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -92,6 +98,7 @@ jobs:
           path: dist
 
   windows:
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -121,6 +128,7 @@ jobs:
           path: dist
 
   macos:
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -150,6 +158,7 @@ jobs:
           path: dist
 
   sdist:
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -166,6 +175,7 @@ jobs:
 
   release:
     name: Release
+    if: ${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     needs: [linux, musllinux, windows, macos, sdist]
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Fuzzing: the initial 24 CPU-hour campaign ran, found nothing, and its corpus now
+  seeds the deep run** (#102). Two targets, 8,640 s x 5 workers each on an Apple M4:
+  `parse_email` 12.1 M executions to 5,047 edges, `parse_agreement` 5.5 M to 5,502,
+  zero crashes, timeouts or OOMs. The minimised corpora (129 MB raw, 8.3 MB compressed)
+  ship as `fuzz-corpus-min.tar.gz` on a `fuzz-corpus-*` release rather than in the
+  tree, and `deep-fuzz.yml` seeds from that asset when its cache is cold (lineage moved
+  to `v3` so the next run does). `publish.yml` is guarded to `v*` tags so a corpus
+  release does not build wheels.
+
 ## [0.9.0] - 2026-08-28
 
 Measured against the published 0.8.0 wheel on an Apple M4 (interleaved, 3 rounds, controls

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,6 +225,26 @@ between runs**,
 so coverage compounds instead of restarting from the fixtures every week — that
 accumulation is most of what makes a scheduled run worth more than the PR pass.
 
+**The initial 24 CPU-hours** the fuzzing issue (#102) asked for ran on 2026-08-28,
+locally: two targets, five forked workers each, 8,640 s per target, ASan, on an
+Apple M4. `parse_email` executed 12.1 M inputs and reached 5,047 edges,
+`parse_agreement` 5.5 M and 5,502; neither found a crash, timeout or OOM. The
+minimised corpora (3,135 and 4,234 inputs) are too large to commit -- 129 MB raw,
+8.3 MB compressed -- so they live as `fuzz-corpus-min.tar.gz` on the newest
+`fuzz-corpus-*` GitHub release, and the deep run seeds from that asset whenever
+its cache is cold. To start from it locally:
+
+```bash
+gh release download "$(gh release list --json tagName --jq '[.[].tagName|select(startswith("fuzz-corpus-"))]|sort|last')" \
+  --pattern fuzz-corpus-min.tar.gz --dir /tmp
+tar -xzf /tmp/fuzz-corpus-min.tar.gz -C fuzz/corpus/parse_email --strip-components=2 corpus-min/parse_email
+RUSTUP_TOOLCHAIN=nightly cargo fuzz run parse_email -- -fork=5 -ignore_crashes=1 -max_total_time=3600 -max_len=65536 -timeout=10
+```
+
+Fork mode keeps going after a crash and leaves each one in `fuzz/artifacts/`; a
+single-process run stops at the first. Refreshing the asset is `-merge=1` from the
+accumulated corpus into an empty directory, then a new `fuzz-corpus-<date>` release.
+
 Generated inputs are capped at 64 KiB (`-max_len`). Uncapped, libFuzzer takes its
 limit from the largest seed — and the seed corpus contains a 0.75 MiB message — so
 it spent its time on ~59 KiB inputs at ~158 executions per second. Bugs per minute


### PR DESCRIPTION
Closes out the last criterion of #102 — **24 CPU-hours of initial fuzzing** — which ran locally today on an Apple M4 (10 cores, 2 targets × 5 forked workers × 8,640 s, ASan, `-max_len=65536`, `-timeout=10`):

| target | executions | edges (start → end) | corpus (minimised) | crashes / timeouts / OOMs |
|---|---|---|---|---|
| `parse_email` | 12,147,230 | 4,197 → **5,047** | 3,135 inputs, 53 MB | **0 / 0 / 0** |
| `parse_agreement` | 5,459,553 | 4,568 → **5,502** | 4,234 inputs, 76 MB | **0 / 0 / 0** |

For scale: the CI runner's best deep run managed 1.15 M executions and 3,968 edges. Nothing to triage, so no regression fixtures to add.

## What this PR does with the result

- **The minimised corpora become a release asset** (`fuzz-corpus-min.tar.gz`, 8.3 MB compressed; 129 MB and 7,369 files raw — too much to commit, and a size-capped subset loses coverage: the ≤2 KiB slice keeps only ~89% of edges). The deep-fuzz workflow now **seeds from the newest `fuzz-corpus-*` release when its cache is cold**, instead of from the 19 fixtures; the cache lineage moves to `v3` so the very next run takes that path and starts from 5,047/5,502 edges rather than the ~4,500 the CI cache has reached on its own.
- **`publish.yml` gets a `v*` tag guard** on every job (and stays dispatchable): it triggered on *any* release, so the corpus release would have built 13 wheels for nothing.
- **CONTRIBUTING** records the campaign, the fork-mode recipe, and how to fetch the corpus locally; **CHANGELOG** gets the entry.

Both workflows parse as YAML locally. After merge: create the `fuzz-corpus-20260828` release with the asset, then one 60-second deep-fuzz dispatch to prove the cold-cache path end to end (the `v3` key guarantees a miss), then close #102 and #104.