### PR TITLE
Stop the scheduled tasks: no weekly deep fuzz, dependabot paused

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,21 @@
 version: 2
+# Version updates are PAUSED (limit 0 on every ecosystem) since 2026-08-28: no
+# scheduled tasks run in this repository. Delete the three limit lines to resume.
+# Security updates are a separate repository setting and are unaffected.
 updates:
   # Rust crate dependencies (Cargo.toml / Cargo.lock at the repo root).
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
 
   # GitHub Actions used by the workflows in .github/workflows.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
 
   # Python test dependencies from pyproject.toml's [project.optional-dependencies]
   # (pytest, pytest-benchmark, mail-parser). Previously uncovered, so these were
@@ -20,3 +25,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0

--- a/.github/workflows/deep-fuzz.yml
+++ b/.github/workflows/deep-fuzz.yml
@@ -2,21 +2,22 @@ name: Deep fuzz
 
 # The PR job fuzzes for 60 seconds with a fixed seed: enough to catch a gross
 # regression, not enough to explore. Real fuzzing needs time and a corpus that
-# grows, which is what this is for (#102).
-#
-# Two things make a weekly run worth more than 30x the PR job:
+# grows, which is what this is for (#102). It runs on demand: the initial
+# 24 CPU-hour campaign ran locally on 2026-08-28 and found nothing, and the
+# weekly schedule that used to be here was stopped the same day; dispatch it
+# after a change to the parse path, or to refresh the corpus asset.
 #
 # Two targets run in parallel, each with its own corpus: `parse_email` on the flat
 # parse, and `parse_agreement` checking the metadata and tree APIs against it
-# (#97, #99). The per-target budget is halved so the weekly runner cost is
-# unchanged.
+# (#97, #99).
 #
-#   - The corpus is cached and restored, so coverage compounds week over week
-#     instead of restarting from the fixtures every time. This is most of the
-#     value: a fuzzer's reach is mostly a function of the corpus it inherits.
+#   - The corpus is cached and restored, so coverage compounds across runs
+#     instead of restarting from the fixtures every time; on a cold cache it is
+#     seeded from the campaign corpus published as a release asset. This is most
+#     of the value: a fuzzer's reach is mostly a function of the corpus it inherits.
 #   - No fixed seed, so each run explores a different path. The PR job pins the
 #     seed deliberately, to stay reproducible; here that would mean repeating one
-#     search every week forever.
+#     search forever.
 #
 # Input size is capped, because leaving it uncapped made the run slow. libFuzzer
 # takes its default limit from the largest seed, and the seed corpus contains a
@@ -29,10 +30,6 @@ name: Deep fuzz
 # A crasher becomes an artifact, a minimized reproducer, and an entry on a single
 # pinned issue rather than a new issue per run.
 on:
-  schedule:
-    # Mondays, 03:17 UTC. Off the hour: scheduled jobs cluster there and get
-    # queued behind everyone else's.
-    - cron: "17 3 * * 1"
   workflow_dispatch:
     inputs:
       seconds:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **No more scheduled tasks.** The weekly deep-fuzz cron is removed (the workflow stays
+  dispatchable, with the same corpus caching and release-asset seeding) and dependabot
+  version updates are paused with `open-pull-requests-limit: 0` on all three ecosystems.
 - **Fuzzing: the initial 24 CPU-hour campaign ran, found nothing, and its corpus now
   seeds the deep run** (#102). Two targets, 8,640 s x 5 workers each on an Apple M4:
   `parse_email` 12.1 M executions to 5,047 edges, `parse_agreement` 5.5 M to 5,502,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -219,11 +219,13 @@ by disagreeing with the original:
 - the tree parses deterministically, and every attachment the flat parse reports
   appears as some leaf's content
 
-A **weekly deep run** (`.github/workflows/deep-fuzz.yml`, Mondays) fuzzes for 30
-minutes per target with no fixed seed and, importantly, **caches the corpus
-between runs**,
-so coverage compounds instead of restarting from the fixtures every week — that
-accumulation is most of what makes a scheduled run worth more than the PR pass.
+An **on-demand deep run** (`.github/workflows/deep-fuzz.yml`, `workflow_dispatch`)
+fuzzes for 15 minutes per target by default with no fixed seed and, importantly,
+**caches the corpus between runs** and seeds a cold cache from the published
+campaign corpus, so coverage compounds instead of restarting from the fixtures —
+that accumulation is most of what makes a long run worth more than the PR pass.
+It used to run weekly; the schedule was stopped on 2026-08-28 after the 24 CPU-hour
+campaign below, so dispatch it after a change to the parse path.
 
 **The initial 24 CPU-hours** the fuzzing issue (#102) asked for ran on 2026-08-28,
 locally: two targets, five forked workers each, 8,640 s per target, ASan, on an


### PR DESCRIPTION
Stops everything that runs on a schedule in this repository, without removing the ability to run any of it by hand.

- **`deep-fuzz.yml`**: the Monday cron is gone; `workflow_dispatch` stays, with the same inputs and the same cold-cache seeding from the `fuzz-corpus-*` release asset. The header comment now describes an on-demand run.
- **`dependabot.yml`**: all three ecosystems set to `open-pull-requests-limit: 0` — GitHub's documented way to pause version updates while keeping the configuration, so re-enabling is deleting three lines. Security updates are unaffected (they are a separate setting).
- **CONTRIBUTING** no longer promises a weekly run; **CHANGELOG** records the change.

Not touched: CodeQL default setup (runs on push/PR; disabling code scanning is a security decision, not a scheduled-task one) and the badge on the README, which will show the last on-demand run's status. Both workflows still parse as YAML locally.